### PR TITLE
Allow forcing quiz continuation

### DIFF
--- a/src/app/resets.rs
+++ b/src/app/resets.rs
@@ -15,7 +15,7 @@ impl QuizApp {
             self.progresses.insert(other, QuizProgress::default());
 
             // 3) elige la primera semana/pregunta y pasa a Quiz
-            self.continuar_quiz();
+            self.continuar_quiz(false);
 
             // 4) limpia las banderas de UI
             self.confirm_reset = false;
@@ -51,7 +51,9 @@ impl QuizApp {
         let lang = self.selected_language.unwrap_or(Language::C);
 
         // 1) Recopilar IDs de esa semana + lenguaje
-        let ids_to_remove: Vec<String> = self.quiz.weeks
+        let ids_to_remove: Vec<String> = self
+            .quiz
+            .weeks
             .get(week_idx)
             .into_iter()
             .flat_map(|w| &w.levels)
@@ -61,19 +63,17 @@ impl QuizApp {
             .collect();
 
         // 2) Buscar primera pregunta pendiente en esa semana
-        let first_pending = self.quiz.weeks
-            .get(week_idx)
-            .and_then(|week| {
-                week.levels.iter().enumerate().find_map(|(li, lvl)| {
-                    lvl.questions.iter().enumerate().find_map(|(qi, q)| {
-                        if q.language == lang && !q.is_done {
-                            Some((li, qi))
-                        } else {
-                            None
-                        }
-                    })
+        let first_pending = self.quiz.weeks.get(week_idx).and_then(|week| {
+            week.levels.iter().enumerate().find_map(|(li, lvl)| {
+                lvl.questions.iter().enumerate().find_map(|(qi, q)| {
+                    if q.language == lang && !q.is_done {
+                        Some((li, qi))
+                    } else {
+                        None
+                    }
                 })
-            });
+            })
+        });
 
         // 3) Borrar IDs y resetear rondas en progress
         {
@@ -108,7 +108,9 @@ impl QuizApp {
         let lang = self.selected_language.unwrap_or(Language::C);
 
         // 1) Recopilar IDs de las preguntas de ese nivel + lenguaje
-        let ids_to_remove: Vec<String> = self.quiz.weeks
+        let ids_to_remove: Vec<String> = self
+            .quiz
+            .weeks
             .get(week_idx)
             .and_then(|w| w.levels.get(level_idx))
             .into_iter()
@@ -118,7 +120,9 @@ impl QuizApp {
             .collect();
 
         // 2) Buscar la primera pregunta pendiente en ese nivel
-        let first_pending = self.quiz.weeks
+        let first_pending = self
+            .quiz
+            .weeks
             .get(week_idx)
             .and_then(|w| w.levels.get(level_idx))
             .and_then(|lvl| {
@@ -146,7 +150,10 @@ impl QuizApp {
         }
 
         // 4) Resetear flags y estadísticas en las preguntas del nivel
-        if let Some(lvl) = self.quiz.weeks.get_mut(week_idx)
+        if let Some(lvl) = self
+            .quiz
+            .weeks
+            .get_mut(week_idx)
             .and_then(|w| w.levels.get_mut(level_idx))
         {
             for q in &mut lvl.questions {
@@ -169,4 +176,3 @@ impl QuizApp {
         self.message.clear();
     }
 }
-

--- a/src/ui/views/level_theory.rs
+++ b/src/ui/views/level_theory.rs
@@ -87,17 +87,8 @@ pub fn ui_level_theory(app: &mut QuizApp, ctx: &egui::Context) {
                             app.message.clear();
                         }
                         if comenzar {
-                            {
-                                let prog = app.progress_mut();
-                                if prog.current_in_level.is_none() {
-                                    prog.current_in_level = Some(0);
-                                }
-                                prog.finished = false;
-                                prog.input.clear();
-                            }
+                            app.continuar_quiz(true);
                             app.update_input_prefill();
-                            app.state = AppState::Quiz;
-                            app.message.clear();
                         }
                     }
                 });

--- a/src/ui/views/welcome.rs
+++ b/src/ui/views/welcome.rs
@@ -1,6 +1,6 @@
-use egui::{Align, Button, CentralPanel, Context, RichText};
 use crate::model::Language;
 use crate::QuizApp;
+use egui::{Align, Button, CentralPanel, Context, RichText};
 
 pub fn ui_welcome(app: &mut QuizApp, ctx: &Context) {
     CentralPanel::default().show(ctx, |ui| {
@@ -44,7 +44,7 @@ pub fn ui_welcome(app: &mut QuizApp, ctx: &Context) {
                         let btn_menu  = ui.add_sized([btn_w, btn_h], Button::new("📅 Seleccionar Semana"));
                         let btn_exit  = ui.add_sized([btn_w, btn_h], Button::new("🔙 Volver"));
 
-                        if let Some(b) = btn_cont { if b.clicked() { app.continuar_quiz(); } }
+                        if let Some(b) = btn_cont { if b.clicked() { app.continuar_quiz(false); } }
                         if btn_start.clicked() {
                             if hay_guardado {
                                 app.confirm_reset = true;


### PR DESCRIPTION
## Summary
- allow forcing transition to quiz when continuing
- update calls to pass force flag and use `continuar_quiz` from theory view

## Testing
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68a1e7c69b248324934b1ac75dfc88f3