### PR TITLE
Relajar comparación del juez C y conservar el código del editor tras fallo

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::code_utils::normalize_code;
+use crate::judge_c::{format_judge_message, grade_c_question, should_use_judge, JudgeResult};
 
 impl QuizApp {
     pub fn procesar_respuesta(&mut self, respuesta: &str) {
@@ -20,24 +21,39 @@ impl QuizApp {
             }
         };
 
-        // 2) Normalizar código para comparar
-        let user_code = normalize_code(respuesta);
-        let answer_code = {
+        // 2) Calcular resultado (normalize o judge_c)
+        let grading_result = {
             let q = &self.quiz.weeks[cw].levels[cl].questions[ci];
-            normalize_code(&q.answer)
+            if should_use_judge(q) {
+                grade_c_question(q, respuesta)
+            } else {
+                let user_code = normalize_code(respuesta);
+                let answer_code = normalize_code(&q.answer);
+                if user_code == answer_code {
+                    JudgeResult::Accepted
+                } else {
+                    JudgeResult::WrongAnswer {
+                        test_index: 0,
+                        input: String::new(),
+                        expected: String::new(),
+                        received: String::new(),
+                        diff: String::new(),
+                    }
+                }
+            }
         };
+        let correcta = matches!(grading_result, JudgeResult::Accepted);
 
         // 3) Mutar la pregunta: intentos y fails / is_done
         {
             let q = &mut self.quiz.weeks[cw].levels[cl].questions[ci];
             q.attempts += 1;
-            if user_code == answer_code {
+            if correcta {
                 q.is_done = true;
             } else {
                 q.fails += 1;
             }
         }
-        let correcta = user_code == answer_code;
 
         // 4) Preparar clonados antes de mutar progress
         let question_id = self.quiz.weeks[cw].levels[cl].questions[ci].id.clone();
@@ -61,8 +77,6 @@ impl QuizApp {
                 prog.input.clear();
                 mark_pending = true;
                 curr_week = prog.current_week;
-            } else {
-                prog.input.clear();
             }
         }
 
@@ -97,11 +111,18 @@ impl QuizApp {
 
         // 8) Sincronizar y prefill, luego mensaje
         self.sync_is_done();
-        self.update_input_prefill();
+        if correcta {
+            self.update_input_prefill();
+        }
         self.message = if correcta {
             "✅ ¡Correcto!".into()
         } else {
-            "❌ Incorrecto. Intenta de nuevo.".into()
+            match &grading_result {
+                JudgeResult::WrongAnswer { test_index, .. } if *test_index == 0 => {
+                    "❌ Incorrecto. Intenta de nuevo.".into()
+                }
+                _ => format_judge_message(&grading_result),
+            }
         };
     }
 
@@ -109,7 +130,7 @@ impl QuizApp {
         // 1) Extraer índices actuales (o salir si no hay pregunta)
         let (cw, cl, ci) = match self.current_position() {
             Some(pos) => pos,
-            None      => return,
+            None => return,
         };
 
         // 2) Registrar estadísticas en la pregunta actual
@@ -152,7 +173,7 @@ impl QuizApp {
         // 1) Extraer índices actuales
         let (cw, cl, ci) = match self.current_position() {
             Some(pos) => pos,
-            None      => return,
+            None => return,
         };
 
         // 2) Marcar que vio la solución
@@ -179,7 +200,10 @@ impl QuizApp {
 
     // TEST helpers
     pub fn complete_all_week(&mut self) {
-        let wi = match self.progress().current_week { Some(w) => w, None => return };
+        let wi = match self.progress().current_week {
+            Some(w) => w,
+            None => return,
+        };
         let lang = self.selected_language.unwrap_or(Language::C);
 
         // 1) Marcar cada pregunta y acumular sus IDs
@@ -214,8 +238,14 @@ impl QuizApp {
 
     /// Marca *todas* las preguntas del nivel actual como completadas y va al resumen de nivel o al resumen semanal si era el último nivel.
     pub fn complete_all_level(&mut self) {
-        let wi = match self.progress().current_week  { Some(w) => w, None => return };
-        let li = match self.progress().current_level { Some(l) => l, None => return };
+        let wi = match self.progress().current_week {
+            Some(w) => w,
+            None => return,
+        };
+        let li = match self.progress().current_level {
+            Some(l) => l,
+            None => return,
+        };
         let lang = self.selected_language.unwrap_or(Language::C);
 
         // 1) Marcar cada pregunta del nivel y acumular IDs
@@ -303,7 +333,10 @@ impl QuizApp {
         // Si todas ya fueron mostradas en esta ronda pero aún hay pendientes, arranca ronda nueva
         let hay_pendientes = level.questions.iter().enumerate().any(|(_q_idx, q)| {
             q.language == language
-                && q.id.as_ref().map(|id| !self.progress().completed_ids.contains(id)).unwrap_or(false)
+                && q.id
+                    .as_ref()
+                    .map(|id| !self.progress().completed_ids.contains(id))
+                    .unwrap_or(false)
         });
 
         if hay_pendientes {
@@ -329,4 +362,3 @@ impl QuizApp {
         None
     }
 }
-

--- a/src/data/quiz_questions_v2.yaml
+++ b/src/data/quiz_questions_v2.yaml
@@ -477,6 +477,52 @@ weeks:
               end algorithm
             hint: Recuerda, primero declara y luego inicializa. Los caracteres se inicializan entre ''.
 
+          - id: c-1-judge-suma
+            language: C
+            week: 1
+            mode: judge_c
+            prompt: Escribe un programa completo que lea dos enteros y muestre su suma seguida de un salto de línea.
+            answer: |
+              #include <stdio.h>
+
+              int main(void) {
+                int a, b;
+                scanf("%d %d", &a, &b);
+                printf("%d\n", a + b);
+                return 0;
+              }
+            tests:
+              - input: "2 3\n"
+                output: "5\n"
+              - input: "10 -4\n"
+                output: "6\n"
+            hint: Usa scanf para leer ambos enteros y printf para escribir la suma exacta.
+
+          - id: c-1-judge-paridad
+            language: C
+            week: 1
+            mode: judge_c
+            prompt: Escribe un programa completo que lea un entero. Si es par imprime PAR\n, en caso contrario imprime IMPAR\n.
+            answer: |
+              #include <stdio.h>
+
+              int main(void) {
+                int n;
+                scanf("%d", &n);
+                if (n % 2 == 0) {
+                  printf("PAR\n");
+                } else {
+                  printf("IMPAR\n");
+                }
+                return 0;
+              }
+            tests:
+              - input: "8\n"
+                output: "PAR\n"
+              - input: "7\n"
+                output: "IMPAR\n"
+            hint: Puedes usar el operador módulo (%).
+
       # Entrada y salida
       - number: 2
         explanation:

--- a/src/data/quiz_questions_v2.yaml
+++ b/src/data/quiz_questions_v2.yaml
@@ -230,6 +230,52 @@ weeks:
             Este algoritmo simula la inicialización de un jugador al comenzar una partida.
 
         questions:
+          - id: c-1-judge-suma
+            language: C
+            week: 1
+            mode: judge_c
+            prompt: Escribe un programa completo que lea dos enteros y muestre su suma seguida de un salto de línea.
+            answer: |
+              #include <stdio.h>
+
+              int main(void) {
+                int a, b;
+                scanf("%d %d", &a, &b);
+                printf("%d\n", a + b);
+                return 0;
+              }
+            tests:
+              - input: "2 3\n"
+                output: "5\n"
+              - input: "10 -4\n"
+                output: "6\n"
+            hint: Usa scanf para leer ambos enteros y printf para escribir la suma exacta.
+
+          - id: c-1-judge-paridad
+            language: C
+            week: 1
+            mode: judge_c
+            prompt: Escribe un programa completo que lea un entero. Si es par imprime PAR\n, en caso contrario imprime IMPAR\n.
+            answer: |
+              #include <stdio.h>
+
+              int main(void) {
+                int n;
+                scanf("%d", &n);
+                if (n % 2 == 0) {
+                  printf("PAR\n");
+                } else {
+                  printf("IMPAR\n");
+                }
+                return 0;
+              }
+            tests:
+              - input: "8\n"
+                output: "PAR\n"
+              - input: "7\n"
+                output: "IMPAR\n"
+            hint: Puedes usar el operador módulo (%).
+
           - id: c-1-max_nombre
             language: C
             week: 1
@@ -476,52 +522,6 @@ weeks:
                 categoriaDron := 'A'
               end algorithm
             hint: Recuerda, primero declara y luego inicializa. Los caracteres se inicializan entre ''.
-
-          - id: c-1-judge-suma
-            language: C
-            week: 1
-            mode: judge_c
-            prompt: Escribe un programa completo que lea dos enteros y muestre su suma seguida de un salto de línea.
-            answer: |
-              #include <stdio.h>
-
-              int main(void) {
-                int a, b;
-                scanf("%d %d", &a, &b);
-                printf("%d\n", a + b);
-                return 0;
-              }
-            tests:
-              - input: "2 3\n"
-                output: "5\n"
-              - input: "10 -4\n"
-                output: "6\n"
-            hint: Usa scanf para leer ambos enteros y printf para escribir la suma exacta.
-
-          - id: c-1-judge-paridad
-            language: C
-            week: 1
-            mode: judge_c
-            prompt: Escribe un programa completo que lea un entero. Si es par imprime PAR\n, en caso contrario imprime IMPAR\n.
-            answer: |
-              #include <stdio.h>
-
-              int main(void) {
-                int n;
-                scanf("%d", &n);
-                if (n % 2 == 0) {
-                  printf("PAR\n");
-                } else {
-                  printf("IMPAR\n");
-                }
-                return 0;
-              }
-            tests:
-              - input: "8\n"
-                output: "PAR\n"
-              - input: "7\n"
-                output: "IMPAR\n"
-            hint: Puedes usar el operador módulo (%).
 
       # Entrada y salida
       - number: 2

--- a/src/judge_c.rs
+++ b/src/judge_c.rs
@@ -1,0 +1,430 @@
+use crate::model::Question;
+
+#[derive(Debug, Clone)]
+pub enum JudgeResult {
+    Accepted,
+    CompileError {
+        stderr: String,
+    },
+    WrongAnswer {
+        test_index: usize,
+        input: String,
+        expected: String,
+        received: String,
+        diff: String,
+    },
+    Timeout {
+        test_index: usize,
+        input: String,
+        timeout_ms: u64,
+    },
+    RuntimeError {
+        test_index: usize,
+        input: String,
+        stderr: String,
+        exit_code: Option<i32>,
+    },
+    InfrastructureError {
+        message: String,
+    },
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use super::JudgeResult;
+    use crate::model::{JudgeTestCase, Question};
+    use std::collections::hash_map::DefaultHasher;
+    use std::env;
+    use std::fs;
+    use std::hash::{Hash, Hasher};
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    const TIMEOUT_MS: u64 = 2_000;
+    const POLL_MS: u64 = 10;
+
+    #[derive(Clone)]
+    enum SubmissionSource {
+        Raw,
+        WrappedBody,
+        CustomHarness,
+    }
+
+    pub fn grade_c_question(question: &Question, user_code: &str) -> JudgeResult {
+        if question.tests.is_empty() {
+            return JudgeResult::InfrastructureError {
+                message: "La pregunta judge_c no tiene tests configurados.".into(),
+            };
+        }
+
+        let compiler = match detect_compiler() {
+            Ok(path) => path,
+            Err(msg) => return JudgeResult::InfrastructureError { message: msg },
+        };
+
+        let cache_dir = match cache_dir() {
+            Ok(dir) => dir,
+            Err(err) => {
+                return JudgeResult::InfrastructureError {
+                    message: format!("No se pudo preparar el cache del juez: {err}"),
+                };
+            }
+        };
+
+        let candidates = build_source_candidates(question, user_code);
+        let mut first_compile_error = None;
+
+        for (source, source_kind) in candidates {
+            let binary_path = build_cached_binary(&cache_dir, &compiler, &source, &source_kind);
+            if !binary_path.exists() {
+                if let Err(stderr) = compile_source(&compiler, &source, &binary_path) {
+                    if first_compile_error.is_none() {
+                        first_compile_error = Some(stderr);
+                    }
+                    continue;
+                }
+            }
+
+            return run_tests(&binary_path, &question.tests);
+        }
+
+        JudgeResult::CompileError {
+            stderr: first_compile_error
+                .unwrap_or_else(|| "Error de compilación desconocido.".into()),
+        }
+    }
+
+    fn build_source_candidates(
+        question: &Question,
+        user_code: &str,
+    ) -> Vec<(String, SubmissionSource)> {
+        let mut candidates = Vec::new();
+
+        if let Some(harness) = question.judge_harness.as_deref() {
+            candidates.push((
+                apply_harness(user_code, Some(harness)),
+                SubmissionSource::CustomHarness,
+            ));
+            return candidates;
+        }
+
+        candidates.push((user_code.to_string(), SubmissionSource::Raw));
+
+        if !contains_main(user_code) {
+            candidates.push((wrap_as_main_body(user_code), SubmissionSource::WrappedBody));
+        }
+
+        candidates
+    }
+
+    fn contains_main(code: &str) -> bool {
+        let normalized = code.replace(char::is_whitespace, "");
+        normalized.contains("main(")
+    }
+
+    fn wrap_as_main_body(code: &str) -> String {
+        format!(
+            "#include <stdio.h>
+#include <stdbool.h>
+
+int main(void) {{
+{code}
+return 0;
+}}
+"
+        )
+    }
+
+    fn run_tests(binary_path: &Path, tests: &[JudgeTestCase]) -> JudgeResult {
+        for (idx, test) in tests.iter().enumerate() {
+            let exec = execute_test(binary_path, test, idx + 1, TIMEOUT_MS);
+            match exec {
+                JudgeResult::Accepted => continue,
+                other => return other,
+            }
+        }
+        JudgeResult::Accepted
+    }
+
+    fn execute_test(
+        binary_path: &Path,
+        test: &JudgeTestCase,
+        test_index: usize,
+        timeout_ms: u64,
+    ) -> JudgeResult {
+        let mut child = match Command::new(binary_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(err) => {
+                return JudgeResult::InfrastructureError {
+                    message: format!("No se pudo ejecutar el binario compilado: {err}"),
+                };
+            }
+        };
+
+        if let Some(mut stdin) = child.stdin.take() {
+            if let Err(err) = stdin.write_all(test.input.as_bytes()) {
+                return JudgeResult::InfrastructureError {
+                    message: format!("No se pudo enviar stdin al programa: {err}"),
+                };
+            }
+        }
+
+        let start = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    let output = match child.wait_with_output() {
+                        Ok(output) => output,
+                        Err(err) => {
+                            return JudgeResult::InfrastructureError {
+                                message: format!("No se pudo leer la salida del programa: {err}"),
+                            };
+                        }
+                    };
+                    return evaluate_output(
+                        test,
+                        test_index,
+                        output.status.code(),
+                        &output.stdout,
+                        &output.stderr,
+                    );
+                }
+                Ok(None) => {
+                    if start.elapsed() > Duration::from_millis(timeout_ms) {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return JudgeResult::Timeout {
+                            test_index,
+                            input: test.input.clone(),
+                            timeout_ms,
+                        };
+                    }
+                    thread::sleep(Duration::from_millis(POLL_MS));
+                }
+                Err(err) => {
+                    return JudgeResult::InfrastructureError {
+                        message: format!("Error esperando al programa: {err}"),
+                    };
+                }
+            }
+        }
+    }
+
+    fn evaluate_output(
+        test: &JudgeTestCase,
+        test_index: usize,
+        exit_code: Option<i32>,
+        stdout: &[u8],
+        stderr: &[u8],
+    ) -> JudgeResult {
+        let received = normalize_newlines(&String::from_utf8_lossy(stdout));
+        let expected = normalize_newlines(&test.output);
+
+        if exit_code.unwrap_or(-1) != 0 {
+            return JudgeResult::RuntimeError {
+                test_index,
+                input: test.input.clone(),
+                stderr: String::from_utf8_lossy(stderr).to_string(),
+                exit_code,
+            };
+        }
+
+        if !matches_expected_output(&received, &expected) {
+            return JudgeResult::WrongAnswer {
+                test_index,
+                input: test.input.clone(),
+                expected,
+                received: received.clone(),
+                diff: line_diff(&test.output, &received),
+            };
+        }
+
+        JudgeResult::Accepted
+    }
+
+    fn normalize_newlines(value: &str) -> String {
+        value.replace("\r\n", "\n")
+    }
+
+    fn matches_expected_output(received: &str, expected: &str) -> bool {
+        if received == expected {
+            return true;
+        }
+
+        let received_trimmed = received.trim_end();
+        let expected_trimmed = expected.trim_end();
+
+        if received_trimmed == expected_trimmed {
+            return true;
+        }
+
+        received_trimmed.ends_with(expected_trimmed)
+    }
+
+    fn line_diff(expected: &str, received: &str) -> String {
+        let expected_norm = expected.replace("\r\n", "\n");
+        let received_norm = received.replace("\r\n", "\n");
+        let exp: Vec<&str> = expected_norm.split('\n').collect();
+        let rec: Vec<&str> = received_norm.split('\n').collect();
+        let max_lines = exp.len().max(rec.len());
+
+        for i in 0..max_lines {
+            let e = exp.get(i).copied().unwrap_or("<sin línea>");
+            let r = rec.get(i).copied().unwrap_or("<sin línea>");
+            if e != r {
+                return format!("Línea {}\n- esperado: {:?}\n+ recibido: {:?}", i + 1, e, r);
+            }
+        }
+
+        "Diferencia no localizada (posible carácter invisible).".into()
+    }
+
+    fn apply_harness(user_code: &str, harness: Option<&str>) -> String {
+        if let Some(harness) = harness {
+            if harness.contains("{{USER_CODE}}") {
+                return harness.replace("{{USER_CODE}}", user_code);
+            }
+            return format!("{user_code}\n{harness}\n");
+        }
+        user_code.to_string()
+    }
+
+    fn compile_source(compiler: &Path, source: &str, output_binary: &Path) -> Result<(), String> {
+        let source_path = output_binary.with_extension("c");
+        fs::write(&source_path, source)
+            .map_err(|e| format!("No se pudo guardar código temporal: {e}"))?;
+
+        let output = Command::new(compiler)
+            .arg(&source_path)
+            .arg("-std=c11")
+            .arg("-O2")
+            .arg("-o")
+            .arg(output_binary)
+            .output()
+            .map_err(|e| format!("No se pudo invocar al compilador: {e}"))?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(String::from_utf8_lossy(&output.stderr).to_string())
+        }
+    }
+
+    fn detect_compiler() -> Result<PathBuf, String> {
+        for candidate in ["clang", "gcc"] {
+            if let Ok(status) = Command::new(candidate)
+                .arg("--version")
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+            {
+                if status.success() {
+                    return Ok(PathBuf::from(candidate));
+                }
+            }
+        }
+
+        Err("No se encontró un compilador C (clang/gcc) en PATH.
+Linux: instala clang o gcc (ej. sudo apt install clang).
+Windows: instala MSYS2/MinGW y agrega gcc/clang a PATH."
+            .into())
+    }
+
+    fn cache_dir() -> Result<PathBuf, std::io::Error> {
+        let base = if cfg!(target_os = "windows") {
+            env::var_os("LOCALAPPDATA")
+                .map(PathBuf::from)
+                .or_else(|| env::var_os("TEMP").map(PathBuf::from))
+                .unwrap_or_else(env::temp_dir)
+        } else {
+            env::var_os("XDG_CACHE_HOME")
+                .map(PathBuf::from)
+                .or_else(|| env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))
+                .unwrap_or_else(env::temp_dir)
+        };
+
+        let dir = base.join("summer_quiz").join("judge_c_cache");
+        fs::create_dir_all(&dir)?;
+        Ok(dir)
+    }
+
+    fn build_cached_binary(
+        cache_dir: &Path,
+        compiler: &Path,
+        source: &str,
+        source_kind: &SubmissionSource,
+    ) -> PathBuf {
+        let mut hasher = DefaultHasher::new();
+        compiler.to_string_lossy().hash(&mut hasher);
+        "-std=c11 -O2".hash(&mut hasher);
+        source.hash(&mut hasher);
+        std::mem::discriminant(source_kind).hash(&mut hasher);
+        let key = format!("{:016x}", hasher.finish());
+        let ext = if cfg!(target_os = "windows") {
+            "exe"
+        } else {
+            "bin"
+        };
+        cache_dir.join(format!("{key}.{ext}"))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn grade_c_question(question: &Question, user_code: &str) -> JudgeResult {
+    native::grade_c_question(question, user_code)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn grade_c_question(_question: &Question, _user_code: &str) -> JudgeResult {
+    JudgeResult::InfrastructureError {
+        message: "El juez C no está disponible en la versión web (wasm32).".into(),
+    }
+}
+
+pub fn format_judge_message(result: &JudgeResult) -> String {
+    match result {
+        JudgeResult::Accepted => "✅ ¡Correcto!".into(),
+        JudgeResult::CompileError { stderr } => {
+            format!("❌ Error de compilación.\n\n{}", stderr.trim())
+        }
+        JudgeResult::WrongAnswer {
+            test_index,
+            input,
+            expected,
+            received,
+            diff,
+        } => format!(
+            "❌ Wrong Answer (caso #{test_index}).\n\nInput:\n{input}\n\nEsperado:\n{expected}\n\nRecibido:\n{received}\n\nDiff:\n{diff}"
+        ),
+        JudgeResult::Timeout {
+            test_index,
+            input,
+            timeout_ms,
+        } => format!("❌ Timeout en caso #{test_index} ({timeout_ms} ms).\n\nInput:\n{input}"),
+        JudgeResult::RuntimeError {
+            test_index,
+            input,
+            stderr,
+            exit_code,
+        } => format!(
+            "❌ Runtime Error en caso #{test_index} (exit code: {}).\n\nInput:\n{input}\n\nStderr:\n{}",
+            exit_code
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "desconocido".into()),
+            stderr.trim()
+        ),
+        JudgeResult::InfrastructureError { message } => format!("⚠ {message}"),
+    }
+}
+
+pub fn should_use_judge(question: &Question) -> bool {
+    question.uses_judge_c()
+}

--- a/src/judge_c.rs
+++ b/src/judge_c.rs
@@ -128,13 +128,13 @@ mod native {
     fn wrap_as_main_body(code: &str) -> String {
         format!(
             "#include <stdio.h>
-#include <stdbool.h>
+            #include <stdbool.h>
 
-int main(void) {{
-{code}
-return 0;
-}}
-"
+            int main(void) {{
+                {code}
+                return 0;
+            }}
+            "
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod app;
 pub mod code_utils;
 pub mod data;
+pub mod judge_c;
 pub mod model;
 pub mod ui;
 pub mod update;

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,17 +6,36 @@ pub enum Language {
     Pseudocode,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GradingMode {
+    Normalize,
+    JudgeC,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct JudgeTestCase {
+    pub input: String,
+    pub output: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Question {
     pub language: Language,
     pub week: usize,
-    pub prompt: String,   // Pregunta
-    pub answer: String,   // Respuesta
+    pub prompt: String, // Pregunta
+    pub answer: String, // Respuesta
     pub hint: Option<String>,
     #[serde(skip)]
     pub number: usize,
     #[serde(default)]
     pub input_prefill: Option<String>,
+    #[serde(default)]
+    pub mode: Option<GradingMode>,
+    #[serde(default)]
+    pub tests: Vec<JudgeTestCase>,
+    #[serde(default)]
+    pub judge_harness: Option<String>,
     #[serde(default)]
     pub is_done: bool,
     #[serde(default)]
@@ -53,7 +72,6 @@ pub struct Quiz {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum AppState {
-
     PendingUpdate,
     LanguageSelect,
     Welcome,
@@ -63,7 +81,6 @@ pub enum AppState {
     Quiz,
     LevelSummary,
     Summary,
-
 }
 
 // ¡Implementa Default!
@@ -74,6 +91,11 @@ impl Default for AppState {
 }
 
 impl Question {
+    pub fn uses_judge_c(&self) -> bool {
+        matches!(self.mode, Some(GradingMode::JudgeC))
+            || (self.language == Language::C && !self.tests.is_empty())
+    }
+
     /// Reinicia los contadores y flags de esta pregunta.
     pub fn reset_stats(&mut self) {
         self.is_done = false;


### PR DESCRIPTION
### Motivation
- Evitar falsos negativos cuando el programa imprime prompts u otros textos antes del resultado esperado al evaluar preguntas en C usando tests automatizados. 
- Mejorar la experiencia de edición evitando que el editor borre el código del usuario tras una respuesta incorrecta. 
- Añadir soporte estructurado para preguntas evaluadas con tests en C y permitir envoltorios o harnesses personalizados.

### Description
- Se añadió el módulo `judge_c` con el tipo `JudgeResult` y la función `grade_c_question` que compila (con caché) y ejecuta los `tests` de `Question` aplicando varios candidatos de fuente (`Raw`, `WrappedBody`, `CustomHarness`).
- El matcher de salida ahora usa `matches_expected_output` que acepta igualdad exacta, igualdad tras `trim_end`, o que la salida normalizada termine con la salida esperada, reduciendo falsos negativos por prompts informativos. 
- `procesar_respuesta` (en `src/app/actions.rs`) integra `grade_c_question` cuando `should_use_judge` es verdadero y solo limpia `prog.input` (`update_input_prefill`) cuando la respuesta es correcta, conservando el código en el editor tras fallos.
- Se añadieron tipos y campos en el modelo: `GradingMode`, `JudgeTestCase`, `Question::mode`, `Question::tests`, `Question::judge_harness` y el helper `uses_judge_c()` para decidir cuándo usar el juez.
- Se registró `mod judge_c` en `lib.rs` y se añadieron ejemplos de preguntas `mode: judge_c` en `src/data/quiz_questions_v2.yaml` para ilustrar el uso.

### Testing
- Ejecutado `cargo fmt` y `rustfmt` sobre los archivos modificados (éxito). 
- Ejecutado `cargo check --offline` (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69964437b7108324804945087e9882f4)