### PR TITLE
Retoma progreso existente al iniciar nivel

### DIFF
--- a/src/ui/views/level_theory.rs
+++ b/src/ui/views/level_theory.rs
@@ -1,8 +1,8 @@
-use eframe::egui;
-use egui_commonmark::CommonMarkViewer;
 use crate::app::QuizApp;
 use crate::model::AppState;
 use crate::ui::layout::two_button_row;
+use eframe::egui;
+use egui_commonmark::CommonMarkViewer;
 
 pub fn ui_level_theory(app: &mut QuizApp, ctx: &egui::Context) {
     egui::CentralPanel::default().show(ctx, |ui| {
@@ -30,7 +30,7 @@ pub fn ui_level_theory(app: &mut QuizApp, ctx: &egui::Context) {
         }
 
         // Evita doble borrow y copias innecesarias gigantes
-        let week_num  = app.quiz.weeks[wi].number;
+        let week_num = app.quiz.weeks[wi].number;
         let theory = app.quiz.weeks[wi].levels[li]
             .explanation
             .get(&app.selected_language.unwrap())
@@ -41,7 +41,6 @@ pub fn ui_level_theory(app: &mut QuizApp, ctx: &egui::Context) {
             .fill(ui.visuals().window_fill())
             .inner_margin(egui::Margin::symmetric(120, 20))
             .show(ui, |ui| {
-
                 ui.vertical_centered(|ui| {
                     ui.set_width(panel_width);
                     ui.heading(format!("Semana {}, Nivel {}", week_num, li + 1));
@@ -56,8 +55,7 @@ pub fn ui_level_theory(app: &mut QuizApp, ctx: &egui::Context) {
                         .max_height(text_h)
                         .auto_shrink([false, false])
                         .show(ui, |ui| {
-                            CommonMarkViewer::new()
-                                .show(ui, &mut app.cm_cache, &theory);
+                            CommonMarkViewer::new().show(ui, &mut app.cm_cache, &theory);
                         });
 
                     ui.add_space(8.0);
@@ -72,32 +70,37 @@ pub fn ui_level_theory(app: &mut QuizApp, ctx: &egui::Context) {
                     // Si vienes del quiz => solo un botón (volver)
                     if matches!(app.theory_return_state, AppState::Quiz) {
                         // Botón único a ancho completo
-                        if ui.add_sized([panel_width / 2.0, 36.0], egui::Button::new(back_label)).clicked() {
+                        if ui
+                            .add_sized([panel_width / 2.0, 36.0], egui::Button::new(back_label))
+                            .clicked()
+                        {
                             app.state = AppState::Quiz;
                             app.message.clear();
                         }
                     } else {
                         // Origen: menú de niveles => dos botones (volver | comenzar)
-                        let (volver, comenzar) = two_button_row(
-                            ui,
-                            panel_width,
-                            back_label,
-                            "Comenzar preguntas ▶"
-                        );
+                        let (volver, comenzar) =
+                            two_button_row(ui, panel_width, back_label, "Comenzar preguntas ▶");
 
                         if volver {
                             app.state = AppState::LevelMenu;
                             app.message.clear();
                         }
                         if comenzar {
-                            app.state = AppState::Quiz;
+                            {
+                                let prog = app.progress_mut();
+                                if prog.current_in_level.is_none() {
+                                    prog.current_in_level = Some(0);
+                                }
+                                prog.finished = false;
+                                prog.input.clear();
+                            }
                             app.update_input_prefill();
+                            app.state = AppState::Quiz;
                             app.message.clear();
                         }
                     }
                 });
-        });
-
-
+            });
     });
 }


### PR DESCRIPTION
## Summary
- Continúa el nivel desde la pregunta pendiente cuando se inicia desde la teoría
- Si el nivel es nuevo, comienza en la primera pregunta

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a1dfa6960883248c51f45898b13208