### PR TITLE
Improve C judge output matching to accept final meaningful token

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::code_utils::normalize_code;
+use crate::judge_c::{format_judge_message, grade_c_question, should_use_judge, JudgeResult};
 
 impl QuizApp {
     pub fn procesar_respuesta(&mut self, respuesta: &str) {
@@ -20,24 +21,39 @@ impl QuizApp {
             }
         };
 
-        // 2) Normalizar código para comparar
-        let user_code = normalize_code(respuesta);
-        let answer_code = {
+        // 2) Calcular resultado (normalize o judge_c)
+        let grading_result = {
             let q = &self.quiz.weeks[cw].levels[cl].questions[ci];
-            normalize_code(&q.answer)
+            if should_use_judge(q) {
+                grade_c_question(q, respuesta)
+            } else {
+                let user_code = normalize_code(respuesta);
+                let answer_code = normalize_code(&q.answer);
+                if user_code == answer_code {
+                    JudgeResult::Accepted
+                } else {
+                    JudgeResult::WrongAnswer {
+                        test_index: 0,
+                        input: String::new(),
+                        expected: String::new(),
+                        received: String::new(),
+                        diff: String::new(),
+                    }
+                }
+            }
         };
+        let correcta = matches!(grading_result, JudgeResult::Accepted);
 
         // 3) Mutar la pregunta: intentos y fails / is_done
         {
             let q = &mut self.quiz.weeks[cw].levels[cl].questions[ci];
             q.attempts += 1;
-            if user_code == answer_code {
+            if correcta {
                 q.is_done = true;
             } else {
                 q.fails += 1;
             }
         }
-        let correcta = user_code == answer_code;
 
         // 4) Preparar clonados antes de mutar progress
         let question_id = self.quiz.weeks[cw].levels[cl].questions[ci].id.clone();
@@ -61,8 +77,6 @@ impl QuizApp {
                 prog.input.clear();
                 mark_pending = true;
                 curr_week = prog.current_week;
-            } else {
-                prog.input.clear();
             }
         }
 
@@ -97,11 +111,18 @@ impl QuizApp {
 
         // 8) Sincronizar y prefill, luego mensaje
         self.sync_is_done();
-        self.update_input_prefill();
+        if correcta {
+            self.update_input_prefill();
+        }
         self.message = if correcta {
             "✅ ¡Correcto!".into()
         } else {
-            "❌ Incorrecto. Intenta de nuevo.".into()
+            match &grading_result {
+                JudgeResult::WrongAnswer { test_index, .. } if *test_index == 0 => {
+                    "❌ Incorrecto. Intenta de nuevo.".into()
+                }
+                _ => format_judge_message(&grading_result),
+            }
         };
     }
 
@@ -109,7 +130,7 @@ impl QuizApp {
         // 1) Extraer índices actuales (o salir si no hay pregunta)
         let (cw, cl, ci) = match self.current_position() {
             Some(pos) => pos,
-            None      => return,
+            None => return,
         };
 
         // 2) Registrar estadísticas en la pregunta actual
@@ -152,7 +173,7 @@ impl QuizApp {
         // 1) Extraer índices actuales
         let (cw, cl, ci) = match self.current_position() {
             Some(pos) => pos,
-            None      => return,
+            None => return,
         };
 
         // 2) Marcar que vio la solución
@@ -179,7 +200,10 @@ impl QuizApp {
 
     // TEST helpers
     pub fn complete_all_week(&mut self) {
-        let wi = match self.progress().current_week { Some(w) => w, None => return };
+        let wi = match self.progress().current_week {
+            Some(w) => w,
+            None => return,
+        };
         let lang = self.selected_language.unwrap_or(Language::C);
 
         // 1) Marcar cada pregunta y acumular sus IDs
@@ -214,8 +238,14 @@ impl QuizApp {
 
     /// Marca *todas* las preguntas del nivel actual como completadas y va al resumen de nivel o al resumen semanal si era el último nivel.
     pub fn complete_all_level(&mut self) {
-        let wi = match self.progress().current_week  { Some(w) => w, None => return };
-        let li = match self.progress().current_level { Some(l) => l, None => return };
+        let wi = match self.progress().current_week {
+            Some(w) => w,
+            None => return,
+        };
+        let li = match self.progress().current_level {
+            Some(l) => l,
+            None => return,
+        };
         let lang = self.selected_language.unwrap_or(Language::C);
 
         // 1) Marcar cada pregunta del nivel y acumular IDs
@@ -303,7 +333,10 @@ impl QuizApp {
         // Si todas ya fueron mostradas en esta ronda pero aún hay pendientes, arranca ronda nueva
         let hay_pendientes = level.questions.iter().enumerate().any(|(_q_idx, q)| {
             q.language == language
-                && q.id.as_ref().map(|id| !self.progress().completed_ids.contains(id)).unwrap_or(false)
+                && q.id
+                    .as_ref()
+                    .map(|id| !self.progress().completed_ids.contains(id))
+                    .unwrap_or(false)
         });
 
         if hay_pendientes {
@@ -329,4 +362,3 @@ impl QuizApp {
         None
     }
 }
-

--- a/src/data.rs
+++ b/src/data.rs
@@ -6,6 +6,6 @@ use serde_yaml;
 /// Carga el banco de preguntas desde el YAML embebido
 pub fn read_questions_embedded() -> Quiz {
     // Ajusta la ruta si pones tu yaml en otra carpeta
-    let file_content = include_str!("data/quiz_questions_v2.yaml");
+    let file_content = include_str!("data/quiz_questions_modes.yaml");
     serde_yaml::from_str(file_content).expect("No se pudo parsear el banco de preguntas YAML")
 }

--- a/src/data/quiz_questions_modes.yaml
+++ b/src/data/quiz_questions_modes.yaml
@@ -1,0 +1,10429 @@
+---
+weeks:
+- number: 1
+  explanation: 'Explicación de semana 1
+
+    '
+  levels:
+  - number: 1
+    explanation:
+      C: "En este nivel aprenderás a **declarar constantes y variables en C**, entender
+        la diferencia entre ambas, y cómo usarlas en un programa con temática de videojuegos.\n\n###
+        Constantes con `#define` (preprocesador)\nSirven para definir valores constantes
+        globales sin tipo.  \nSon reemplazadas por su valor antes de compilar y no
+        ocupan memoria.  \nNo llevan `;` al final.  \n\n```c\n#define MAX_JUGADORES
+        4\n#define PUNTOS_VICTORIA 1000\n\nint main() {\n    return 0;\n}\n```\n\nEn
+        un videojuego, `MAX_JUGADORES` puede representar el número máximo de jugadores
+        en una partida multijugador, y `PUNTOS_VICTORIA` la puntuación necesaria para
+        ganar.\n\n---\n\n### Constantes locales con `const` (con tipo)\nSe definen
+        dentro de una función, tienen tipo y deben inicializarse al declararse.  \n\n```c\nint
+        main() {\n    const float VELOCIDAD_JUGADOR = 5.5;\n    const int VIDAS_INICIALES
+        = 3;\n    return 0;\n}\n```\n\nAquí `VELOCIDAD_JUGADOR` podría representar
+        la velocidad base de un personaje y `VIDAS_INICIALES` el número de vidas con
+        las que empieza un jugador.\n\n---\n\n### Declaración de variables\nLas variables
+        se usan para almacenar datos que pueden cambiar durante el juego.  \nCada
+        tipo se declara con una palabra clave:\n\n- `int` → enteros  \n- `float` →
+        decimales  \n- `bool` → booleanos (requiere `#include <stdbool.h>`)  \n- `char`
+        → un carácter individual  \n- `char[]` → cadenas de caracteres con tamaño
+        fijo  \n\n```c\nint main() {\n    int puntuacion;\n    float energia;\n    bool
+        nivelCompletado;\n    char inicialJugador;\n    char nombreJugador[30];\n
+        \   return 0;\n}\n```\n\n---\n\n### Inicialización y asignación\nPuedes **inicializar
+        al declarar**:\n\n```c\nint main() {\n    int puntuacion = 500;\n    float
+        energia = 5.5;\n    char inicialJugador = 'L';\n    char nombreJugador[30]
+        = \"Link\";\n    return 0;\n}\n```\n\nO **declarar primero y asignar después**:\n\n```c\nint
+        main() {\n    int puntuacion;\n    puntuacion = 500;\n\n    float energia;\n
+        \   energia = 5.5;\n\n    char inicialJugador;\n    inicialJugador = 'L';\n\n
+        \   return 0;\n}\n```\n\n---\n\n### Ejemplo completo\n```c\n#include <stdio.h>\n#include
+        <stdbool.h>\n#define MAX_JUGADORES 4\n#define PUNTOS_VICTORIA 1000\n\nint
+        main() {\n    const float VELOCIDAD_JUGADOR = 5.5;\n    const int VIDAS_INICIALES
+        = 3;\n\n    int puntuacion = 500;\n    float energia = VELOCIDAD_JUGADOR;\n
+        \   bool nivelCompletado = false;\n    char inicialJugador = 'L';\n    char
+        nombreJugador[30] = \"Link\";\n\n    printf(\"Jugador %c (%s) empieza con
+        %d vidas y velocidad %.1f.\\n\", \n           inicialJugador, nombreJugador,
+        VIDAS_INICIALES, VELOCIDAD_JUGADOR);\n    return 0;\n}\n```\n\nEste programa
+        inicializa un jugador con nombre, vidas y velocidad para una partida.\n"
+      Pseudocode: "En este nivel aprenderás a **declarar constantes y variables en
+        pseudocódigo**, entender su diferencia, y cómo usarlas en un programa con
+        temática de videojuegos.\n\n### Constantes\nSe definen en un bloque `const
+        ... end const`, indicando tipo y valor.  \nRepresentan valores que no cambian
+        durante la ejecución del programa.\n\n```pseudocode\nconst\n  MAX_JUGADORES:
+        integer = 4;\n  PUNTOS_VICTORIA: integer = 1000;\n  VELOCIDAD_JUGADOR: real
+        = 5.5;\n  VIDAS_INICIALES: integer = 3;\nend const\n```\n\nAquí `MAX_JUGADORES`
+        define el número máximo de jugadores en una partida y `PUNTOS_VICTORIA` los
+        puntos necesarios para ganar.\n\n---\n\n### Variables\nSe declaran en un bloque
+        `var ... end var` dentro del algoritmo principal.  \nNo se pueden inicializar
+        en la misma línea de la declaración.\n\n```pseudocode\nalgorithm\n  var\n
+        \   puntuacion: integer;\n    energia: real;\n    nivelCompletado: boolean;\n
+        \   inicialJugador: character;\n    nombreJugador: string;\n  end var\nend
+        algorithm\n```\n\n---\n\n### Asignación de valores\nDespués de declararlas,
+        se asigna valor con `:=`.\n\n```pseudocode\nalgorithm\n  var\n    puntuacion:
+        integer;\n    energia: real;\n    nivelCompletado: boolean;\n    inicialJugador:
+        character;\n    nombreJugador: string;\n  end var\n\n  puntuacion := 500;\n
+        \ energia := VELOCIDAD_JUGADOR;\n  nivelCompletado := false;\n  inicialJugador
+        := 'L';\n  nombreJugador := \"Link\";\nend algorithm\n```\n\n---\n\n### Tipos
+        básicos\n- `integer` → enteros  \n- `real` → decimales  \n- `boolean` → `true`
+        o `false`  \n- `character` → un solo carácter, ej. `'A'`  \n- `string` → cadenas
+        de texto  \n\n---\n\n### Ejemplo completo\n```pseudocode\nconst\n  MAX_JUGADORES:
+        integer = 4;\n  PUNTOS_VICTORIA: integer = 1000;\n  VELOCIDAD_JUGADOR: real
+        = 5.5;\n  VIDAS_INICIALES: integer = 3;\nend const\n\nalgorithm partidaVideojuego\n
+        \ var\n    puntuacion: integer;\n    energia: real;\n    nivelCompletado:
+        boolean;\n    inicialJugador: character;\n    nombreJugador: string;\n  end
+        var\n\n  puntuacion := 500;\n  energia := VELOCIDAD_JUGADOR;\n  nivelCompletado
+        := false;\n  inicialJugador := 'L';\n  nombreJugador := \"Link\";\n\n  writeString(\"Jugador
+        \");\n  writeCharacter(inicialJugador);\n  writeString(\" (\");\n  writeString(nombreJugador);\n
+        \ writeString(\") empieza con \");\n  writeInteger(VIDAS_INICIALES);\n  writeString(\"
+        vidas y velocidad \");\n  writeReal(VELOCIDAD_JUGADOR);\nend algorithm\n```\n\nEste
+        algoritmo simula la inicialización de un jugador al comenzar una partida.\n"
+    questions:
+    - id: c-1-judge-suma
+      language: C
+      week: 1
+      mode: judge_c
+      prompt: Escribe un programa completo que lea dos enteros y muestre su suma seguida
+        de un salto de línea.
+      answer: |
+        #include <stdio.h>
+
+        int main(void) {
+          int a, b;
+          scanf("%d %d", &a, &b);
+          printf("%d\n", a + b);
+          return 0;
+        }
+      tests:
+      - input: '2 3
+
+          '
+        output: '5
+
+          '
+      - input: '10 -4
+
+          '
+        output: '6
+
+          '
+      hint: Usa scanf para leer ambos enteros y printf para escribir la suma exacta.
+    - id: c-1-judge-paridad
+      language: C
+      week: 1
+      mode: judge_c
+      prompt: Escribe un programa completo que lea un entero. Si es par imprime PAR\n,
+        en caso contrario imprime IMPAR\n.
+      answer: |
+        #include <stdio.h>
+
+        int main(void) {
+          int n;
+          scanf("%d", &n);
+          if (n % 2 == 0) {
+            printf("PAR\n");
+          } else {
+            printf("IMPAR\n");
+          }
+          return 0;
+        }
+      tests:
+      - input: '8
+
+          '
+        output: 'PAR
+
+          '
+      - input: '7
+
+          '
+        output: 'IMPAR
+
+          '
+      hint: Puedes usar el operador módulo (%).
+    - id: c-1-max_nombre
+      language: C
+      week: 1
+      prompt: Usando la directiva define, declara una constante para el máximo de
+        un nombre "MAX_NOMBRE" con el valor entero 20.
+      answer: "#define MAX_NOMBRE 20"
+      hint:
+      mode: normalize
+    - id: c-1-max_drones
+      language: C
+      week: 1
+      prompt: Declara una constante para el máximo de drones "MAX_DRONES" con el valor
+        entero 5.
+      answer: "#define MAX_DRONES 5"
+      hint:
+      mode: normalize
+    - id: p-1-max_drones
+      language: Pseudocode
+      week: 1
+      prompt: Declara una constante para el máximo de drones "MAX_DRONES" con el valor
+        entero 5.
+      answer: |-
+        const
+            MAX_DRONES: integer = 5;
+        end const
+      hint:
+      mode: normalize
+    - id: c-1-const_decimal
+      language: C
+      week: 1
+      prompt: Declara una constante local de tipo decimal para la distancia mínima
+        "DISTANCIA_MINIMA", asignale el valor 250.0.
+      answer: |
+        int main(){
+          const float DISTANCIA_MINIMA = 250.0;
+          return 0;
+        }
+      hint: Las constantes locales comienzan por const.
+      mode: normalize
+    - id: p-1-const_decimal
+      language: Pseudocode
+      week: 1
+      prompt: Declara una constante de tipo decimal para la distancia mínima "DISTANCIA_MINIMA",
+        asignale el valor 250.0.
+      answer: |-
+        const
+          DISTANCIA_MINIMA: real = 250.0;
+        end const
+      hint: No olvides las palabras reservadas const end const y ;
+      mode: normalize
+    - id: c-1-const_entera
+      language: C
+      week: 1
+      prompt: Declara una constante local de tipo entera para el puntaje inicial INITIAL_SCORE,
+        asignale el valor 0.
+      answer: |
+        int main(){
+            const int INITIAL_SCORE = 0;
+          return 0;
+        }
+      hint: Las constantes locales comienzan por const.
+      mode: normalize
+    - id: p-1-const_entera
+      language: Pseudocode
+      week: 1
+      prompt: Declara una constante local de tipo entera para el puntaje inicial INITIAL_SCORE,
+        asignale el valor 0.
+      answer: |
+        const
+          INITIAL_SCORE: integer = 0;
+        end const
+      hint: No olvides las palabras reservadas const end const y ;
+      mode: normalize
+    - id: c-1-nombredron_20
+      language: C
+      week: 1
+      prompt: Declara una cadena de caracteres llamada nombreDron con tamaño 20.
+      answer: |
+        int main(){
+          char nombreDron[20];
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-nombredron_string
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable de tipo string llamada nombreDron.
+      answer: |-
+        algorithm
+          var
+            nombreDron: string;
+          end var
+        end algorithm
+      hint: Recuerda las palabras reservadas var end var.
+      mode: normalize
+    - id: c-1-nombredron_max_nombre
+      language: C
+      week: 1
+      prompt: Declara una cadena de caracteres llamada nombreDron con tamaño 20, pero
+        esta vez utiliza la constante "MAX_NOMBRE".
+      answer: |
+        int main(){
+          char nombreDron[MAX_NOMBRE];
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: c-1-iddron_entera
+      language: C
+      week: 1
+      prompt: Declara una variable entera para almacenar el identificador del dron,
+        llamala idDron.
+      answer: |
+        int main(){
+          int idDron;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-iddron_entera
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable entera para almacenar el identificador del dron,
+        llamala idDron.
+      answer: "algorithm\n  var \n    idDron: integer; \n  end var\nend algorithm"
+      hint:
+      mode: normalize
+    - id: c-1-bateriainicial_float
+      language: C
+      week: 1
+      prompt: Declara una variable decimal para la batería inicial del dron, llamala
+        bateriaInicial.
+      answer: |
+        int main(){
+          float bateriaInicial;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-bateriainicial_real
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable decimal para la batería inicial del dron, llamala
+        bateriaInicial.
+      answer: "algorithm\n  var \n    bateriaInicial: real; \n  end var\nend algorithm"
+      hint:
+      mode: normalize
+    - id: c-1-iddron_menos1
+      language: C
+      week: 1
+      prompt: Inicializa la variable idDron en -1.
+      answer: |
+        int main(){
+          idDron = -1;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-iddron_menos1
+      language: Pseudocode
+      week: 1
+      prompt: Inicializa la variable idDron en -1.
+      answer: |
+        algorithm
+          idDron := -1;
+        end algorithm
+      hint: El operador de asignación en pseudocódigo es diferente al de C.
+      mode: normalize
+    - id: c-1-distanciaminima_const
+      language: C
+      week: 1
+      prompt: Declara una variable llamada distanciaMinima e inicializala con la constante
+        "DISTANCIA_MINIMA".
+      answer: |-
+        int main(){
+          float distanciaMinima = DISTANCIA_MINIMA;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-distanciaminima_const
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable llamada distanciaMinima e inicializala con la constante
+        "DISTANCIA_MINIMA".
+      answer: |-
+        algorithm
+          var
+            distanciaMinima: real;
+          end var
+
+          distanciaMinima:= DISTANCIA_MINIMA;
+
+        end algorithm
+      hint: Aquí es importante recordar que en pseudocódigo no es posible declarar
+        e inicializar a la vez, primero declara y luego asignale el valor, no olvides
+        las palabras reservadas var end var.
+      mode: normalize
+    - id: c-1-dronactivo_true
+      language: C
+      week: 1
+      prompt: Declara una variable booleana llamada dronActivo e inicialízala a true
+        en la misma linea.
+      answer: |
+        int main(){
+          bool dronActivo = true;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-dronactivo_true
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable booleana llamada dronActivo e inicialízala a true.
+      answer: "algorithm\n  var \n    dronActivo: boolean; \n  end var \n\n  dronActivo
+        := true;\n\nend algorithm"
+      hint: Recuerda, primero declara (var end var) y luego inicializa.
+      mode: normalize
+    - id: c-1-categoriadron_a
+      language: C
+      week: 1
+      prompt: Declara e inicializa una variable char llamada categoriaDron a "A" en
+        la misma linea.
+      answer: |
+        int main(){
+          char categoriaDron = 'A';
+          return 0;
+        }
+      hint: Los caracteres se inicializan entre ''.
+      mode: normalize
+    - id: p-1-categoriadron_a
+      language: Pseudocode
+      week: 1
+      prompt: Declara e inicializa una variable char llamada categoriaDron a "A".
+      answer: |-
+        algorithm
+          var
+            categoriaDron: character;
+          end var
+
+          categoriaDron := 'A'
+        end algorithm
+      hint: Recuerda, primero declara y luego inicializa. Los caracteres se inicializan
+        entre ''.
+      mode: normalize
+  - number: 2
+    explanation:
+      C: "En este nivel aprenderás a leer y escribir datos en C utilizando las funciones
+        `scanf` y `printf`.  \nEstas funciones permiten la interacción entre el programa
+        y el jugador: `scanf` captura lo que escribe el usuario, y `printf` muestra
+        información en pantalla.\n\n### Lectura de datos con `scanf`\nSe usa para
+        leer información introducida por el jugador.  \n- En variables simples (`int`,
+        `float`, `char`) se pasa la **dirección de memoria** con `&`.  \n- En cadenas
+        (`char[]`), no se usa `&` porque los arrays ya son punteros.\n\n```c\n#include
+        <stdio.h>\n\nint main() {\n    char nombreJugador[30];\n    int nivel;\n    float
+        energia;\n    char teclaAccion;\n\n    scanf(\"%s\", nombreJugador); // cadena\n
+        \   scanf(\"%d\", &nivel);        // entero\n    scanf(\"%f\", &energia);
+        \     // decimal\n    scanf(\" %c\", &teclaAccion); // carácter\n    return
+        0;\n}\n```\n\nTambién puedes leer datos sobre un string que ya tenga un valor
+        inicial (se reemplaza el contenido):\n\n```c\n#include <stdio.h>\n\nint main()
+        {\n    char nombreJugador[30] = \"Jugador1\";\n    printf(\"Introduce nuevo
+        nombre: \");\n    scanf(\"%s\", nombreJugador);\n    return 0;\n}\n```\n\n####
+        Formatos comunes en `scanf`\n- `%s` → cadenas  \n- `%d` → enteros  \n- `%f`
+        → decimales  \n- `%c` → caracteres  \n\n---\n\n### Escritura de datos con
+        `printf`\nSe usa para mostrar información de la partida en pantalla.  \nLos
+        valores se muestran en el mismo orden que aparecen en la cadena de formato.\n\n```c\n#include
+        <stdio.h>\n\nint main() {\n    char nombreJugador[30] = \"Mario\";\n    int
+        nivel = 2;\n    float energia = 75.5;\n    char teclaAccion = 'A';\n\n    printf(\"Jugador:
+        %s\\n\", nombreJugador);\n    printf(\"Nivel: %d\\n\", nivel);\n    printf(\"Energía:
+        %.1f%%\\n\", energia);\n    printf(\"Tecla de acción: %c\\n\", teclaAccion);\n\n
+        \   return 0;\n}\n```\n\n#### Formatos comunes en `printf`\n- `%s` → cadenas
+        \ \n- `%d` → enteros  \n- `%f` → decimales  \n- `%.1f` → decimales con 1 cifra
+        \ \n- `%c` → caracteres  \n\n**Notas importantes**\n- En `scanf`, usar `&`
+        para variables simples (int, float, char), pero no para cadenas.  \n- En `printf`,
+        el orden y tipo de las variables deben coincidir con los especificadores.
+        \ \n\n---\n\n### Ejemplo completo\n```c\n#include <stdio.h>\n\nint main()
+        {\n    char nombreJugador[30];\n    int nivel;\n    float energia;\n    char
+        teclaAccion;\n\n    printf(\"Introduce tu nombre: \");\n    scanf(\"%s\",
+        nombreJugador);\n\n    printf(\"Introduce nivel inicial: \");\n    scanf(\"%d\",
+        &nivel);\n\n    printf(\"Introduce energía inicial: \");\n    scanf(\"%f\",
+        &energia);\n\n    printf(\"Introduce la tecla de acción: \");\n    scanf(\"
+        %c\", &teclaAccion);\n\n    printf(\"\\n--- Datos del jugador ---\\n\");\n
+        \   printf(\"Nombre: %s\\n\", nombreJugador);\n    printf(\"Nivel: %d\\n\",
+        nivel);\n    printf(\"Energía: %.1f\\n\", energia);\n    printf(\"Tecla de
+        acción: %c\\n\", teclaAccion);\n\n    return 0;\n}\n```\n\nEste programa solicita
+        al jugador sus datos y luego los muestra por pantalla.\n"
+      Pseudocode: "En este nivel aprenderás a leer y escribir datos en pseudocódigo
+        utilizando las funciones `readTipo()` y `writeTipo()`.  \nEstas funciones
+        permiten la interacción entre el programa y el jugador: `read...` captura
+        lo que escribe el usuario, y `write...` muestra información en pantalla.\n\n###
+        Lectura de datos\nCada tipo de dato tiene su función de lectura `readTipo()`.
+        \ \nEl valor obtenido debe asignarse a una variable con `:=`.\n\n```pseudocode\nalgorithm\n
+        \ var\n    nombreJugador: string;\n    nivel: integer;\n    energia: real;\n
+        \   teclaAccion: character;\n    modoCoop: boolean;\n  end var\n\n  nombreJugador
+        := readString();\n  nivel := readInteger();\n  energia := readReal();\n  teclaAccion
+        := readCharacter();\n  modoCoop := readBoolean();\nend algorithm\n```\n\nTambién
+        puedes leer sobre un string que ya tenga valor inicial (el contenido anterior
+        se reemplaza):\n\n```pseudocode\nalgorithm\n  var\n    nombreJugador: string;\n
+        \ end var\n\n  nombreJugador := \"Jugador1\";\n  nombreJugador := readString();\nend
+        algorithm\n```\n\n#### Funciones más comunes de lectura\n- `readString()`
+        → cadenas  \n- `readInteger()` → enteros  \n- `readReal()` → decimales  \n-
+        `readCharacter()` → caracteres  \n- `readBoolean()` → booleanos (`true` /
+        `false`)  \n\n---\n\n### Escritura de datos\nCada tipo de dato tiene su función
+        `writeTipo(valor)`.  \nSolo puedes imprimir un dato por llamada, por lo que
+        debes hacer varias llamadas para mostrar diferentes valores.\n\n```pseudocode\nwriteString(\"Jugador:
+        \");\nwriteString(nombreJugador);\n\nwriteString(\", Nivel: \");\nwriteInteger(nivel);\n\nwriteString(\",
+        Energía: \");\nwriteReal(energia);\n\nwriteString(\", Tecla de acción: \");\nwriteCharacter(teclaAccion);\n\nwriteString(\",
+        Modo cooperativo: \");\nwriteBoolean(modoCoop);\n```\n\n#### Funciones más
+        comunes de escritura\n- `writeString(valor)` → cadenas  \n- `writeInteger(valor)`
+        → enteros  \n- `writeReal(valor)` → decimales  \n- `writeCharacter(valor)`
+        → caracteres  \n- `writeBoolean(valor)` → booleanos  \n\n**Notas importantes**\n-
+        Cada llamada `write...` imprime un único dato o texto.  \n- Los booleanos
+        se muestran como `true` o `false`.  \n- El orden de las llamadas determina
+        el orden en pantalla.  \n\n---\n\n### Ejemplo completo\n```pseudocode\nalgorithm
+        datosJugador\n  var\n    nombreJugador: string;\n    nivel: integer;\n    energia:
+        real;\n    teclaAccion: character;\n  end var\n\n  writeString(\"Introduce
+        tu nombre: \");\n  nombreJugador := readString();\n\n  writeString(\"Introduce
+        nivel inicial: \");\n  nivel := readInteger();\n\n  writeString(\"Introduce
+        energía inicial: \");\n  energia := readReal();\n\n  writeString(\"Introduce
+        la tecla de acción: \");\n  teclaAccion := readCharacter();\n\n  writeString(\"---
+        Datos del jugador --- \");\n  writeString(\"Nombre: \");\n  writeString(nombreJugador);\n
+        \ writeString(\", Nivel: \");\n  writeInteger(nivel);\n  writeString(\", Energía:
+        \");\n  writeReal(energia);\n  writeString(\", Tecla: \");\n  writeCharacter(teclaAccion);\nend
+        algorithm\n```\n\nEste algoritmo solicita al jugador sus datos y luego los
+        muestra en pantalla.\n"
+    questions:
+    - id: c-1-scanf_nombredron
+      language: C
+      week: 1
+      prompt: Lee el nombre del dron desde teclado usando scanf y guardalo en nombreDron.
+      answer: |
+        int main(){
+          scanf("%s", nombreDron);
+          return 0;
+        }
+      hint: El especificador de formato de string es %s.
+      mode: normalize
+    - id: p-1-readstring_nombredron
+      language: Pseudocode
+      week: 1
+      prompt: Lee el nombre del dron desde teclado y guardalo en nombreDron.
+      answer: |
+        algorithm
+          nombreDron := readString();
+        end algorithm
+      hint: Recuerda que cada tipo tiene una función de lectura que comienza por read.
+        El formato es similar al de una inicialización.
+      mode: normalize
+    - id: c-1-scanf_iddron
+      language: C
+      week: 1
+      prompt: Lee el identificador del dron desde teclado usando scanf y guardalo
+        en idDron.
+      answer: |
+        int main(){
+          scanf("%d", &idDron);
+          return 0;
+        }
+      hint: El especificador de formato de integer es %d.
+      mode: normalize
+    - id: p-1-readinteger_iddron
+      language: Pseudocode
+      week: 1
+      prompt: Lee el identificador del dron desde teclado y guardalo en idDron.
+      answer: |
+        algorithm
+          idDron := readInteger();
+        end algorithm
+      hint: Recuerda que cada tipo tiene una función de lectura que comienza por read.
+        El formato es similar al de una inicialización.
+      mode: normalize
+    - id: c-1-scanf_bateriai
+      language: C
+      week: 1
+      prompt: Lee el valor de la batería inicial desde teclado usando scanf y guárdalo
+        en bateriaInicial.
+      answer: |
+        int main(){
+          scanf("%f", &bateriaInicial);
+          return 0;
+        }
+      hint: El especificador de formato de float es %f.
+      mode: normalize
+    - id: p-1-readreal_bateriai
+      language: Pseudocode
+      week: 1
+      prompt: Lee el valor de la batería inicial desde teclado y guárdalo en bateriaInicial.
+      answer: |
+        algorithm
+          bateriaInicial := readReal();
+        end algorithm
+      hint: Recuerda que cada tipo tiene una función de lectura que comienza por read.
+        El formato es similar al de una inicialización.
+      mode: normalize
+    - id: c-1-scanf_categoriadron
+      language: C
+      week: 1
+      prompt: Lee un carácter del usuario desde teclado usando scanf y guárdalo en
+        categoriaDron.
+      answer: |
+        int main(){
+          scanf(" %c", &categoriaDron);
+          return 0;
+        }
+      hint: El especificador de formato de char es %c.
+      mode: normalize
+    - id: p-1-readcharacter_categoriadron
+      language: Pseudocode
+      week: 1
+      prompt: Lee un character del usuario desde teclado y guárdalo en categoriaDron.
+      answer: |
+        algorithm
+          categoriaDron := readCharacter();
+        end algorithm
+      hint: Recuerda que cada tipo tiene una función de lectura que comienza por read.
+        El formato es similar al de una inicialización.
+      mode: normalize
+    - id: c-1-printf_nombre_id
+      language: C
+      week: 1
+      prompt: 'Imprime el nombre del dron y su identificador. Usa "Dron: x, ID: x"
+        para la impresión, siendo "x" el especificador de formato.'
+      answer: |
+        int main(){
+          printf("Dron: %s, ID: %d", nombreDron, idDron);
+          return 0;
+        }
+      hint: 'Ejemplo de ejecución: "Dron: dron001, ID: 1"'
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+    - id: p-1-writestring_nombre_id
+      language: Pseudocode
+      week: 1
+      prompt: 'Imprime el nombre del dron y su identificador. Usa "Dron: x, ID: x"
+        para la impresión, siendo "x" el valor pertinente.'
+      answer: "algorithm\n  writeString(\"Dron: \"); \n  writeString(nombreDron);
+        \n  writeString(\", ID: \"); \n  writeInteger(idDron);'\nend algorithm"
+      hint: 'Ejemplo de ejecución: "Dron: dron001, ID: 1". Recuerda que en pseudocódigo
+        no puedes imprimir mas de un dato por linea.'
+      mode: normalize
+    - id: c-1-printf_bateria
+      language: C
+      week: 1
+      prompt: 'Imprime la batería inicial del dron con un decimal. Usa "Batería: x"
+        para la impresión, siendo "x" el especificador de formato.'
+      answer: |
+        int main(){
+          printf("Batería: %.1f", bateriaInicial);
+          return 0;
+        }
+      hint: Para imprimir cierto numero de decimales utiliza %.xf, siendo x el numero
+        de decimales.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+    - id: p-1-writestring_bateria
+      language: Pseudocode
+      week: 1
+      prompt: 'Imprime la batería inicial del dron. Usa "Batería: x" para la impresión,
+        siendo "x" el valor pertinente.'
+      answer: |-
+        algorithm
+          writeString("Batería: ");
+          writeReal(bateriaInicial);
+        end algorithm
+      hint:
+      mode: normalize
+    - id: c-1-printf_categoria
+      language: C
+      week: 1
+      prompt: 'Imprime la categoría del dron como carácter. Usa "Categoría: x" para
+        la impresión, siendo "x" el especificador de formato.'
+      answer: |
+        int main(){
+          printf("Categoría: %c", categoriaDron);
+          return 0;
+        }
+      hint:
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+    - id: p-1-writestring_categoria
+      language: Pseudocode
+      week: 1
+      prompt: 'Imprime la categoría del dron como carácter. Usa "Categoría: x" para
+        la impresión, siendo "x" el valor pertinente.'
+      answer: |-
+        algorithm
+          writeString("Categoría: ");
+          writeCharacter(categoriaDron);
+        end algorithm
+      hint:
+      mode: normalize
+  - number: 3
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **enumerativos, operadores aritméticos,
+        relacionales y lógicos, el operador ternario y conversiones de tipo en C**.
+        \ \nEstos conceptos son muy útiles para representar estados de un videojuego,
+        calcular puntuaciones o decidir acciones en el juego.\n\n### Enumerativos
+        (enum)\nUn `enum` define un conjunto finito de etiquetas con valores enteros
+        subyacentes (normalmente `int` empezando en 0).  \nSon ideales para representar
+        estados del juego con nombres claros en lugar de números.\n\n```c\n#include
+        <stdio.h>\n\ntypedef enum {\n  IDLE, ATACANDO, KO\n} tEstadoJugador;\n\nint
+        main() {\n    tEstadoJugador estado = ATACANDO;   // inicialización\n\n    //
+        Lectura como entero sin signo\n    scanf(\"%u\", &estado);   // %u es el especificador
+        para enumerativos\n\n    // Impresión del valor numérico\n    printf(\"Estado
+        (0=IDLE,1=ATACANDO,2=KO): %u\\n\", estado);\n    return 0;\n}\n```\n\n---\n\n###
+        Operadores aritméticos y compuestos\n- Básicos: `+ - * / %`  \n- Compuestos:
+        `+= -= *= /= %=` (operación + asignación).  \n- `++` y `--` incrementan/decrementan
+        en 1.\n\n```c\n#include <stdio.h>\n\nint main() {\n    int puntuacion = 900;\n
+        \   puntuacion += 50;    // ahora 950\n    int vidas = 3;\n    vidas--;             //
+        ahora 2\n    float energia = 87.5f;\n    energia -= 12.5f;    // ahora 75.0\n
+        \   return 0;\n}\n```\n\n---\n\n### Operadores relacionales y lógicos\n- Comparaciones:
+        `== != < <= > >=` → devuelven `bool`.  \n- Lógicos: `&&` (AND), `||` (OR),
+        `!` (NOT).  \n\n```c\n#include <stdio.h>\n#include <stdbool.h>\n\nint main()
+        {\n    bool activo = true;\n    bool averiado = false;\n    float bateria
+        = 22.0f;\n    int vidas = 3;\n\n    bool suficiente = (bateria >= 20.0f);\n
+        \   bool enServicio = activo && !averiado;\n    bool puedeJugar = suficiente
+        && (vidas > 0);\n\n    return 0;\n}\n```\n\n---\n\n### Operador ternario `?:`\nSelecciona
+        entre dos expresiones según una condición.\n\n```c\n#include <stdio.h>\n#include
+        <stdbool.h>\n\nint main() {\n    int puntuacion = 1050;\n    bool enServicio
+        = true;\n\n    printf(\"%s\\n\", enServicio ? \"En servicio\" : \"Fuera de
+        servicio\");\n    int bonus = (puntuacion >= 1000) ? 100 : 0;\n\n    printf(\"Bonus:
+        %d\\n\", bonus);\n    return 0;\n}\n```\n\n---\n\n### Conversiones (casts)\n```c\n#include
+        <stdio.h>\n\nint main() {\n    float energia = 73.8f;\n    int energiaEntera
+        = (int)energia;    // 73\n    int vidas = 2;\n    float vidasF = (float)vidas;
+        \        // 2.0\n\n    printf(\"Energía entera: %d\\n\", energiaEntera);\n
+        \   printf(\"Vidas como real: %.1f\\n\", vidasF);\n\n    return 0;\n}\n```\n\n---\n\n###
+        Ejemplo completo\n```c\n#include <stdio.h>\n#include <stdbool.h>\n\ntypedef
+        enum {\n  IDLE, ATACANDO, KO\n} tEstadoJugador;\n\nint main() {\n    int puntuacion
+        = 950;\n    int vidas = 3;\n    float energia = 73.8f;\n    bool activo =
+        true;\n    bool averiado = false;\n    tEstadoJugador estado = ATACANDO;\n\n
+        \   // Relacionales y lógicos\n    bool suficiente = (energia >= 50.0f);\n
+        \   bool enServicio = activo && !averiado;\n\n    // Operador ternario\n    int
+        bonus = (puntuacion >= 1000) ? 100 : 0;\n\n    // Conversiones\n    int energiaEntera
+        = (int)energia;\n\n    printf(\"Estado del jugador: %u\\n\", estado);\n    printf(\"Puntuación:
+        %d (+%d bonus)\\n\", puntuacion, bonus);\n    printf(\"Vidas: %d\\n\", vidas);\n
+        \   printf(\"Energía: %.1f (entera: %d)\\n\", energia, energiaEntera);\n    printf(\"En
+        servicio: %s\\n\", enServicio ? \"Sí\" : \"No\");\n    return 0;\n}\n```\n\nEste
+        programa combina enumerativos, operadores y conversiones para simular el estado
+        de un jugador en un videojuego.\n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **enumerativos, operadores
+        aritméticos, relacionales y lógicos, además de conversiones de tipo en pseudocódigo**.
+        \ \nEstos conceptos son muy útiles para representar estados de un videojuego,
+        actualizar puntuaciones o decidir acciones.\n\n### Enumerativos\n```pseudocode\ntype\n
+        \ tEstadoJugador = { IDLE, ATACANDO, KO }\nend type\n\nalgorithm\n  var\n
+        \   estado: tEstadoJugador;\n  end var\n\n  estado := ATACANDO;\n  estado
+        := readEnum();\n  writeString(\"Estado actual: \");\n  writeEnum(estado);\nend
+        algorithm\n```\n\n---\n\n### Operadores aritméticos\n```pseudocode\nalgorithm\n
+        \ var\n    puntuacion: integer;\n    vidas: integer;\n    energia: real;\n
+        \ end var\n\n  puntuacion := 900;\n  puntuacion := puntuacion + 50;   { ahora
+        950 }\n  vidas := 3;\n  vidas := vidas - 1;              { ahora 2 }\n  energia
+        := 87.5;\n  energia := energia - 12.5;       { ahora 75.0 }\nend algorithm\n```\n\n---\n\n###
+        Operadores relacionales y lógicos\n```pseudocode\nalgorithm\n  var\n    bateria:
+        real;\n    vidas: integer;\n    activo: boolean;\n    averiado: boolean;\n
+        \   suficiente: boolean;\n    puedeJugar: boolean;\n  end var\n\n  bateria
+        := 22.0;\n  vidas := 3;\n  activo := true;\n  averiado := false;\n\n  suficiente
+        := bateria ≥ 20.0;\n  puedeJugar := suficiente y (vidas > 0);\n  activo :=
+        no averiado;\nend algorithm\n```\n\n---\n\n### Conversiones de tipo\n```pseudocode\nalgorithm\n
+        \ var\n    energia: real;\n    energiaEntera: integer;\n    vidas: integer;\n
+        \   vidasF: real;\n  end var\n\n  energia := 73.8;\n  energiaEntera := realToInteger(energia);\n
+        \ vidas := 2;\n  vidasF := integerToReal(vidas);\n\n  writeString(\"Energía
+        entera: \");\n  writeInteger(energiaEntera);\n  writeString(\", Vidas como
+        real: \");\n  writeReal(vidasF);\nend algorithm\n```\n\n---\n\n### Ejemplo
+        completo\n```pseudocode\ntype\n  tEstadoJugador = { IDLE, ATACANDO, KO }\nend
+        type\n\nalgorithm estadoJugador\n  var\n    puntuacion: integer;\n    vidas:
+        integer;\n    energia: real;\n    activo: boolean;\n    averiado: boolean;\n
+        \   estado: tEstadoJugador;\n    suficiente: boolean;\n    enServicio: boolean;\n
+        \   energiaEntera: integer;\n    bonus: integer;\n  end var\n\n  puntuacion
+        := 950;\n  vidas := 3;\n  energia := 73.8;\n  activo := true;\n  averiado
+        := false;\n  estado := ATACANDO;\n\n  suficiente := energia ≥ 50.0;\n  enServicio
+        := activo y (no averiado);\n\n  { Operador ternario simulado con asignación
+        condicional }\n  si puntuacion ≥ 1000 entonces\n    bonus := 100;\n  si no\n
+        \   bonus := 0;\n  fin si\n\n  energiaEntera := realToInteger(energia);\n\n
+        \ writeString(\"Estado del jugador: \");\n  writeEnum(estado);\n  writeString(\",
+        Puntuación: \");\n  writeInteger(puntuacion);\n  writeString(\" (+\");\n  writeInteger(bonus);\n
+        \ writeString(\" bonus)\");\n  writeString(\", Vidas: \");\n  writeInteger(vidas);\n
+        \ writeString(\", Energía: \");\n  writeReal(energia);\n  writeString(\" (entera:
+        \");\n  writeInteger(energiaEntera);\n  writeString(\")\");\n  writeString(\",
+        En servicio: \");\n  writeBoolean(enServicio);\nend algorithm\n```\n\nEste
+        algoritmo combina enumerativos, operadores y conversiones para simular el
+        estado de un jugador en un videojuego.\n"
+    questions:
+    - id: c-1-enum_tdrone
+      language: C
+      week: 1
+      prompt: Declara un enumerado tDronEstado con los valores PARADO, EN_VUELO y
+        ESTRELLADO.
+      answer: "typedef enum { \n  PARADO, \n  EN_VUELO, \n  ESTRELLADO \n} tDronEstado;"
+      hint: la palabra reservada es typedef enum, recuerda poner ; a continuación
+        del nombre del enum.
+      mode: normalize
+    - id: p-1-type_tdrone
+      language: Pseudocode
+      week: 1
+      prompt: Declara un enumerado tDronEstado con los valores PARADO, EN_VUELO y
+        ESTRELLADO.
+      answer: |-
+        type
+          tDronEstado = { PARADO, EN_VUELO y ESTRELLADO }
+        end type
+      hint: No olvides las palabras reservadas type end type.
+      mode: normalize
+    - id: c-1-estado_en_vuelo
+      language: C
+      week: 1
+      prompt: Declara una variable tDronEstado llamada estado e inicialízala a EN_VUELO.
+      answer: |
+        int main(){
+          tDronEstado estado = EN_VUELO;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-estado_en_vuelo
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable tDronEstado llamada estado e inicialízala a EN_VUELO.
+      answer: |-
+        algorithm
+          var
+            estado: tDronEstado;
+          end var
+
+        estado := EN_VUELO;
+
+        end algorithm
+      hint: 'Recuerda: primero declara, luego inicializa.'
+      mode: normalize
+    - id: c-1-lee_estado_enum
+      language: C
+      week: 1
+      prompt: Lee el valor del estado del dron desde teclado usando scanf y guárdalo
+        en estado.
+      answer: |
+        int main(){
+          scanf("%u", &estado);
+          return 0;
+        }
+      hint: El especificador de formato para leer enumerativos es %u
+      mode: normalize
+    - id: p-1-readenum_estado
+      language: Pseudocode
+      week: 1
+      prompt: Lee el valor del estado del dron desde teclado usando scanf y guárdalo
+        en estado.
+      answer: |
+        algorithm
+          estado := readEnum();
+        end algorithm
+      hint: La función que se encarga de leer un enumerativo es readEnum.
+      mode: normalize
+    - id: c-1-printf_estado_num
+      language: C
+      week: 1
+      prompt: 'Imprime el valor numérico del estado del dron con una explicación.
+        Usa "Estado (0=PARADO, 1=EN_VUELO, 2=ESTRELLADO): x" para la impresión, siendo
+        "x" el especificador de formato.'
+      answer: |
+        int main(){
+          printf("Estado (0=PARADO, 1=EN_VUELO, 2=ESTRELLADO): %d", estado);
+          return 0;
+        }
+      hint: 'Ejemplo de ejecución: "Estado (0=PARADO, 1=EN_VUELO, 2=ESTRELLADO): 1"'
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+    - id: p-1-writestring_estado_num
+      language: Pseudocode
+      week: 1
+      prompt: 'Imprime el valor del estado del dron con una explicación. Usa "Estado:
+        x" para la impresión, siendo "x" el valor a enseñar.'
+      answer: |-
+        algorithm
+          writeString("Estado: ");
+          writeEnum(estado);
+        end algorithm
+      hint: 'Ejemplo de ejecución: Estado: 1'
+      mode: normalize
+    - id: c-1-incremento_iddron
+      language: C
+      week: 1
+      prompt: Incrementa la variable idDron en 1 usando el operador de incremento
+        al finalizar la carrera.
+      answer: |
+        int main(){
+          idDron++;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-incrementa_iddron
+      language: Pseudocode
+      week: 1
+      prompt: Incrementa la variable idDron en 1 al finalizar la carrera.
+      answer: |
+        algorithm
+          idDron := idDron +1;
+        end algorithm
+      hint: Recuerda que en pseudocódigo no existe el operador ++ o -- .
+      mode: normalize
+    - id: c-1-compuesto_bateria
+      language: C
+      week: 1
+      prompt: Resta 10.5 a la bateríaInicial usando operador compuesto.
+      answer: |
+        int main(){
+          float bateriaInicial = 100.0;
+          bateriaInicial -= 10.5;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-resta_bateria
+      language: Pseudocode
+      week: 1
+      prompt: Resta 10.5 a la bateríaInicial .
+      answer: |
+        algorithm
+          bateriaInicial := bateriaInicial - 10.5;
+        end algorithm
+      hint:
+      mode: normalize
+    - id: c-1-suficiente_bool
+      language: C
+      week: 1
+      prompt: Calcula si la batería es suficiente usando un operador relacional y
+        guarda el resultado en en una variable booleana "suficiente". Diremos que
+        la batería es suficiente si tiene al menos un 20%
+      answer: |
+        int main(){
+          bool suficiente = bateriaInicial >= 20.0;
+          return 0;
+        }
+      hint: batería mayor o igual a 20.0
+      mode: normalize
+    - id: p-1-suficiente_bool
+      language: Pseudocode
+      week: 1
+      prompt: Calcula si la batería es suficiente usando un operador relacional y
+        guarda el resultado en en una variable booleana "suficiente". Diremos que
+        la batería es suficiente si tiene al menos un 20%. Necesitarás este operador
+        "≥".
+      answer: |-
+        algorithm
+          var
+            suficiente: boolean;
+          end var
+
+          suficiente := bateriaInicial ≥ 20.0;
+
+        end algorithm
+      hint: 'Ten en cuenta que una comparación con operadores relacionales, siempre
+        devuelven un resultado booleano de verdadero o falso, por eso podemos guardar
+        el resultado en una variable booleana. Extra: bateria ≥ a 20.0.'
+      mode: normalize
+    - id: c-1-ternario_en_servicio
+      language: C
+      week: 1
+      prompt: Usa el operador ternario para imprimir "En servicio" si dronActivo es
+        verdadero, si no imprime "Fuera de servicio".
+      answer: |
+        int main(){
+          printf("%s", dronActivo ? "En servicio" : "Fuera de servicio");
+          return 0;
+        }
+      hint: 'recuerda que printf acepta como argumento cualquier expresión que devuelva
+        un valor, por eso podemos usar el operador ternario. Ejemplo: printf("%s",
+        variable o condición ? "output1"" : ""output2"");"'
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+    - id: c-1-ternario_apto
+      language: C
+      week: 1
+      prompt: Imprime "Apto para siguiente ronda" si suficiente es verdadero, si no
+        imprime "No apto", usando ternario.
+      answer: |
+        int main(){
+          printf("%s", suficiente ? "Apto para siguiente ronda" : "No apto");
+          return 0;
+        }
+      hint:
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+    - id: c-1-cast_bateriaentera
+      language: C
+      week: 1
+      prompt: Convierte bateriaInicial a entero y guárdalo en bateriaEntera.
+      answer: "\nint main(){\n  int bateriaEntera = (int)bateriaInicial;              \n
+        \ return 0;\n}\n"
+      hint: Recuerda que para castear una variable utilizas (tipo)variable.
+      mode: normalize
+    - id: p-1-cast_bateriaentera
+      language: Pseudocode
+      week: 1
+      prompt: Convierte bateriaInicial a entero y guárdalo en bateriaEntera.
+      answer: |-
+        algorithm
+          var
+            bateriaEntera: integer;
+          end var
+
+          bateriaEntera := realToInteger(bateriaInicial);
+        end algorithm
+      hint: Recuerda que para castear una variable decimal a una entera usamos realToInteger().
+        También recuerda que primero debes declarar la variable bateriaEntera.
+      mode: normalize
+    - id: c-1-cast_nuevabateria
+      language: C
+      week: 1
+      prompt: Convierte bateriaEntera otra vez a decimal y guárdalo en nuevaBateria.
+      answer: |
+        int main(){
+          float nuevaBateria = (float)bateriaEntera;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-cast_nuevabateria
+      language: Pseudocode
+      week: 1
+      prompt: Convierte bateriaEntera otra vez a decimal y guárdalo en nuevaBateria.
+      answer: |-
+        algorithm
+          var
+            nuevaBateria: integer;
+          end var
+
+          nuevaBateria := integerToReal(bateriaInicial);
+        end algorithm
+      hint:
+      mode: normalize
+- number: 2
+  explanation: 'Explicación de semana 2
+
+    '
+  levels:
+  - number: 1
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **arrays en C**, tanto de números
+        como de cadenas.  \nLos arrays son fundamentales en videojuegos para guardar
+        puntuaciones de enemigos, inventarios o niveles.\n\n### Arrays en C\nUn **array**
+        es una colección de elementos del mismo tipo almacenados en posiciones consecutivas
+        de memoria.  \nEl tamaño del array debe ser fijo y conocerse en tiempo de
+        compilación.\n\n---\n\n### Tamaño con número fijo o con constante\n```c\n#define
+        MAX_ENEMIGOS 5\n\nint main() {\n    int puntosEnemigos[5];                 //
+        tamaño fijo\n    int puntosEnemigosConst[MAX_ENEMIGOS]; // con constante\n
+        \   return 0;\n}\n```\n\n---\n\n### Inicialización de arrays de tipos primitivos\nPuedes
+        inicializar al declarar:\n```c\nint main() {\n    int puntosEnemigos[5] =
+        {100, 200, 150, 300, 500};\n    return 0;\n}\n```\n\nO asignar después elemento
+        por elemento:\n```c\nint main() {\n    int puntosEnemigos[5];\n    puntosEnemigos[0]
+        = 100;\n    puntosEnemigos[1] = 200;\n    puntosEnemigos[2] = 150;\n    puntosEnemigos[3]
+        = 300;\n    puntosEnemigos[4] = 500;\n    return 0;\n}\n```\n\n*Recuerda*:
+        en C los índices empiezan en **0**.\n\n---\n\n### Arrays de cadenas\nUna cadena
+        es un array de `char` terminado con `'\\0'`.  \nPara guardar varias cadenas
+        se usan arrays bidimensionales:\n\n```c\n#define MAX_OBJETOS 3\n#define MAX_LONGITUD
+        20\n\nint main() {\n    char inventario[MAX_OBJETOS][MAX_LONGITUD];\n    return
+        0;\n}\n```\n\nInicialización directa:\n```c\nint main() {\n    char inventario[3][20]
+        = {\"Espada\", \"Escudo\", \"Poción\"};\n    return 0;\n}\n```\n\nO asignación
+        posterior:\n```c\n#include <string.h>\n\nint main() {\n    char inventario[3][20];\n
+        \   strcpy(inventario[0], \"Espada\");\n    strcpy(inventario[1], \"Escudo\");\n
+        \   strcpy(inventario[2], \"Poción\");\n    return 0;\n}\n```\n\n---\n\n###
+        Acceso a elementos\n```c\nint main() {\n    int puntosEnemigos[5] = {100,
+        200, 150, 300, 500};\n    int valor = puntosEnemigos[2]; // devuelve 150\n\n
+        \   char inventario[3][20] = {\"Espada\", \"Escudo\", \"Poción\"};\n    //
+        inventario[1] → \"Escudo\"\n\n    return 0;\n}\n```\n\n---\n\n### Ejemplo
+        completo\n```c\n#include <stdio.h>\n#include <string.h>\n#define MAX_ENEMIGOS
+        5\n#define MAX_OBJETOS 3\n#define MAX_LONGITUD 20\n\nint main() {\n    int
+        puntosEnemigos[MAX_ENEMIGOS] = {100, 200, 150, 300, 500};\n    char inventario[MAX_OBJETOS][MAX_LONGITUD]
+        = {\"Espada\", \"Escudo\", \"Poción\"};\n\n    printf(\"Puntos del tercer
+        enemigo: %d\\n\", puntosEnemigos[2]);\n    printf(\"Objeto en la segunda ranura:
+        %s\\n\", inventario[1]);\n\n    // Actualizar inventario\n    strcpy(inventario[2],
+        \"Llave mágica\");\n    printf(\"Nuevo objeto en la tercera ranura: %s\\n\",
+        inventario[2]);\n    return 0;\n}\n```\n\nEste programa muestra cómo inicializar
+        arrays, acceder a sus elementos y modificarlos, simulando un sistema de enemigos
+        y objetos en un videojuego.\n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **arrays en pseudocódigo**,
+        tanto de números como de cadenas.  \nSon muy útiles para representar puntuaciones
+        de enemigos o inventarios en videojuegos.\n\n### Arrays en pseudocódigo\nUn
+        **array** es una colección de elementos del mismo tipo.  \nEl tamaño es fijo
+        y se define al crearlo.\n\n---\n\n### Tamaño con número fijo o constante\n```pseudocode\nalgorithm\n
+        \ var\n    puntosEnemigos: vector[5] of integer;\n  end var\nend algorithm\n```\n\n```pseudocode\nconst\n
+        \ MAX_ENEMIGOS: integer = 5;\nend const\n\nalgorithm\n  var\n    puntosEnemigos:
+        vector[MAX_ENEMIGOS] of integer;\n  end var\nend algorithm\n```\n\n---\n\n###
+        Inicialización de arrays de tipos primitivos\nEn pseudocódigo no se permiten
+        llaves `{}`.  \nSe asigna elemento por elemento:\n\n```pseudocode\nconst\n
+        \ MAX_ENEMIGOS: integer = 5;\nend const\n\nalgorithm\n  var\n    puntosEnemigos:
+        vector[MAX_ENEMIGOS] of integer;\n  end var\n\n  puntosEnemigos[1] := 100;\n
+        \ puntosEnemigos[2] := 200;\n  puntosEnemigos[3] := 150;\n  puntosEnemigos[4]
+        := 300;\n  puntosEnemigos[5] := 500;\nend algorithm\n```\n\n*Recuerda*: en
+        pseudocódigo los índices empiezan en **1**.\n\n---\n\n### Arrays de cadenas\n```pseudocode\nconst\n
+        \ MAX_OBJETOS: integer = 3;\nend const\n\nalgorithm\n  var\n    inventario:
+        vector[MAX_OBJETOS] of string;\n  end var\n\n  inventario[1] := \"Espada\";\n
+        \ inventario[2] := \"Escudo\";\n  inventario[3] := \"Poción\";\nend algorithm\n```\n\n---\n\n###
+        Acceso a elementos\n```pseudocode\nvalor := puntosEnemigos[3];\nobjeto :=
+        inventario[2];\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\nconst\n
+        \ MAX_ENEMIGOS: integer = 5;\n  MAX_OBJETOS: integer = 3;\nend const\n\nalgorithm
+        arraysVideojuego\n  var\n    puntosEnemigos: vector[MAX_ENEMIGOS] of integer;\n
+        \   inventario: vector[MAX_OBJETOS] of string;\n    valor: integer;\n    objeto:
+        string;\n  end var\n\n  puntosEnemigos[1] := 100;\n  puntosEnemigos[2] :=
+        200;\n  puntosEnemigos[3] := 150;\n  puntosEnemigos[4] := 300;\n  puntosEnemigos[5]
+        := 500;\n\n  inventario[1] := \"Espada\";\n  inventario[2] := \"Escudo\";\n
+        \ inventario[3] := \"Poción\";\n\n  valor := puntosEnemigos[3];\n  objeto
+        := inventario[2];\n\n  writeString(\"Puntos del tercer enemigo: \");\n  writeInteger(valor);\n
+        \ writeString(\", Objeto en la segunda ranura: \");\n  writeString(objeto);\nend
+        algorithm\n```\n\nEste algoritmo muestra cómo usar arrays para almacenar y
+        consultar puntuaciones de enemigos y un inventario de objetos en un videojuego.\n"
+    questions:
+    - id: c-2-include_stdio
+      language: C
+      week: 2
+      prompt: Incluye la biblioteca estándar de entrada/salida en C para poder usar
+        printf y scanf.
+      answer: "#include <stdio.h>\n"
+      hint: 'Empieza por #include'
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-include_stdbool
+      language: C
+      week: 2
+      prompt: Incluye la biblioteca necesaria para poder usar variables booleanas
+        en C.
+      answer: "#include <stdbool.h>\n"
+      hint: El nombre contiene "std"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-include_string
+      language: C
+      week: 2
+      prompt: Incluye la biblioteca necesaria para trabajar con cadenas de caracteres
+        (funciones como strcpy, strcat, strcmp, strlen).
+      answer: "#include <string.h>\n"
+      hint: La biblioteca clásica para manipulación de strings, el nombre acaba con
+        .h .
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-max_plants_define
+      language: C
+      week: 2
+      prompt: Declara una constante MAX_PLANTS con valor 5 usando define.
+      answer: "#define MAX_PLANTS 5\n"
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-max_plants_const
+      language: Pseudocode
+      week: 2
+      prompt: Declara una constante MAX_PLANTS con valor 5.
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-max_name_define
+      language: C
+      week: 2
+      prompt: Declara una constante MAX_NAME con valor 25 usando define.
+      answer: "#define MAX_NAME 25\n"
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-const_temp_minima
+      language: C
+      week: 2
+      prompt: Dentro de la función main, declara una constante local de tipo float
+        llamada TEMP_MINIMA con valor 15.0.
+      answer: |
+        int main() {
+            const float TEMP_MINIMA = 15.0;
+            return 0;
+        }
+      hint: |
+        int main(){
+
+          // Código
+
+          return 0;
+        }
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-const_temp_minima
+      language: Pseudocode
+      week: 2
+      prompt: Declara una constante de tipo decimal llamada TEMP_MINIMA con valor
+        15.0.
+      answer: |
+        const
+          TEMP_MINIMA: real = 15.0;
+        end const
+      hint: Los decimales en pseudocódigo son el tipo real.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-array-nombres-solo
+      language: C
+      week: 2
+      prompt: Declara un array de cadenas nombrePlantas para 5 plantas, cada nombre
+        de 20 caracteres.
+      answer: |
+        int main() {
+            char nombrePlantas[5][20];
+            return 0;
+        }
+      hint: Primero va el número de elementos, luego el tamaño de cada string.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-array-nombres-solo
+      language: Pseudocode
+      week: 2
+      prompt: Declara un array de strings nombrePlantas para 5 plantas.
+      answer: |
+        algorithm
+          var
+            nombrePlantas: vector[5] of string;
+          end var
+        end algorithm
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-arr_nombreplanta
+      language: C
+      week: 2
+      prompt: |
+        Declara las constantes MAX_PLANTS = 5 y MAX_NAME = 25.
+
+        Dentro de main, declara un array de cadenas nombrePlanta para los nombres de las plantas usando ambas constantes.
+      answer: |
+        #define MAX_PLANTS 5
+        #define MAX_NAME 25
+
+        int main() {
+            char nombrePlanta[MAX_PLANTS][MAX_NAME];
+            return 0;
+        }
+      hint: Después del nombre del array va primero el maximo de plantas y después
+        el de los nombres
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-arr_nombreplanta
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTS = 5.
+
+        Dentro del algoritmo principal, declara un array de strings nombrePlanta para los nombres de las plantas usando dicha constante.
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+
+        algorithm
+          var
+            nombrePlanta: vector[MAX_PLANTS] of string;
+          end var
+        end algorithm
+      hint: No olvides todas las palabras reservadas como const, algorithm y var.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-arr_sensoresactivos
+      language: C
+      week: 2
+      prompt: |
+        Incluye la biblioteca necesaria para booleanos.
+
+        Declara la constante MAX_PLANTS = 5 y un array booleano sensoresActivos usando MAX_PLANTS dentro de main.
+      answer: |
+        #include <stdbool.h>
+        #define MAX_PLANTS 5
+
+        int main() {
+            bool sensoresActivos[MAX_PLANTS];
+            return 0;
+        }
+      hint: Incluye stdbool y usa bool, no int.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-arr_sensoresactivos
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTS = 5.
+
+        Dentro del algoritmo principal, declara un array de booleanos sensoresActivos usando dicha constante.
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+
+        algorithm
+          var
+             sensoresActivos: vector[MAX_PLANTS] of boolean;
+          end var
+        end algorithm
+      hint: No olvides todas las palabras reservadas como const, algorithm y var.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-array-alturas
+      language: C
+      week: 2
+      prompt: Declara la constante MAX_PLANTAS = 5 y un array float alturas usando
+        la constante.
+      answer: |
+        #define MAX_PLANTAS 5
+
+        int main() {
+            float alturas[MAX_PLANTAS];
+            return 0;
+        }
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-array-alturas
+      language: Pseudocode
+      week: 2
+      prompt: Declara la constante MAX_PLANTAS = 5 y un array real alturas usando
+        la constante.
+      answer: |
+        const
+          MAX_PLANTAS: integer = 5;
+        end const
+
+        algorithm
+          var
+            alturas: vector[MAX_PLANTAS] of real;
+          end var
+        end algorithm
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-array-nombres-alturas
+      language: C
+      week: 2
+      prompt: Declara las constantes MAX_PLANTAS = 5 y MAX_NOMBRE = 20. Declara un
+        array de cadenas nombrePlantas y un array float alturas, ambos usando MAX_PLANTAS.
+      answer: |
+        #define MAX_PLANTAS 5
+        #define MAX_NOMBRE 20
+
+        int main() {
+            char nombrePlantas[MAX_PLANTAS][MAX_NOMBRE];
+            float alturas[MAX_PLANTAS];
+            return 0;
+        }
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-array-nombres-alturas
+      language: Pseudocode
+      week: 2
+      prompt: Declara la constante MAX_PLANTAS = 5. Declara un array de strings nombrePlantas
+        y un array de reales alturas usando la constante.
+      answer: |
+        const
+          MAX_PLANTAS: integer = 5;
+        end const
+
+        algorithm
+          var
+            nombrePlantas: vector[MAX_PLANTAS] of string;
+            alturas: vector[MAX_PLANTAS] of real;
+          end var
+        end algorithm
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-arr_humedad
+      language: C
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTS = 5 y un array de enteros humedad con MAX_PLANTS,
+
+        inicializado con los valores "60, 85, 72, 91, 65" en la misma linea dentro de main.
+      answer: |
+        #define MAX_PLANTS 5
+
+        int main() {
+            int humedad[MAX_PLANTS] = {60, 85, 72, 91, 65};
+            return 0;
+        }
+      hint: Los valores deben estar entre llaves, separados por comas.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-arr_humedad
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTS = 5.
+
+        Dentro del algoritmo principal, declara un array de enteros humedad con MAX_PLANTS.
+
+        Inicializa el array con los valores "60, 85, 72, 91, 65".
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+
+        algorithm
+          var
+             humedad: vector[MAX_PLANTS] of integer;
+          end var
+
+          humedad[1] := 60;
+          humedad[2] := 85;
+          humedad[3] := 72;
+          humedad[4] := 91;
+          humedad[5] := 65;
+        end algorithm
+      hint: Recuerda que en pseudocódigo, primero declaramos las variables y después
+        las inicializamos.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-inicializa-alturas
+      language: C
+      week: 2
+      prompt: Declara la constante MAX_PLANTAS = 5 y un array float alturas, inicializándolo
+        con los valores 11.2, 18.4, 13.0, 17.5, 15.1.
+      answer: |
+        #define MAX_PLANTAS 5
+
+        int main() {
+            float alturas[MAX_PLANTAS] = {11.2, 18.4, 13.0, 17.5, 15.1};
+            return 0;
+        }
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-inicializa-alturas
+      language: Pseudocode
+      week: 2
+      prompt: Declara la constante MAX_PLANTAS = 5 y un array real alturas. Inicializa
+        los 5 valores a 11.2, 18.4, 13.0, 17.5, 15.1.
+      answer: |
+        const
+          MAX_PLANTAS: integer = 5;
+        end const
+
+        algorithm
+          var
+            alturas: vector[MAX_PLANTAS] of real;
+          end var
+
+          alturas[1] := 11.2;
+          alturas[2] := 18.4;
+          alturas[3] := 13.0;
+          alturas[4] := 17.5;
+          alturas[5] := 15.1;
+        end algorithm
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 2
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **matrices (arrays bidimensionales)**
+        en C.  \nLas matrices son muy útiles en videojuegos para representar mapas,
+        tableros o zonas de juego.\n\n### ¿Qué es una matriz?\nUna **matriz** es un
+        array con **filas** y **columnas**.  \nLa forma general es:  \n```c\ntipo
+        nombre[FILAS][COLUMNAS];\n```\n*Primero se escriben las filas y después las
+        columnas*.  \nLos índices en C empiezan en **0**.\n\n---\n\n### Declaración
+        con constantes fuera de `main`\n```c\n#define FILAS 3\n#define COLUMNAS 4\n\nint
+        main() {\n    int tablero[FILAS][COLUMNAS];\n    return 0;\n}\n```\n\n---\n\n###
+        Inicialización con llaves `{}` al declarar\n```c\n#define FILAS 2\n#define
+        COLUMNAS 3\n\nint main() {\n    int mapa[FILAS][COLUMNAS] = {\n        {1,
+        0, 0},\n        {0, 1, 0}\n    };\n    return 0;\n}\n```\n\n---\n\n### Inicialización
+        manual elemento a elemento\n```c\n#define FILAS 2\n#define COLUMNAS 3\n\nint
+        main() {\n    int zonas[FILAS][COLUMNAS];\n    zonas[0][0] = 1;\n    zonas[0][1]
+        = 0;\n    zonas[0][2] = 0;\n\n    zonas[1][0] = 0;\n    zonas[1][1] = 1;\n
+        \   zonas[1][2] = 0;\n    return 0;\n}\n```\n\n---\n\n### Matrices booleanas\n```c\n#include
+        <stdbool.h>\n#define FILAS 2\n#define COLUMNAS 3\n\nint main() {\n    bool
+        zonaActiva[FILAS][COLUMNAS];\n\n    zonaActiva[0][0] = true;\n    zonaActiva[0][1]
+        = false;\n    zonaActiva[0][2] = false;\n\n    zonaActiva[1][0] = false;\n
+        \   zonaActiva[1][1] = true;\n    zonaActiva[1][2] = false;\n    return 0;\n}\n```\n\n---\n\n###
+        Acceso a un elemento concreto\n```c\n#define FILAS 2\n#define COLUMNAS 3\n\nint
+        main() {\n    float valores[FILAS][COLUMNAS] = {\n        {6.1f, 6.3f, 6.0f},\n
+        \       {7.1f, 7.0f, 6.9f}\n    };\n    float x = valores[1][0]; // fila 2,
+        columna 1 → 7.1\n    return 0;\n}\n```\n\n---\n\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n#include <stdbool.h>\n#define FILAS 2\n#define COLUMNAS 3\n\nint
+        main() {\n    // Matriz de enteros para un mapa\n    int mapa[FILAS][COLUMNAS]
+        = {\n        {1, 0, 0},\n        {0, 1, 0}\n    };\n\n    // Matriz booleana
+        para zonas activas\n    bool zonaActiva[FILAS][COLUMNAS];\n    zonaActiva[0][0]
+        = true;\n    zonaActiva[0][1] = false;\n    zonaActiva[0][2] = false;\n    zonaActiva[1][0]
+        = false;\n    zonaActiva[1][1] = true;\n    zonaActiva[1][2] = false;\n\n
+        \   // Acceso a valores\n    int casilla = mapa[0][0]; // 1\n    bool activa
+        = zonaActiva[1][1]; // true\n\n    printf(\"Casilla inicial: %d\\n\", casilla);\n
+        \   printf(\"Zona (2,2) activa: %s\\n\", activa ? \"sí\" : \"no\");\n\n    return
+        0;\n}\n```\n\nEste programa muestra cómo declarar, inicializar y acceder a
+        matrices, simulando un mapa de un videojuego con zonas activas o inactivas.\n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **matrices (vectores bidimensionales)**
+        en pseudocódigo.  \nSirven para representar mapas, tableros o zonas en videojuegos.\n\n###
+        ¿Qué es una matriz?\nUna **matriz** es un vector con dos dimensiones: **filas**
+        y **columnas**.  \nEn pseudocódigo los índices empiezan en **1**.\n\n---\n\n###
+        Declaración con constantes\n```pseudocode\nconst\n  FILAS: integer = 3;\n
+        \ COLUMNAS: integer = 4;\nend const\n\nalgorithm\n  var\n    tablero: vector[FILAS][COLUMNAS]
+        of integer;\n  end var\nend algorithm\n```\n\n---\n\n### Inicialización manual\nEn
+        pseudocódigo no se permiten llaves `{}`, se hace elemento por elemento:\n```pseudocode\nconst\n
+        \ FILAS: integer = 2;\n  COLUMNAS: integer = 3;\nend const\n\nalgorithm\n
+        \ var\n    zonas: vector[FILAS][COLUMNAS] of integer;\n  end var\n\n  zonas[1][1]
+        := 1;\n  zonas[1][2] := 0;\n  zonas[1][3] := 0;\n\n  zonas[2][1] := 0;\n  zonas[2][2]
+        := 1;\n  zonas[2][3] := 0;\nend algorithm\n```\n\n---\n\n### Matrices booleanas\n```pseudocode\nconst\n
+        \ FILAS: integer = 2;\n  COLUMNAS: integer = 3;\nend const\n\nalgorithm\n
+        \ var\n    activo: vector[FILAS][COLUMNAS] of boolean;\n  end var\n\n  activo[1][1]
+        := true;\n  activo[1][2] := false;\n  activo[1][3] := false;\n\n  activo[2][1]
+        := false;\n  activo[2][2] := true;\n  activo[2][3] := false;\nend algorithm\n```\n\n---\n\n###
+        Acceso a un elemento concreto\n```pseudocode\ndato := valores[2][1];  { fila
+        2, columna 1 }\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\nconst\n
+        \ FILAS: integer = 2;\n  COLUMNAS: integer = 3;\nend const\n\nalgorithm matrizVideojuego\n
+        \ var\n    mapa: vector[FILAS][COLUMNAS] of integer;\n    zonaActiva: vector[FILAS][COLUMNAS]
+        of boolean;\n    casilla: integer;\n    activa: boolean;\n  end var\n\n  mapa[1][1]
+        := 1;\n  mapa[1][2] := 0;\n  mapa[1][3] := 0;\n  mapa[2][1] := 0;\n  mapa[2][2]
+        := 1;\n  mapa[2][3] := 0;\n\n  zonaActiva[1][1] := true;\n  zonaActiva[1][2]
+        := false;\n  zonaActiva[1][3] := false;\n  zonaActiva[2][1] := false;\n  zonaActiva[2][2]
+        := true;\n  zonaActiva[2][3] := false;\n\n  casilla := mapa[1][1];\n  activa
+        := zonaActiva[2][2];\n\n  writeString(\"Casilla inicial: \");\n  writeInteger(casilla);\n
+        \ writeString(\", Zona (2,2) activa: \");\n  writeBoolean(activa);\nend algorithm\n```\n\nEste
+        algoritmo muestra cómo declarar, inicializar y acceder a matrices, simulando
+        un mapa de un videojuego con zonas activas o inactivas.\n"
+    questions:
+    - id: c-2-mat_sensorestemp
+      language: C
+      week: 2
+      prompt: |
+        Declara las constantes FILAS = 3 y COLUMNAS = 4.
+
+        Dentro de main, declara una matriz de enteros sensoresTemperatura con FILAS Y COLUMNAS.
+      answer: |
+        #define FILAS 3
+        #define COLUMNAS 4
+
+        int main() {
+            int sensoresTemperatura[FILAS][COLUMNAS];
+            return 0;
+        }
+      hint: En una matriz van siempre primero las filas y luego las columnas
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-mat_sensorestemp
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara las constantes FILAS = 3 y COLUMNAS = 4.
+
+        Dentro del algoritmo principal, declara una matriz de enteros sensoresTemperatura con FILAS Y COLUMNAS.
+      answer: |
+        const
+          FILAS: integer = 3;
+          COLUMNAS: integer = 4;
+        end const
+
+        algorithm
+          var
+             sensoresTemperatura: vector[FILAS][COLUMNAS] of integer;
+          end var
+        end algorithm
+      hint: En una matriz van siempre primero las filas y luego las columnas, no olvides
+        todas las palabras reservadas para declarar los datos.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-mat_zonas_bool
+      language: C
+      week: 2
+      prompt: "Declara las constantes FILAS = 2 y COLUMNAS = 3.\n\nDentro de main,
+        declara una matriz booleana zonas con FILAS Y COLUMNAS.\n\nInicialízala con
+        los valores: \nfila 1: true, false, false \nfila 2: false, true, false.\n"
+      answer: |
+        #include <stdbool.h>
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        int main() {
+            bool zonas[FILAS][COLUMNAS];
+
+            zonas[0][0] = true;
+            zonas[0][1] = false;
+            zonas[0][2] = false;
+
+            zonas[1][0] = false;
+            zonas[1][1] = true;
+            zonas[1][2] = false;
+
+            return 0;
+        }
+      hint: Recuerda la biblioteca para el tipo booleano.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-mat_zonas_bool
+      language: Pseudocode
+      week: 2
+      prompt: "Declara las constantes FILAS = 2 y COLUMNAS = 3.\n\nDentro del algoritmo
+        principal, declara una matriz booleana zonas con FILAS Y COLUMNAS. \n\nInicialízala
+        con los valores: \nfila 1: true, false, false \nfila 2: false, true, false.\n"
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 3;
+        end const
+
+        algorithm
+          var
+             zonas: vector[FILAS][COLUMNAS] of boolean;
+          end var
+
+          zonas[1][1] := true;
+          zonas[1][2] := false;
+          zonas[1][3] := false;
+
+          zonas[2][1] := false;
+          zonas[2][2] := true;
+          zonas[2][3] := false;
+        end algorithm
+      hint: No olvides las palabras reservadas para declarar los datos y el algoritmo
+        principal.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-matriz-inicializa-llaves
+      language: C
+      week: 2
+      prompt: "Declara las constantes FILAS = 2 y COLUMNAS = 3. \n\nDentro de la función
+        main, declara e inicializa una matriz de enteros llamada `zonas` con los siguientes
+        valores usando llaves `{}`:\n- fila 1: 1, 0, 0\n- fila 2: 0, 1, 0\n"
+      answer: |
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        int main() {
+            int zonas[FILAS][COLUMNAS] = {
+                {1, 0, 0},
+                {0, 1, 0}
+            };
+            return 0;
+        }
+      hint: "Ejemplo: \n  tipo matriz[2][3] = { {a, b, c}, {d, e, f} };\n"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-matriz-inicializa-manual
+      language: C
+      week: 2
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Dentro de la función main, declara una matriz de enteros llamada `zonas` y asigna manualmente los siguientes valores:
+        - fila 1: 1, 0, 0
+        - fila 2: 0, 1, 0
+      answer: |
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        int main() {
+            int zonas[FILAS][COLUMNAS];
+            zonas[0][0] = 1;
+            zonas[0][1] = 0;
+            zonas[0][2] = 0;
+
+            zonas[1][0] = 0;
+            zonas[1][1] = 1;
+            zonas[1][2] = 0;
+            return 0;
+        }
+      hint: |
+        Asigna cada elemento individualmente con zonas[fila][columna].
+        Recuerda: en C los índices empiezan en 0.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-matriz-inicializa-const
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Dentro del algoritmo principal, declara una matriz de enteros zonas de tamaño FILAS x COLUMNAS.
+
+        Inicializa la matriz manualmente con los valores siguientes:
+        - fila 1: 1, 0, 0
+        - fila 2: 0, 1, 0
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 3;
+        end const
+
+        algorithm
+          var
+            zonas: vector[FILAS][COLUMNAS] of integer;
+          end var
+
+          zonas[1][1] := 1;
+          zonas[1][2] := 0;
+          zonas[1][3] := 0;
+          zonas[2][1] := 0;
+          zonas[2][2] := 1;
+          zonas[2][3] := 0;
+        end algorithm
+      hint: |
+        En pseudocódigo la inicialización de matrices es siempre manual, elemento a elemento.
+        Los índices comienzan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-matriz-ph
+      language: C
+      week: 2
+      prompt: |
+        Incluye stdio.
+
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Declara una matriz float phSuelo.
+
+        Inicializa utilizando {} con los valores:
+        fila 1: 6.1, 6.3, 6.0
+        fila 2: 7.1, 7.0, 6.9
+
+        Imprime el valor de la posición fila 2, columna 1 con el formato "pH: x".
+      answer: |
+        #include <stdio.h>
+
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        int main() {
+            float phSuelo[FILAS][COLUMNAS] = {
+                {6.1, 6.3, 6.0},
+                {7.1, 7.0, 6.9}
+            };
+            printf("pH: %.1f\n", phSuelo[1][0]);
+            return 0;
+        }
+      hint: "Ejemplo de ejecución: \n  pH: 7.1\n"
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'pH: 7.1
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-matriz-ph
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Declara una matriz real phSuelo.
+
+        Inicializa los valores:
+        fila 1: 6.1, 6.3, 6.0
+        fila 2: 7.1, 7.0, 6.9
+
+        Imprime el valor de la posición fila 2, columna 1 el formato "pH: x".
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 3;
+        end const
+
+        algorithm
+          var
+            phSuelo: vector[FILAS][COLUMNAS] of real;
+          end var
+
+          phSuelo[1][1] := 6.1;
+          phSuelo[1][2] := 6.3;
+          phSuelo[1][3] := 6.0;
+          phSuelo[2][1] := 7.1;
+          phSuelo[2][2] := 7.0;
+          phSuelo[2][3] := 6.9;
+
+          writeString("pH: ");
+          writeReal(phSuelo[2][1]);
+        end algorithm
+      hint: "Recuerda que en pseudocódigo no puedes imprimir mas de un dato por linea.\n\nEjemplo
+        de ejecución: \npH: 7.1\n"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 3
+    explanation:
+      C: "En este nivel aprenderás a leer y escribir datos en arrays, y también a
+        copiar y comparar cadenas de caracteres en C.  \nEsto es útil en videojuegos
+        para guardar puntuaciones de rondas o nombres de objetos en un inventario.\n\n###
+        Leer datos numéricos en arrays\nPuedes leer enteros o reales uno por uno usando
+        `scanf`:\n\n```c\n#include <stdio.h>\n#define MAX_PUNTOS 3\n\nint main() {\n
+        \   int puntos[MAX_PUNTOS];\n\n    printf(\"Puntos ronda 1: \");\n    scanf(\"%d\",
+        &puntos[0]);\n\n    printf(\"Puntos ronda 2: \");\n    scanf(\"%d\", &puntos[1]);\n\n
+        \   printf(\"Puntos ronda 3: \");\n    scanf(\"%d\", &puntos[2]);\n\n    return
+        0;\n}\n```\n\n---\n\n### Mostrar datos de un array\n```c\nprintf(\"Ronda 1:
+        %d\\n\", puntos[0]);\nprintf(\"Ronda 2: %d\\n\", puntos[1]);\nprintf(\"Ronda
+        3: %d\\n\", puntos[2]);\n```\n\n---\n\n### Arrays de cadenas: copiar con `strncpy`\nLas
+        cadenas se almacenan en arrays bidimensionales.  \nPara copiar texto en cada
+        posición, se usa `strncpy`:\n\n```c\n#include <stdio.h>\n#include <string.h>\n#define
+        MAX_ARMAS 2\n#define MAX_NOMBRE 20\n\nint main() {\n    char armas[MAX_ARMAS][MAX_NOMBRE];\n\n
+        \   strncpy(armas[0], \"Espada de fuego\", MAX_NOMBRE);\n    strncpy(armas[1],
+        \"Arco helado\", MAX_NOMBRE);\n\n    printf(\"Arma 1: %s\\n\", armas[0]);\n
+        \   printf(\"Arma 2: %s\\n\", armas[1]);\n    return 0;\n}\n```\n\n---\n\n###
+        Comparar cadenas con `strcmp`\nPara saber si dos cadenas son iguales, se usa
+        `strcmp`, que devuelve 0 si son iguales:\n\n```c\nint esIgual;\nesIgual =
+        strcmp(armas[0], \"Espada de fuego\") == 0 ? 1 : 0;\n```\n\n*Si `esIgual`
+        vale 1, las cadenas son iguales.*\n\n---\n\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n#include <string.h>\n#define MAX_PUNTOS 3\n#define MAX_ARMAS 2\n#define
+        MAX_NOMBRE 20\n\nint main() {\n    int puntos[MAX_PUNTOS];\n    char armas[MAX_ARMAS][MAX_NOMBRE];\n
+        \   int esIgual;\n\n    // Lectura de puntos\n    printf(\"Introduce los puntos
+        de 3 rondas:\\n\");\n    scanf(\"%d\", &puntos[0]);\n    scanf(\"%d\", &puntos[1]);\n
+        \   scanf(\"%d\", &puntos[2]);\n\n    // Mostrar puntos\n    printf(\"Ronda
+        1: %d\\n\", puntos[0]);\n    printf(\"Ronda 2: %d\\n\", puntos[1]);\n    printf(\"Ronda
+        3: %d\\n\", puntos[2]);\n\n    // Copiar nombres de armas\n    strncpy(armas[0],
+        \"Espada de fuego\", MAX_NOMBRE);\n    strncpy(armas[1], \"Arco helado\",
+        MAX_NOMBRE);\n\n    // Mostrar armas\n    printf(\"Arma 1: %s\\n\", armas[0]);\n
+        \   printf(\"Arma 2: %s\\n\", armas[1]);\n\n    // Comparar cadenas\n    esIgual
+        = strcmp(armas[0], \"Espada de fuego\") == 0 ? 1 : 0;\n    printf(\"¿Arma
+        1 es 'Espada de fuego'? %s\\n\", esIgual ? \"Sí\" : \"No\");\n\n    return
+        0;\n}\n```\n\nEste programa combina lectura y escritura de arrays numéricos
+        con el manejo de cadenas en un inventario de armas.\n"
+      Pseudocode: "En este nivel aprenderás a leer y mostrar datos en arrays, y también
+        a copiar y comparar cadenas en pseudocódigo.  \nEsto es útil en videojuegos
+        para guardar puntuaciones de rondas o nombres de objetos.\n\n### Leer datos
+        numéricos\n```pseudocode\nconst\n  MAX_PUNTOS: integer = 3;\nend const\n\nalgorithm
+        leerPuntos\n  var\n    puntos: vector[MAX_PUNTOS] of integer;\n  end var\n\n
+        \ writeString(\"Puntos ronda 1: \");\n  puntos[1] := readInteger();\n\n  writeString(\"Puntos
+        ronda 2: \");\n  puntos[2] := readInteger();\n\n  writeString(\"Puntos ronda
+        3: \");\n  puntos[3] := readInteger();\nend algorithm\n```\n\n---\n\n### Escribir
+        datos\n```pseudocode\nalgorithm mostrarPuntos\n  var\n    puntos: vector[3]
+        of integer;\n  end var\n\n  writeString(\"Ronda 1: \");\n  writeInteger(puntos[1]);\n\n
+        \ writeString(\"Ronda 2: \");\n  writeInteger(puntos[2]);\n\n  writeString(\"Ronda
+        3: \");\n  writeInteger(puntos[3]);\nend algorithm\n```\n\n---\n\n### Leer
+        cadenas\n```pseudocode\nconst\n  MAX_ARMAS: integer = 2;\nend const\n\nalgorithm
+        leerArmas\n  var\n    armas: vector[MAX_ARMAS] of string;\n  end var\n\n  writeString(\"Nombre
+        del arma 1: \");\n  armas[1] := readString();\n\n  writeString(\"Nombre del
+        arma 2: \");\n  armas[2] := readString();\nend algorithm\n```\n\n---\n\n###
+        Comparar cadenas\nEn pseudocódigo se comparan directamente con `=`:\n\n```pseudocode\nalgorithm
+        compararArma\n  var\n    armas: vector[2] of string;\n    esIgual: boolean;\n
+        \ end var\n\n  armas[1] := \"Espada de fuego\";\n  esIgual := (armas[1] =
+        \"Espada de fuego\");\n  writeBoolean(esIgual);\nend algorithm\n```\n\n---\n\n###
+        Ejemplo completo\n```pseudocode\nconst\n  MAX_PUNTOS: integer = 3;\n  MAX_ARMAS:
+        integer = 2;\nend const\n\nalgorithm arraysVideojuego\n  var\n    puntos:
+        vector[MAX_PUNTOS] of integer;\n    armas: vector[MAX_ARMAS] of string;\n
+        \   esIgual: boolean;\n  end var\n\n  writeString(\"Introduce los puntos de
+        3 rondas:\");\n  puntos[1] := readInteger();\n  puntos[2] := readInteger();\n
+        \ puntos[3] := readInteger();\n\n  writeString(\"Puntos registrados:\");\n
+        \ writeInteger(puntos[1]);\n  writeInteger(puntos[2]);\n  writeInteger(puntos[3]);\n\n
+        \ armas[1] := \"Espada de fuego\";\n  armas[2] := \"Arco helado\";\n\n  writeString(\"Arma
+        1: \");\n  writeString(armas[1]);\n  writeString(\", Arma 2: \");\n  writeString(armas[2]);\n\n
+        \ esIgual := (armas[1] = \"Espada de fuego\");\n  writeString(\"¿Arma 1 es
+        'Espada de fuego'? \");\n  writeBoolean(esIgual);\nend algorithm\n```\n\nEste
+        algoritmo combina lectura y escritura de arrays de enteros y cadenas para
+        simular un marcador de rondas y un inventario de armas.\n"
+    questions:
+    - id: c-2-inicializa-nombreplanta
+      language: C
+      week: 2
+      prompt: "Incluye string\n\nDeclara las constantes MAX_PLANTS = 5 y MAX_NAME
+        = 25.\n\nDentro de main, declara un array de cadenas nombrePlanta para los
+        nombres de las plantas y \nusa strncpy para inicializar el primer elemento
+        a \"Margarita\".\n"
+      answer: |
+        #include <string.h>
+        #define MAX_PLANTS 5
+        #define MAX_NAME 25
+
+        int main() {
+            char nombrePlanta[MAX_PLANTS][MAX_NAME];
+            strncpy(nombrePlanta[0], "Margarita", MAX_NAME);
+            return 0;
+        }
+      hint: Usa strncpy para copiar la cadena al array de strings. No olvides pasar
+        el tamaño máximo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-inicializa-nombreplanta
+      language: Pseudocode
+      week: 2
+      prompt: "Declara la constante MAX_PLANTS = 5. \n\nDentro del algoritmo principal,
+        declara un array de strings nombrePlanta y asigna \"Margarita\" al primer
+        elemento.\n"
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+        algorithm
+          var
+            nombrePlanta: vector[MAX_PLANTS] of string;
+          end var
+
+          nombrePlanta[1] := "Margarita";
+        end algorithm
+      hint: En pseudocódigo los índices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-inicializa-varios-nombres
+      language: C
+      week: 2
+      prompt: "Incluye string.\n\nDeclara las constantes MAX_PLANTS = 5 y MAX_NAME
+        = 25.\n\nDentro de main, declara un array de cadenas nombrePlanta y usa strncpy
+        para inicializar los nombres \n\"Margarita\", \"Rosa\", \"Lirio\", \"Orquídea\",
+        \"Girasol\" en el array.\n"
+      answer: |
+        #include <string.h>
+        #define MAX_PLANTS 5
+        #define MAX_NAME 25
+
+        int main() {
+            char nombrePlanta[MAX_PLANTS][MAX_NAME];
+            strncpy(nombrePlanta[0], "Margarita", MAX_NAME);
+            strncpy(nombrePlanta[1], "Rosa", MAX_NAME);
+            strncpy(nombrePlanta[2], "Lirio", MAX_NAME);
+            strncpy(nombrePlanta[3], "Orquídea", MAX_NAME);
+            strncpy(nombrePlanta[4], "Girasol", MAX_NAME);
+            return 0;
+        }
+      hint: Siempre que copies un string, usa strncpy y el tamaño máximo como tercer
+        argumento.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-inicializa-varios-nombres
+      language: Pseudocode
+      week: 2
+      prompt: "Declara la constante MAX_PLANTS = 5. \nDeclara un array de strings
+        nombrePlanta y asigna los nombres \n\"Margarita\", \"Rosa\", \"Lirio\", \"Orquídea\",
+        \"Girasol\" en el array.\n"
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+        algorithm
+          var
+            nombrePlanta: vector[MAX_PLANTS] of string;
+          end var
+
+          nombrePlanta[1] := "Margarita";
+          nombrePlanta[2] := "Rosa";
+          nombrePlanta[3] := "Lirio";
+          nombrePlanta[4] := "Orquídea";
+          nombrePlanta[5] := "Girasol";
+        end algorithm
+      hint: Recuerda, índices desde 1 en pseudocódigo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-muestra-primer-nombre
+      language: C
+      week: 2
+      prompt: |
+        Incluye stdio y string.
+
+        Declara las constantes MAX_PLANTS = 5 y MAX_NAME = 25.
+
+        Declara un array de cadenas nombrePlanta, inicializa el primer elemento con "Margarita" usando strncpy,
+        y muestra el primer nombre con printf.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_PLANTS 5
+        #define MAX_NAME 25
+
+        int main() {
+            char nombrePlanta[MAX_PLANTS][MAX_NAME];
+            strncpy(nombrePlanta[0], "Margarita", MAX_NAME);
+            printf("%s\n", nombrePlanta[0]);
+            return 0;
+        }
+      hint: Usa printf, recuerda el especificador de string y el salto de linea. También
+        recuerda las bibliotecas necesarias.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Margarita
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-muestra-primer-nombre
+      language: Pseudocode
+      week: 2
+      prompt: "Declara la constante MAX_PLANTS = 5. \n\nDeclara un array de strings
+        nombrePlanta, asigna \"Margarita\" al primer elemento \ny muestra ese nombre
+        con writeString.\n"
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+        algorithm
+          var
+            nombrePlanta: vector[MAX_PLANTS] of string;
+          end var
+
+          nombrePlanta[1] := "Margarita";
+          writeString(nombrePlanta[1]);
+        end algorithm
+      hint: Primero declaramos, después asignamos valor y finalmente imprimimos.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-copia-nombre-a-otro
+      language: C
+      week: 2
+      prompt: |
+        Incluye string.
+
+        Declara las constantes MAX_PLANTS = 5 y MAX_NAME = 25. Declara un array de cadenas nombrePlanta.
+
+        Usa strncpy para copiar el nombre "Margarita" en el primer elemento y después usa strncpy para copiar ese mismo nombre
+        al segundo elemento.
+      answer: |
+        #include <string.h>
+        #define MAX_PLANTS 5
+        #define MAX_NAME 25
+
+        int main() {
+            char nombrePlanta[MAX_PLANTS][MAX_NAME];
+            strncpy(nombrePlanta[0], "Margarita", MAX_NAME);
+            strncpy(nombrePlanta[1], nombrePlanta[0], MAX_NAME);
+            return 0;
+        }
+      hint: strncpy sirve para copiar tanto un literal como de un array a otro.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-copia-nombre-a-otro
+      language: Pseudocode
+      week: 2
+      prompt: "Declara la constante MAX_PLANTS = 5. \n\nDeclara un array de strings
+        nombrePlanta, asigna \"Margarita\" al primer elemento\ny copia ese nombre
+        al segundo elemento.\n"
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+        algorithm
+          var
+            nombrePlanta: vector[MAX_PLANTS] of string;
+          end var
+
+          nombrePlanta[1] := "Margarita";
+          nombrePlanta[2] := nombrePlanta[1];
+        end algorithm
+      hint: En pseudocódigo puedes asignar directamente un string a otro.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-array-temp
+      language: C
+      week: 2
+      prompt: "Incluye stdio.\n\nDeclara la constante MAX_PLANTAS = 4 y un array float
+        tempPlantas.\n\nInicializa los valores a 19.2, 20.5, 22.1 y 18.9 usando {}.
+        \n\nImprime el tercer valor con el formato \"Temp: x\".\n"
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_PLANTAS 4
+
+        int main() {
+            float tempPlantas[MAX_PLANTAS] = {19.2, 20.5, 22.1, 18.9};
+            printf("Temp: %.1f\n", tempPlantas[2]);
+            return 0;
+        }
+      hint: "Ejemplo de ejecución: \nTemp: 22.1\nFijate que solo hay un decimal.\n"
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Temp: 22.1
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-array-temp
+      language: Pseudocode
+      week: 2
+      prompt: "Declara la constante MAX_PLANTAS = 4.\n\nDeclara un array real tempPlantas.\n\nInicializa
+        los valores a 19.2, 20.5, 22.1 y 18.9. \n\nImprime el tercer valor.\n"
+      answer: |
+        const
+          MAX_PLANTAS: integer = 4;
+        end const
+
+        algorithm
+          var
+            tempPlantas: vector[MAX_PLANTAS] of real;
+          end var
+
+          tempPlantas[1] := 19.2;
+          tempPlantas[2] := 20.5;
+          tempPlantas[3] := 22.1;
+          tempPlantas[4] := 18.9;
+
+          writeReal(tempPlantas[3]);
+        end algorithm
+      hint: "Ejemplo de ejecución: \n22.1\n"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-acceso-paralelos
+      language: C
+      week: 2
+      prompt: |
+        Incluye stdio y string.
+
+        Declara las constantes MAX_PLANTAS = 3, MAX_NOMBRE = 10.
+
+        Declara nombrePlantas (cadenas) y alturaPlantas (float).
+
+        Inicializa con "Loto", "Boj", "Tejo" y 1.2, 0.4, 4.8.
+
+        Imprime el nombre y altura de la primera planta, cada uno en su línea.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+        #define MAX_PLANTAS 3
+        #define MAX_NOMBRE 10
+
+        int main() {
+            char nombrePlantas[MAX_PLANTAS][MAX_NOMBRE];
+            float alturaPlantas[MAX_PLANTAS];
+            strncpy(nombrePlantas[0], "Loto", MAX_NOMBRE);
+            strncpy(nombrePlantas[1], "Boj", MAX_NOMBRE);
+            strncpy(nombrePlantas[2], "Tejo", MAX_NOMBRE);
+            alturaPlantas[0] = 1.2;
+            alturaPlantas[1] = 0.4;
+            alturaPlantas[2] = 4.8;
+            printf("%s\n", nombrePlantas[0]);
+            printf("%.1f\n", alturaPlantas[0]);
+            return 0;
+        }
+      hint: |
+        Recuerda importar las bibliotecas necesarias. Y no olvides los saltos de linea y fijate que el numero solo tiene
+        un decimal.
+
+        Ejemplo de ejecución:
+          Loto
+          1.2
+      mode: judge_c
+      tests:
+      - input: ''
+        output: |
+          Loto
+          1.2
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-acceso-paralelos
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTAS = 3.
+
+        Declara nombrePlantas (strings) y alturaPlantas (reales).
+
+        Inicializa con "Loto", "Boj", "Tejo" y 1.2, 0.4, 4.8.
+
+        Imprime el nombre y altura de la primera planta, cada uno en su línea.
+      answer: |
+        const
+          MAX_PLANTAS: integer = 3;
+        end const
+
+        algorithm
+          var
+            nombrePlantas: vector[MAX_PLANTAS] of string;
+            alturaPlantas: vector[MAX_PLANTAS] of real;
+          end var
+
+          nombrePlantas[1] := "Loto";
+          nombrePlantas[2] := "Boj";
+          nombrePlantas[3] := "Tejo";
+          alturaPlantas[1] := 1.2;
+          alturaPlantas[2] := 0.4;
+          alturaPlantas[3] := 4.8;
+
+          writeString(nombrePlantas[1]);
+          writeReal(alturaPlantas[1]);
+        end algorithm
+      hint: |
+        Ejemplo de ejecución:
+        Loto
+        1.2
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-leer-string
+      language: C
+      week: 2
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAX_NOMBRE = 15.
+
+        Dentro de main, declara la cadena nombrePlanta y lee su valor por teclado usando scanf. Imprime el nombre en el formato "Nombre: x".
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_NOMBRE 15
+
+        int main() {
+            char nombrePlanta[MAX_NOMBRE];
+            scanf("%s", nombrePlanta);
+            printf("Nombre: %s\n", nombrePlanta);
+            return 0;
+        }
+      hint: "Recuerda la biblioteca y el salto de linea en el print.\n\nEjemplo de
+        ejecución: \n\nNombre: Jacinto\n"
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-leer-string
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Dentro del algoritmo principal, declara una variable nombrePlanta de tipo string.
+
+        Lee su valor usando readString y después imprímelo.
+      answer: |
+        algorithm
+          var
+            nombrePlanta: string;
+          end var
+
+          nombrePlanta := readString();
+          writeString(nombrePlanta);
+        end algorithm
+      hint: Recuerda usar readString para leer el dato.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-leer-array-int
+      language: C
+      week: 2
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAX_PLANTAS = 3.
+
+        Declara el array edadPlantas.
+
+        Lee 3 valores enteros por teclado y guárdalos en el array. Imprime el segundo valor leído.
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_PLANTAS 3
+
+        int main() {
+            int edadPlantas[MAX_PLANTAS];
+            scanf("%d", &edadPlantas[0]);
+            scanf("%d", &edadPlantas[1]);
+            scanf("%d", &edadPlantas[2]);
+            printf("%d\n", edadPlantas[1]);
+            return 0;
+        }
+      hint: "El usuario debe escribir 3 números. \n\nEjemplo entrada: 7 8 10\n\nEjemplo
+        salida: 8\n"
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-leer-array-int
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTAS = 3.
+
+        Declara el array edadPlantas.
+
+        Lee 3 valores enteros usando readInteger y guárdalos en el array. Imprime el segundo valor.
+      answer: |
+        const
+          MAX_PLANTAS: integer = 3;
+        end const
+
+        algorithm
+          var
+            edadPlantas: vector[MAX_PLANTAS] of integer;
+          end var
+
+          edadPlantas[1] := readInteger();
+          edadPlantas[2] := readInteger();
+          edadPlantas[3] := readInteger();
+
+          writeInteger(edadPlantas[2]);
+        end algorithm
+      hint: Recuerda, cada readInteger debe ir en línea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+- number: 3
+  explanation: 'Explicación de semana 3
+
+    '
+  levels:
+  - number: 1
+    explanation:
+      C: "En este nivel aprenderás a representar información de videojuegos como **tipos
+        de enemigos, nombres de personajes, vidas, estados y mapas**, utilizando enumerados,
+        cadenas, arrays paralelos y matrices en C.  \nEstos conceptos permiten organizar
+        datos del juego de forma clara y estructurada.\n\n### Enumerados (enum)\nSirven
+        para definir categorías con nombres.  \nPor ejemplo, los **tipos de enemigo**:\n\n```c\ntypedef
+        enum {\n    ZOMBIE,\n    ALIEN,\n    ROBOT\n} tTipoEnemigo;\n\nint main()
+        {\n    tTipoEnemigo tipo = ALIEN;  // Inicialización\n    return 0;\n}\n```\n\n---\n\n###
+        Arrays de enumerados\nPuedes crear un array con el tipo de cada enemigo:\n\n```c\n#include
+        <stdio.h>\n\n#define MAX_ENEMIGOS 3\n\ntypedef enum {\n    ZOMBIE,\n    ALIEN,\n
+        \   ROBOT\n} tTipoEnemigo;\n\nint main() {\n    tTipoEnemigo enemigos[MAX_ENEMIGOS]
+        = { ZOMBIE, ALIEN, ROBOT };\n    printf(\"Primer enemigo: %d\\n\", enemigos[0]);
+        // 0 → ZOMBIE\n    return 0;\n}\n```\n\n---\n\n### Cadenas con `strncpy`\nPara
+        guardar nombres de personajes se usa un array de `char`:\n\n```c\n#include
+        <string.h>\n#define MAX_NOMBRE 20\n\nint main() {\n    char nombre1[MAX_NOMBRE];\n
+        \   char nombre2[MAX_NOMBRE];\n\n    strncpy(nombre1, \"Link\", MAX_NOMBRE);\n
+        \   strncpy(nombre2, \"Zelda\", MAX_NOMBRE);\n\n    return 0;\n}\n```\n\n---\n\n###
+        Arrays paralelos\nSon arrays diferentes relacionados por posición.  \nPor
+        ejemplo, un array de nombres y otro de vidas:\n\n```c\n#include <stdio.h>\n#define
+        MAX_JUGADORES 3\n#define MAX_NOMBRE 20\n\nint main() {\n    char personaje[MAX_JUGADORES][MAX_NOMBRE]
+        = { \"Mario\", \"Luigi\", \"Peach\" };\n    int vidas[MAX_JUGADORES] = { 3,
+        2, 5 };\n\n    printf(\"%s tiene %d vidas\\n\", personaje[0], vidas[0]);\n
+        \   return 0;\n}\n```\n\nCada índice representa un jugador:\n- `personaje[0]
+        = \"Mario\"` y `vidas[0] = 3`  \n- `personaje[1] = \"Luigi\"` y `vidas[1]
+        = 2`  \n- `personaje[2] = \"Peach\"` y `vidas[2] = 5`  \n\n---\n\n### Booleanos
+        y ternario\nPuedes guardar si una misión está completada:\n\n```c\n#include
+        <stdio.h>\n#include <stdbool.h>\n\n#define MAX_MISIONES 2\n\nint main() {\n
+        \   bool misionCompletada[MAX_MISIONES] = { true, false };\n\n    printf(\"%s\\n\",
+        misionCompletada[0] ? \"Completada\" : \"Pendiente\");\n    return 0;\n}\n```\n\n---\n\n###
+        Matriz booleana\nLas matrices permiten representar una cuadrícula.  \nPor
+        ejemplo, casillas de un mapa exploradas o no:\n\n```c\n#include <stdio.h>\n#include
+        <stdbool.h>\n\nint main() {\n    bool mapa[2][3] = {\n        { true, false,
+        true },\n        { false, true, false }\n    };\n\n    printf(\"Fila 0, Col
+        1: %d\\n\", mapa[0][1]);\n    return 0;\n}\n```\n\n---\n\n### Entrada con
+        `scanf`\nPuedes pedir al jugador que introduzca la salud de un personaje:\n\n```c\n#include
+        <stdio.h>\n\nint main() {\n    int salud[2];\n    printf(\"Introduce la salud
+        de Link: \");\n    scanf(\"%d\", &salud[0]);\n\n    printf(\"Salud de Link:
+        %d\\n\", salud[0]);\n    return 0;\n}\n```\n\n---\n\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n#include <stdbool.h>\n#include <string.h>\n\n#define MAX_JUGADORES
+        3\n#define MAX_NOMBRE 20\n#define MAX_MISIONES 2\n\ntypedef enum {\n    ZOMBIE,
+        ALIEN, ROBOT\n} tTipoEnemigo;\n\nint main() {\n    // Arrays paralelos\n    char
+        personaje[MAX_JUGADORES][MAX_NOMBRE] = { \"Mario\", \"Luigi\", \"Peach\" };\n
+        \   int vidas[MAX_JUGADORES] = { 3, 2, 5 };\n\n    // Estado de misiones\n
+        \   bool misionCompletada[MAX_MISIONES] = { true, false };\n\n    // Matriz
+        booleana de mapa\n    bool mapa[2][3] = {\n        { true, false, true },\n
+        \       { false, true, false }\n    };\n\n    // Entrada de datos\n    int
+        salud[2];\n    printf(\"Introduce la salud de Link: \");\n    scanf(\"%d\",
+        &salud[0]);\n\n    // Salidas\n    printf(\"%s tiene %d vidas\\n\", personaje[0],
+        vidas[0]);\n    printf(\"Misión 1: %s\\n\", misionCompletada[0] ? \"Completada\"
+        : \"Pendiente\");\n    printf(\"Mapa Fila 0, Col 1: %d\\n\", mapa[0][1]);\n
+        \   printf(\"Salud de Link: %d\\n\", salud[0]);\n\n    return 0;\n}\n```\n\nEste
+        programa combina enumerados, cadenas, arrays paralelos y matrices para representar
+        un estado de videojuego.\n"
+      Pseudocode: "En este nivel aprenderás a representar información de videojuegos
+        como **enemigos, nombres de personajes, vidas y mapas**, utilizando enumerados,
+        cadenas, arrays paralelos y matrices en pseudocódigo.  \nEsto permite organizar
+        datos del juego de manera clara.\n\n### Enumerados\n```pseudocode\ntype\n
+        \ tTipoEnemigo = { ZOMBIE, ALIEN, ROBOT }\nend type\n\nalgorithm\n  var\n
+        \   estado: tTipoEnemigo;\n  end var\n\n  estado := ALIEN;\n  writeEnum(estado);\nend
+        algorithm\n```\n\n---\n\n### Cadenas\n```pseudocode\nalgorithm\n  var\n    personaje:
+        vector[2] of string;\n  end var\n\n  personaje[1] := \"Mario\";\n  personaje[2]
+        := \"Peach\";\n\n  writeString(personaje[1]);\n  writeString(personaje[2]);\nend
+        algorithm\n```\n\n---\n\n### Arrays paralelos\n```pseudocode\nalgorithm\n
+        \ var\n    personaje: vector[2] of string;\n    vidas: vector[2] of integer;\n
+        \ end var\n\n  personaje[1] := \"Mario\";\n  vidas[1] := 3;\n\n  personaje[2]
+        := \"Luigi\";\n  vidas[2] := 2;\n\n  writeString(personaje[1]);\n  writeInteger(vidas[1]);\nend
+        algorithm\n```\n\n---\n\n### Booleanos\n```pseudocode\nalgorithm\n  var\n
+        \   mision: vector[2] of boolean;\n  end var\n\n  mision[1] := true;\n  mision[2]
+        := false;\n\n  writeBoolean(mision[1]);\nend algorithm\n```\n\n---\n\n###
+        Matriz booleana\n```pseudocode\nalgorithm\n  var\n    mapa: vector[2][2] of
+        boolean;\n  end var\n\n  mapa[1][1] := true;\n  mapa[1][2] := false;\n  mapa[2][1]
+        := true;\n  mapa[2][2] := false;\n\n  writeBoolean(mapa[1][2]);\nend algorithm\n```\n\n---\n\n###
+        Lectura de datos\n```pseudocode\nalgorithm\n  var\n    vidas: vector[2] of
+        integer;\n  end var\n\n  writeString(\"Introduce las vidas del jugador 1:
+        \");\n  vidas[1] := readInteger();\n\n  writeString(\"Vidas del jugador 1:
+        \");\n  writeInteger(vidas[1]);\nend algorithm\n```\n\n---\n\n### Ejemplo
+        completo\n```pseudocode\ntype\n  tTipoEnemigo = { ZOMBIE, ALIEN, ROBOT }\nend
+        type\n\nalgorithm estadoJuego\n  var\n    personaje: vector[2] of string;\n
+        \   vidas: vector[2] of integer;\n    mision: vector[2] of boolean;\n    mapa:
+        vector[2][2] of boolean;\n    salud: vector[2] of integer;\n    estado: tTipoEnemigo;\n
+        \ end var\n\n  personaje[1] := \"Mario\";\n  vidas[1] := 3;\n\n  personaje[2]
+        := \"Luigi\";\n  vidas[2] := 2;\n\n  mision[1] := true;\n  mision[2] := false;\n\n
+        \ mapa[1][1] := true;\n  mapa[1][2] := false;\n  mapa[2][1] := true;\n  mapa[2][2]
+        := false;\n\n  writeString(\"Introduce la salud de Mario: \");\n  salud[1]
+        := readInteger();\n\n  estado := ALIEN;\n\n  writeString(personaje[1]);\n
+        \ writeString(\" tiene \");\n  writeInteger(vidas[1]);\n  writeString(\" vidas\");\n\n
+        \ writeString(\", Misión 1: \");\n  writeBoolean(mision[1]);\n\n  writeString(\",
+        Casilla (1,2): \");\n  writeBoolean(mapa[1][2]);\n\n  writeString(\", Salud
+        de Mario: \");\n  writeInteger(salud[1]);\n\n  writeString(\", Estado enemigo:
+        \");\n  writeEnum(estado);\nend algorithm\n```\n\nEste algoritmo combina enumerados,
+        cadenas, arrays paralelos y matrices para representar un estado de videojuego.\n"
+    questions:
+    - id: c-3-enum-declaracion
+      language: C
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 3.
+
+        Declara un enumerado tTipoAnimal con los valores PERRO, GATO y AVE.
+
+        Dentro de main, declara un array tipoAnimal de tipo tTipoAnimal inicializado con PERRO, GATO y AVE usando llaves {}.
+      answer: |
+        #define MAX_ANIMALES 3
+
+        typedef enum {
+            PERRO,
+            GATO,
+            AVE
+        } tTipoAnimal;
+
+        int main() {
+            tTipoAnimal tipoAnimal[MAX_ANIMALES] = { PERRO, GATO, AVE };
+            return 0;
+        }
+      hint: Los enumerativos se inicializan igual que los enteros usando sus etiquetas.
+        No olvides la función main y el return 0.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-enum-declaracion
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 3.
+
+        Declara el tipo enumerado tTipoAnimal con los valores PERRO, GATO y AVE.
+
+        Dentro del algoritmo principal, declara un array tipoAnimal de tTipoAnimal, inicializado con PERRO, GATO y AVE.
+      answer: |
+        const
+          MAX_ANIMALES: integer = 3;
+        end const
+
+        type
+          tTipoAnimal = { PERRO, GATO, AVE }
+        end type
+
+        algorithm
+          var
+            tipoAnimal: vector[MAX_ANIMALES] of tTipoAnimal;
+          end var
+
+          tipoAnimal[1] := PERRO;
+          tipoAnimal[2] := GATO;
+          tipoAnimal[3] := AVE;
+        end algorithm
+      hint: Enum en pseudocódigo siempre van entre { }.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-nombres-strncpy
+      language: C
+      week: 3
+      prompt: |
+        Incluye string y stdio
+
+        Declara las constantes MAX_ANIMALES = 2 y MAX_NOMBRE = 15.
+
+        Dentro de main, declara dos cadenas de caracteres usando MAX_NOMBRE: nombre1 y nombre2.
+
+        Inicializa nombre1 y nombre2 con "Nina" y "Rocky" respectivamente usando strncpy.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_ANIMALES 2
+        #define MAX_NOMBRE 15
+
+        int main() {
+            char nombre1[MAX_NOMBRE];
+            char nombre2[MAX_NOMBRE];
+            strncpy(nombre1, "Nina", MAX_NOMBRE);
+            strncpy(nombre2, "Rocky", MAX_NOMBRE);
+            return 0;
+        }
+      hint: strncpy(destino, origen, tamaño) para inicializar strings.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-nombres-strings
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 2.
+
+        Dentro del algoritmo principal, declara un array nombre de strings para dos animales.
+
+        Inicializa nombre[1] con "Nina" y nombre[2] con "Rocky".
+      answer: |
+        const
+          MAX_ANIMALES: integer = 2;
+        end const
+
+        algorithm
+          var
+            nombre: vector[MAX_ANIMALES] of string;
+          end var
+
+          nombre[1] := "Nina";
+          nombre[2] := "Rocky";
+        end algorithm
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-ternario-vacunado
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio y stdbool.
+
+        Declara la constante MAX_ANIMALES = 2 y un array booleano vacunado inicializado con true y false con {}.
+
+        Imprime usando printf y el operador ternario: "Vacunado" si el primer animal está vacunado, "No vacunado" si no lo está.
+
+        Ejemplo de salida: "Vacunado"
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+
+        #define MAX_ANIMALES 2
+
+        int main() {
+            bool vacunado[MAX_ANIMALES] = { true, false };
+            printf("%s\n", vacunado[0] ? "Vacunado" : "No vacunado");
+            return 0;
+        }
+      hint: 'Recuerda la sintaxis del operador ternario: condicion ? valor_si_true
+        : valor_si_false'
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Vacunado
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-arrays-paralelos
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara las constantes MAX_ANIMALES = 3 y MAX_NOMBRE = 15.
+
+        Dentro de main, declara un array de cadenas de caracteres con MAX_ANIMALES y MAX_NOMBRE y un array de enteros edad con (MAX_ANIMALES).
+
+        Inicializa los arrays usando llaves {}, con los nombres "Bobby", "Lili", "Rex" y las edades 2, 5, 3.
+
+        Imprime en diferentes líneas cada nombre seguido de la edad, usando printf, en el formato: "Nombre: Bobby, Edad: 2".
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ANIMALES 3
+        #define MAX_NOMBRE 15
+
+        int main() {
+            char nombre[MAX_ANIMALES][MAX_NOMBRE] = { "Bobby", "Lili", "Rex" };
+            int edad[MAX_ANIMALES] = { 2, 5, 3 };
+            printf("Nombre: %s, Edad: %d\n", nombre[0], edad[0]);
+            printf("Nombre: %s, Edad: %d\n", nombre[1], edad[1]);
+            printf("Nombre: %s, Edad: %d\n", nombre[2], edad[2]);
+            return 0;
+        }
+      hint: Cada printf debe estar en una línea diferente y no olvides el salto de
+        linea.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: |
+          Nombre: Bobby, Edad: 2
+          Nombre: Lili, Edad: 5
+          Nombre: Rex, Edad: 3
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-arrays-paralelos
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 3.
+
+        Dentro del algoritmo principal, declara un array nombre de strings y un array edad de enteros para tres animales.
+
+        Inicializa nombre con "Bobby", "Lili", "Rex" y edad con 2, 5, 3.
+
+        Imprime el nombre y la edad de cada animal, uno por línea, usando writeString y writeInteger.
+
+        Ejemplo de salida:
+          Nombre: Bobby
+          Edad: 2
+          Nombre: Lili
+          Edad: 5
+          Nombre: Rex
+          Edad: 3
+      answer: |
+        const
+          MAX_ANIMALES: integer = 3;
+        end const
+
+        algorithm
+          var
+            nombre: vector[MAX_ANIMALES] of string;
+            edad: vector[MAX_ANIMALES] of integer;
+          end var
+
+          nombre[1] := "Bobby";
+          nombre[2] := "Lili";
+          nombre[3] := "Rex";
+
+          edad[1] := 2;
+          edad[2] := 5;
+          edad[3] := 3;
+
+          writeString("Nombre: ");
+          writeString(nombre[1]);
+          writeString("Edad: ");
+          writeInteger(edad[1]);
+          writeString("Nombre: ");
+          writeString(nombre[2]);
+          writeString("Edad: ");
+          writeInteger(edad[2]);
+          writeString("Nombre: ");
+          writeString(nombre[3]);
+          writeString("Edad: ");
+          writeInteger(edad[3]);
+        end algorithm
+      hint: Cada writeString/writeInteger en su línea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-matriz-booleana
+      language: C
+      week: 3
+      prompt: "Incluye stdio y stdbool.\n\nDeclara las constantes FILAS = 2 y COLUMNAS
+        = 3.\n\nDentro de main, declara una matriz de booleanos estadoVacuna con FILAS
+        x COLUMNAS e inicialízala manualmente con: \n  fila 0: true, false, true\n
+        \ fila 1: false, true, false\n\nImprime el valor de cada casilla en una línea
+        con printf. \n\nEjemplo: \"Fila 0, Col 0: 1\" (donde 1 es true y 0 es false)\n"
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        int main() {
+            bool estadoVacuna[FILAS][COLUMNAS];
+            estadoVacuna[0][0] = true;
+            estadoVacuna[0][1] = false;
+            estadoVacuna[0][2] = true;
+            estadoVacuna[1][0] = false;
+            estadoVacuna[1][1] = true;
+            estadoVacuna[1][2] = false;
+
+            printf("Fila 0, Col 0: %d\n", estadoVacuna[0][0]);
+            printf("Fila 0, Col 1: %d\n", estadoVacuna[0][1]);
+            printf("Fila 0, Col 2: %d\n", estadoVacuna[0][2]);
+            printf("Fila 1, Col 0: %d\n", estadoVacuna[1][0]);
+            printf("Fila 1, Col 1: %d\n", estadoVacuna[1][1]);
+            printf("Fila 1, Col 2: %d\n", estadoVacuna[1][2]);
+            return 0;
+        }
+      hint: Imprime todos los valores de la matriz, un dato por línea.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: |
+          Fila 0, Col 0: 1
+          Fila 0, Col 1: 0
+          Fila 0, Col 2: 1
+          Fila 1, Col 0: 0
+          Fila 1, Col 1: 1
+          Fila 1, Col 2: 0
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-matriz-booleana
+      language: Pseudocode
+      week: 3
+      prompt: "Declara las constantes FILAS = 2 y COLUMNAS = 3.\n\nDentro del algoritmo
+        principal, declara una matriz booleana estadoVacuna con FILAS x COLUMNAS e
+        inicialízala manualmente con: \n  fila 1: true, false, true\n  fila 2: false,
+        true, false\n\nImprime el valor de cada casilla, uno por línea, usando writeBoolean.\n\nEjemplo
+        de salida:\n  true\n  false\n  true\n  ...\n"
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 3;
+        end const
+
+        algorithm
+          var
+            estadoVacuna: vector[FILAS][COLUMNAS] of boolean;
+          end var
+
+          estadoVacuna[1][1] := true;
+          estadoVacuna[1][2] := false;
+          estadoVacuna[1][3] := true;
+          estadoVacuna[2][1] := false;
+          estadoVacuna[2][2] := true;
+          estadoVacuna[2][3] := false;
+
+          writeBoolean(estadoVacuna[1][1]);
+          writeBoolean(estadoVacuna[1][2]);
+          writeBoolean(estadoVacuna[1][3]);
+          writeBoolean(estadoVacuna[2][1]);
+          writeBoolean(estadoVacuna[2][2]);
+          writeBoolean(estadoVacuna[2][3]);
+        end algorithm
+      hint: Escribe un dato por línea, usando writeBoolean.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-lee-edad
+      language: C
+      week: 3
+      prompt: "Incluye stdio.\n\nDeclara la constante MAX_ANIMALES = 2.\n\nDentro
+        de main, declara un array de enteros edad. \n\nPide al usuario que introduzca
+        las edades usando scanf, guardando los valores en el primer y segundo elemento
+        del array.\n\nUsa el siguiente formato:\n  \"Introduce la edad del animal
+        1: \"\n  \"Introduce la edad del animal 2: \"\n"
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ANIMALES 2
+
+        int main() {
+            int edad[MAX_ANIMALES];
+            printf("Introduce la edad del animal 1: ");
+            scanf("%d", &edad[0]);
+            printf("Introduce la edad del animal 2: ");
+            scanf("%d", &edad[1]);
+            return 0;
+        }
+      hint: recuerda el especificador de formato de los enteros para leer el dato.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-lee-edad
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 2.
+
+        Dentro del algoritmo principal, declara un array edad de enteros.
+
+        Pide al usuario que introduzca las edades con readInteger y guarda los valores en el primer y segundo elemento del array.
+      answer: |
+        const
+          MAX_ANIMALES: integer = 2;
+        end const
+
+        algorithm
+          var
+            edad: vector[MAX_ANIMALES] of integer;
+          end var
+
+          writeString("Introduce la edad del animal 1: ");
+          edad[1] := readInteger();
+          writeString("Introduce la edad del animal 2: ");
+          edad[2] := readInteger();
+        end algorithm
+      hint: Lee y guarda cada valor por separado. Los indices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 2
+    explanation:
+      C: "En este nivel aprenderás a **tomar decisiones en tus programas** usando
+        estructuras condicionales como `if`, `else`, `else if`, `strcmp`, el operador
+        ternario y `switch`.  \nEstas herramientas son fundamentales en los videojuegos
+        para decidir acciones, comparar valores o controlar estados.\n\n### if\nEl
+        `if` permite ejecutar una acción si una condición es verdadera.  \nPor ejemplo,
+        decidir si un Pokémon está en forma para la batalla:\n\n```c\n#include <stdio.h>\n\nint
+        main() {\n    int salud;\n    printf(\"Introduce la salud del Pokémon: \");\n
+        \   scanf(\"%d\", &salud);\n\n    if (salud > 50) {\n        printf(\"Listo
+        para luchar\\n\");\n    }\n    return 0;\n}\n```\n\n---\n\n### if...else\nCon
+        `else` puedes ejecutar una alternativa si la condición no se cumple:\n\n```c\n#include
+        <stdio.h>\n#include <stdbool.h>\n\nint main() {\n    bool tienePocion;\n    printf(\"¿Tienes
+        poción? (1 = sí, 0 = no): \");\n    scanf(\"%d\", &tienePocion);\n\n    if
+        (tienePocion) {\n        printf(\"Usas la poción\\n\");\n    } else {\n        printf(\"No
+        puedes curarte\\n\");\n    }\n    return 0;\n}\n```\n\n---\n\n### if...else
+        if...else\nPara múltiples condiciones, puedes usar `else if`:\n\n```c\n#include
+        <stdio.h>\n\nint main() {\n    int nivel;\n    printf(\"Nivel del jugador:
+        \");\n    scanf(\"%d\", &nivel);\n\n    if (nivel < 5) {\n        printf(\"Novato\\n\");\n
+        \   } else if (nivel <= 10) {\n        printf(\"Intermedio\\n\");\n    } else
+        {\n        printf(\"Experto\\n\");\n    }\n    return 0;\n}\n```\n\n---\n\n###
+        strcmp\n`strcmp(cadena1, cadena2)` compara dos cadenas. Devuelve **0 si son
+        iguales**:\n\n```c\n#include <stdio.h>\n#include <string.h>\n\nint main()
+        {\n    char nombre1[10];\n    char nombre2[10];\n\n    strncpy(nombre1, \"Link\",
+        10);\n    strncpy(nombre2, \"Zelda\", 10);\n\n    printf(\"%s\\n\", strcmp(nombre1,
+        nombre2) == 0 ? \"Mismos personajes\" : \"Distintos personajes\");\n    return
+        0;\n}\n```\n\n---\n\n### Operador ternario anidado para enums\nPuedes convertir
+        un enum a texto usando ternarios:\n\n```c\n#include <stdio.h>\n#include <string.h>\n\ntypedef
+        enum { MAGE, WARRIOR, ROGUE } tClase;\n\nint main() {\n    tClase claseJugador
+        = MAGE;\n    char claseStr[20];\n\n    strncpy(claseStr,\n        (claseJugador
+        == MAGE) ? \"Mago\" :\n        (claseJugador == WARRIOR) ? \"Guerrero\" :
+        \"Pícaro\",\n        20);\n\n    printf(\"Clase: %s\\n\", claseStr);\n    return
+        0;\n}\n```\n\n---\n\n### switch\nCuando tienes varios casos posibles para
+        un mismo valor, puedes usar `switch`:\n\n```c\n#include <stdio.h>\n\nint main()
+        {\n    int opcion;\n    printf(\"Elige tu clase (1-Mago, 2-Guerrero, 3-Arquero):
+        \");\n    scanf(\"%d\", &opcion);\n\n    switch (opcion) {\n        case 1:\n
+        \           printf(\"Has elegido Mago\\n\");\n            break;\n        case
+        2:\n            printf(\"Has elegido Guerrero\\n\");\n            break;\n
+        \       case 3:\n            printf(\"Has elegido Arquero\\n\");\n            break;\n
+        \       default:\n            printf(\"Opción no válida\\n\");\n    }\n    return
+        0;\n}\n```\n\n---\n\n### Ejemplo completo\n```c\n#include <stdio.h>\n#include
+        <stdbool.h>\n#include <string.h>\n\ntypedef enum { MAGE, WARRIOR, ROGUE }
+        tClase;\n\nint main() {\n    int salud = 60;\n    bool tienePocion = true;\n
+        \   char nombre1[10] = \"Link\";\n    char nombre2[10] = \"Zelda\";\n    tClase
+        claseJugador = WARRIOR;\n    int opcion = 2;\n    char claseStr[20];\n\n    //
+        if simple\n    if (salud > 50) {\n        printf(\"Listo para luchar\\n\");\n
+        \   }\n\n    // if...else\n    if (tienePocion) {\n        printf(\"Usas la
+        poción\\n\");\n    } else {\n        printf(\"No puedes curarte\\n\");\n    }\n\n
+        \   // strcmp con ternario\n    printf(\"%s\\n\", strcmp(nombre1, nombre2)
+        == 0 ? \"Mismos personajes\" : \"Distintos personajes\");\n\n    // Enum a
+        string con ternario\n    strncpy(claseStr,\n        (claseJugador == MAGE)
+        ? \"Mago\" :\n        (claseJugador == WARRIOR) ? \"Guerrero\" : \"Pícaro\",\n
+        \       20);\n    printf(\"Clase: %s\\n\", claseStr);\n\n    // switch\n    switch
+        (opcion) {\n        case 1:\n            printf(\"Has elegido Mago\\n\");\n
+        \           break;\n        case 2:\n            printf(\"Has elegido Guerrero\\n\");\n
+        \           break;\n        case 3:\n            printf(\"Has elegido Arquero\\n\");\n
+        \           break;\n        default:\n            printf(\"Opción no válida\\n\");\n
+        \   }\n    return 0;\n}\n```\n\nEste programa combina todas las estructuras
+        condicionales para simular distintas decisiones de un videojuego.\n"
+      Pseudocode: "En este nivel aprenderás a **tomar decisiones en tus algoritmos**
+        usando `if`, `else`, `else if` y `switch`.  \nSon muy útiles en videojuegos
+        para controlar acciones, comparar valores o traducir estados a texto.\n\n###
+        if\nEjecuta una acción si se cumple una condición:\n\n```pseudocode\nalgorithm\n
+        \ var\n    salud: integer;\n  end var\n\n  writeString(\"Introduce la salud
+        del personaje: \");\n  salud := readInteger();\n\n  if salud > 50 then\n    writeString(\"Listo
+        para luchar\");\n  end if\nend algorithm\n```\n\n---\n\n### if...else\nEjecuta
+        una alternativa si no se cumple la condición:\n\n```pseudocode\nalgorithm\n
+        \ var\n    tieneEspada: boolean;\n  end var\n\n  writeString(\"¿Tienes espada?
+        (true/false): \");\n  tieneEspada := readBoolean();\n\n  if tieneEspada then\n
+        \   writeString(\"Puedes atacar\");\n  else\n    writeString(\"Necesitas un
+        arma\");\n  end if\nend algorithm\n```\n\n---\n\n### if...else if...else\nPuedes
+        verificar varias condiciones:\n\n```pseudocode\nalgorithm\n  var\n    nivel:
+        integer;\n  end var\n\n  writeString(\"Introduce el nivel del monstruo: \");\n
+        \ nivel := readInteger();\n\n  if nivel < 5 then\n    writeString(\"Fácil\");\n
+        \ else\n    if nivel <= 10 then\n      writeString(\"Normal\");\n    else\n
+        \     writeString(\"Difícil\");\n    end if\n  end if\nend algorithm\n```\n\n---\n\n###
+        Comparar cadenas\nEn pseudocódigo se comparan directamente con `=`:\n\n```pseudocode\nalgorithm\n
+        \ var\n    nombre1: string;\n    nombre2: string;\n  end var\n\n  nombre1
+        := \"Mario\";\n  nombre2 := \"Luigi\";\n\n  if nombre1 = nombre2 then\n    writeString(\"Iguales\");\n
+        \ else\n    writeString(\"Distintos\");\n  end if\nend algorithm\n```\n\n---\n\n###
+        Convertir enums a texto con if anidado\n```pseudocode\ntype\n  tClase = {
+        MAGO, GUERRERO, ARQUERO }\nend type\n\nalgorithm\n  var\n    claseJugador:
+        tClase;\n    claseStr: string;\n  end var\n\n  claseJugador := MAGO;\n\n  if
+        claseJugador = MAGO then\n    claseStr := \"Mago\";\n  else\n    if claseJugador
+        = GUERRERO then\n      claseStr := \"Guerrero\";\n    else\n      claseStr
+        := \"Arquero\";\n    end if\n  end if\n\n  writeString(claseStr);\nend algorithm\n```\n\n---\n\n###
+        switch\nElige una acción según el número introducido por el usuario:\n\n```pseudocode\nalgorithm\n
+        \ var\n    clase: integer;\n  end var\n\n  writeString(\"Elige una clase (1-Mago,
+        2-Guerrero, 3-Arquero): \");\n  clase := readInteger();\n\n  switch clase\n
+        \   case 1 then\n      writeString(\"Has elegido Mago\");\n    end case\n
+        \   case 2 then\n      writeString(\"Has elegido Guerrero\");\n    end case\n
+        \   case 3 then\n      writeString(\"Has elegido Arquero\");\n    end case\n
+        \   case default then\n      writeString(\"Opción no válida\");\n    end case\n
+        \ end switch\nend algorithm\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\ntype\n
+        \ tClase = { MAGO, GUERRERO, ARQUERO }\nend type\n\nalgorithm decisionesJuego\n
+        \ var\n    salud: integer;\n    tienePocion: boolean;\n    nombre1: string;\n
+        \   nombre2: string;\n    claseJugador: tClase;\n    clase: integer;\n    claseStr:
+        string;\n  end var\n\n  salud := 60;\n  tienePocion := true;\n  nombre1 :=
+        \"Link\";\n  nombre2 := \"Zelda\";\n  claseJugador := GUERRERO;\n  clase :=
+        2;\n\n  if salud > 50 then\n    writeString(\"Listo para luchar\");\n  end
+        if\n\n  if tienePocion then\n    writeString(\", Usas la poción\");\n  else\n
+        \   writeString(\", No puedes curarte\");\n  end if\n\n  if nombre1 = nombre2
+        then\n    writeString(\", Mismos personajes\");\n  else\n    writeString(\",
+        Distintos personajes\");\n  end if\n\n  if claseJugador = MAGO then\n    claseStr
+        := \"Mago\";\n  else\n    if claseJugador = GUERRERO then\n      claseStr
+        := \"Guerrero\";\n    else\n      claseStr := \"Arquero\";\n    end if\n  end
+        if\n\n  writeString(\", Clase: \");\n  writeString(claseStr);\n\n  switch
+        clase\n    case 1 then\n      writeString(\", Has elegido Mago\");\n    end
+        case\n    case 2 then\n      writeString(\", Has elegido Guerrero\");\n    end
+        case\n    case 3 then\n      writeString(\", Has elegido Arquero\");\n    end
+        case\n    case default then\n      writeString(\", Opción no válida\");\n
+        \   end case\n  end switch\nend algorithm\n```\n\nEste algoritmo combina todas
+        las estructuras condicionales para simular distintas decisiones de un videojuego.\n"
+    questions:
+    - id: c-3-if-simple
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Dentro de main, declara una variable edad y pídele al usuario que la introduzca.
+
+        Usa el formato de pregunta: "Introduce la edad del animal: ".
+
+        Usa un if para comprobar si la edad es mayor que 10. Si lo es, imprime "Mayor que 10".
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int edad;
+
+            printf("Introduce la edad del animal: ");
+            scanf("%d", &edad);
+
+            if(edad > 10) {
+                printf("Mayor que 10\n");
+            }
+
+            return 0;
+        }
+      hint: Usa if y no olvides el salto de linea. Recuerda que para leer cualquier
+        dato que no sea un string necesitamos el operador &.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-if-simple
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Dentro del algoritmo principal, declara una variable edad, pide el valor al usuario.
+
+        Usa el formato de pregunta: "Introduce la edad del animal: ".
+
+        Usa un if para comprobar si la edad es mayor que 10. Si lo es, imprime "Mayor que 10".
+      answer: |2
+
+        algorithm
+          var
+            edad: integer;
+          end var
+
+          writeString("Introduce la edad del animal: ");
+          edad := readInteger();
+
+          if edad > 10 then
+            writeString("Mayor que 10");
+          end if
+        end algorithm
+      hint: No hace falta else.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-if-else
+      language: C
+      week: 3
+      prompt: "Incluye stdio.h.\n\nDentro de main, declara una variable vacunado (bool)
+        y pide al usuario un número (0 para no vacunado, 1 para vacunado).\n\nUsa
+        un if else para imprimir \"Vacunado\" o \"No vacunado\". \n\nUsa este formato
+        de pregunta: \"¿El animal está vacunado? (1 = sí, 0 = no): \"\n"
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+
+        int main() {
+            bool vacunado;
+
+            printf("¿El animal está vacunado? (1 = sí, 0 = no): ");
+            scanf("%d", &vacunado);
+
+            if(vacunado) {
+                printf("Vacunado\n");
+            } else {
+                printf("No vacunado\n");
+            }
+            return 0;
+        }
+      hint: El valor 0 es false, 1 es true.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-if-else
+      language: Pseudocode
+      week: 3
+      prompt: "Dentro del algoritmo principal, declara una variable vacunado (boolean).\n\nPide
+        al usuario que introduzca true o false (usa readBoolean). \n\nUsa un if else
+        para imprimir \"Vacunado\" o \"No vacunado\".\n\nUsa este formato de pregunta:
+        \"¿El animal está vacunado? (true/false): \"\n"
+      answer: |
+        algorithm
+          var
+            vacunado: boolean;
+          end var
+
+          writeString("¿El animal está vacunado? (true/false): ");
+          vacunado := readBoolean();
+
+          if vacunado then
+            writeString("Vacunado");
+          else
+            writeString("No vacunado");
+          end if
+        end algorithm
+      hint: Usa readBoolean para leer el dato.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-compara-strcmp
+      language: C
+      week: 3
+      prompt: |
+        Incluye string y stdio.
+
+        Declara la constante MAX_NOMBRE = 10.
+
+        Dentro de main, declara dos cadenas de caracteres nombre1 y nombre2 inicializados con "Kira" y "Max" usando strncpy.
+
+        Usa strcmp para comparar si son iguales. Si lo son, imprime "Nombres iguales", si no, imprime "Nombres diferentes".
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 10
+
+        int main() {
+            char nombre1[MAX_NOMBRE];
+            char nombre2[MAX_NOMBRE];
+
+            strncpy(nombre1, "Kira", MAX_NOMBRE);
+            strncpy(nombre2, "Max", MAX_NOMBRE);
+
+            if(strcmp(nombre1, nombre2) == 0) {
+                printf("Nombres iguales\n");
+            } else {
+                printf("Nombres diferentes\n");
+            }
+            return 0;
+        }
+      hint: strcmp devuelve 0 si las cadenas son iguales. No olvides los saltos de
+        linea.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Nombres diferentes
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-compara-strings
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 2.
+
+        Dentro del algoritmo principal, declara un array nombre de strings para dos animales.
+
+        Inicializa nombre[1] con "Kira" y nombre[2] con "Max".
+
+        Si los nombres son iguales, imprime "Nombres iguales", si no, imprime "Nombres diferentes".
+      answer: |
+        const
+          MAX_ANIMALES: integer = 2;
+        end const
+
+        algorithm
+          var
+            nombre: vector[MAX_ANIMALES] of string;
+          end var
+
+          nombre[1] := "Kira";
+          nombre[2] := "Max";
+
+          if nombre[1] = nombre[2] then
+            writeString("Nombres iguales");
+          else
+            writeString("Nombres diferentes");
+          end if
+        end algorithm
+      hint: En pseudocódigo puedes comparar strings con = .
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-if-else-encadenado
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Dentro de main, declara una variable edad y pide al usuario una edad y usa if, else if y else para imprimir:
+        - "Joven" si la edad es menor que 5,
+        - "Adulto" si es entre 5 y 10 (ambos inclusive),
+        - "Senior" si es mayor de 10.
+
+        Usa el siguiente formato de pregunta: "Introduce la edad del animal: "
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int edad;
+
+            printf("Introduce la edad del animal: ");
+            scanf("%d", &edad);
+
+            if(edad < 5) {
+                printf("Joven\n");
+            } else if(edad <= 10) {
+                printf("Adulto\n");
+            } else {
+                printf("Senior\n");
+            }
+            return 0;
+        }
+      hint: Usa ifs encadenados. No olvides los saltos de linea.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-if-else-encadenado
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Dentro del algoritmo principal, declara una variable edad, pide una edad al usuario y usa if, else, if anidados para imprimir:
+        - "Joven" si la edad es menor que 5,
+        - "Adulto" si es entre 5 y 10 (ambos inclusive),
+        - "Senior" si es mayor de 10.
+
+        Usa el siguiente formato de pregunta: "Introduce la edad del animal: "
+      answer: |
+        algorithm
+          var
+            edad: integer;
+          end var
+
+          writeString("Introduce la edad del animal: ");
+          edad := readInteger();
+
+          if edad < 5 then
+            writeString("Joven");
+          else
+            if edad <= 10 then
+              writeString("Adulto");
+            else
+              writeString("Senior");
+            end if
+          end if
+        end algorithm
+      hint: Usa if anidados.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-enum-to-string-ternario
+      language: C
+      week: 3
+      prompt: |
+        Incluye string y stdio.
+
+        Declara la constante MAX_ANIMALES = 3
+
+        Declara un enumerado tTipoAnimal con PERRO, GATO y AVE.
+
+        Declara un array tipoAnimal de tTipoAnimal inicializado con PERRO, GATO y AVE usando {}.
+
+        Declara una cadena de caracteres tipoStr de longitud 20 (Usa el valor directo).
+
+        Copia en tipoStr el nombre del primer animal usando strncpy y el operador ternario anidado para convertir el enum a string ("Perro", "Gato" o "Ave").
+
+        Resumiendo, debes guardar el tipo de animal en un formato string. Para convertir el enumerativo en string, usaras el operador ternario.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_ANIMALES 3
+
+        typedef enum {
+            PERRO, GATO, AVE
+        } tTipoAnimal;
+
+        int main() {
+            tTipoAnimal tipoAnimal[MAX_ANIMALES] = { PERRO, GATO, AVE };
+            char tipoStr[20];
+            strncpy(tipoStr,
+                (tipoAnimal[0] == PERRO) ? "Perro" :
+                (tipoAnimal[0] == GATO) ? "Gato" : "Ave",
+                20);
+            return 0;
+        }
+      hint: Usa strncpy siempre y pon el tamaño como tercer parámetro. En el segundo
+        parametro debe ir el operador ternario anidado.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-enum-to-string-anidado
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 3.
+
+        Declara el tipo enumerado tTipoAnimal con PERRO, GATO y AVE.
+
+        Dentro del algoritmo principal, declara un array tipoAnimal de tTipoAnimal inicializado con PERRO, GATO y AVE.
+
+        Declara una variable tipoStr de tipo string.
+
+        Si tipoAnimal[1] es PERRO, tipoStr debe ser "Perro"; si es GATO, "Gato"; si es AVE, "Ave".
+
+        Para lograrlo deberás usar if else if anidados.
+      answer: |
+        const
+          MAX_ANIMALES: integer = 3;
+        end const
+
+        type
+          tTipoAnimal = { PERRO, GATO, AVE }
+        end type
+
+        algorithm
+          var
+            tipoAnimal: vector[MAX_ANIMALES] of tTipoAnimal;
+            tipoStr: string;
+          end var
+
+          tipoAnimal[1] := PERRO;
+          tipoAnimal[2] := GATO;
+          tipoAnimal[3] := AVE;
+
+          if tipoAnimal[1] = PERRO then
+            tipoStr := "Perro";
+          else
+            if tipoAnimal[1] = GATO then
+              tipoStr := "Gato";
+            else
+              tipoStr := "Ave";
+            end if
+          end if
+        end algorithm
+      hint: Deberas usar if else if... Los anidados son if dentro de else.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-switch
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.h.
+
+        Dentro de main, crea una variable entera opcion y pide al usuario un entero entre 1 y 3.
+
+        Usa el siguiente formato: "Introduce el tipo de animal (1-Perro, 2-Gato, 3-Ave): 1"
+
+        Usa switch para imprimir:
+          1 → "Perro"
+          2 → "Gato"
+          3 → "Ave"
+          cualquier otro → "Opción inválida"
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int opcion;
+
+            printf("Introduce el tipo de animal (1-Perro, 2-Gato, 3-Ave): ");
+            scanf("%d", &opcion);
+
+            switch(opcion) {
+                case 1:
+                    printf("Perro\n");
+                    break;
+                case 2:
+                    printf("Gato\n");
+                    break;
+                case 3:
+                    printf("Ave\n");
+                    break;
+                default:
+                    printf("Opción inválida\n");
+            }
+            return 0;
+        }
+      hint: Usa switch...case...break. Y recuerda los saltos de linea.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-switch
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Dentro del algoritmo principal, crea una variable entera opcion y pide al usuario un entero entre 1 y 3.
+
+        Usa el siguiente formato: "Introduce el tipo de animal (1-Perro, 2-Gato, 3-Ave): 1"
+
+        Usa switch para imprimir:
+          1 → "Perro"
+          2 → "Gato"
+          3 → "Ave"
+          cualquier otro → "Opción inválida"
+      answer: |
+        algorithm
+          var
+            opcion: integer;
+          end var
+
+          writeString("Introduce el tipo de animal (1-Perro, 2-Gato, 3-Ave): ");
+          opcion := readInteger();
+
+          switch opcion
+            case 1 then
+              writeString("Perro");
+            end case
+            case 2 then
+              writeString("Gato");
+            end case
+            case 3 then
+              writeString("Ave");
+            end case
+            case default then
+              writeString("Opción inválida");
+            end case
+          end switch
+        end algorithm
+      hint: |-
+        Recuerda la estructura del switch en pseudocódigo. switch case    then end case
+        case default then end case end switch
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 3
+    explanation:
+      C: "En este nivel aprenderás a **repetir instrucciones** usando bucles `for`,
+        `while` y `do while`, para recorrer arrays y matrices relacionados con videojuegos.
+        \ \nEstos bucles permiten procesar listas de datos como niveles, puntos de
+        experiencia o mapas.\n\n### Bucle `for` básico\nEl `for` sirve para repetir
+        una acción un número fijo de veces.  \nEjemplo: mostrar los primeros 10 niveles
+        de un personaje:\n\n```c\n#include <stdio.h>\n#define MAX_NIVELES 10\n\nint
+        main() {\n    int i;\n    for (i = 0; i < MAX_NIVELES; i++) {\n        printf(\"%d\\n\",
+        i + 1);\n    }\n    return 0;\n}\n```\n\n---\n\n### Recorrer un array con
+        `for`\nPuedes recorrer un array de puntos de experiencia ganados en misiones:\n\n```c\n#include
+        <stdio.h>\n#define MAX_MISIONES 4\n\nint main() {\n    int experiencia[MAX_MISIONES]
+        = {150, 300, 200, 400};\n    int i;\n\n    for (i = 0; i < MAX_MISIONES; i++)
+        {\n        printf(\"%d\\n\", experiencia[i]);\n    }\n    return 0;\n}\n```\n\n---\n\n###
+        Leer datos en un array con `for`\nPuedes usar `scanf` en un bucle para leer
+        datos del usuario.  \nPor ejemplo, el tiempo que tardó en cada misión:\n\n```c\n#include
+        <stdio.h>\n\nint main() {\n    float tiempo[3];\n    int i;\n\n    for (i
+        = 0; i < 3; i++) {\n        printf(\"Tiempo en misión %d: \", i + 1);\n        scanf(\"%f\",
+        &tiempo[i]);\n    }\n    return 0;\n}\n```\n\n---\n\n### `while` y `do while`\n-
+        `while` se ejecuta mientras se cumpla una condición.  \n- `do while` se ejecuta
+        al menos una vez.\n\n```c\n#include <stdio.h>\n\nint main() {\n    int i =
+        0;\n\n    while (i < 5) {\n        printf(\"%d\\n\", i);\n        i++;\n    }\n\n
+        \   i = 0;\n    do {\n        printf(\"%d\\n\", i);\n        i++;\n    } while
+        (i < 5);\n\n    return 0;\n}\n```\n\n---\n\n### Suma de elementos en un array\nPuedes
+        sumar los puntos conseguidos en varios niveles:\n\n```c\n#include <stdio.h>\n\nint
+        main() {\n    int puntos[4] = {10, 20, 30, 40};\n    int suma = 0;\n    int
+        i;\n\n    for (i = 0; i < 4; i++) {\n        suma += puntos[i];\n    }\n\n
+        \   printf(\"Total: %d\\n\", suma);\n    return 0;\n}\n```\n\n---\n\n### strncpy
+        en bucle\nPuedes copiar nombres de enemigos usando un bucle y `strncpy`:\n\n```c\n#include
+        <stdio.h>\n#include <string.h>\n#define MAX 3\n#define MAX_NOMBRE 12\n\nint
+        main() {\n    char enemigos[MAX][MAX_NOMBRE];\n    char nombresBase[MAX][MAX_NOMBRE]
+        = {\"Goblin\", \"Orco\", \"Troll\"};\n    int i;\n\n    for (i = 0; i < MAX;
+        i++) {\n        strncpy(enemigos[i], nombresBase[i], MAX_NOMBRE);\n    }\n\n
+        \   for (i = 0; i < MAX; i++) {\n        printf(\"%s\\n\", enemigos[i]);\n
+        \   }\n    return 0;\n}\n```\n\n---\n\n### Recorrer matrices\nPuedes recorrer
+        mapas, inventarios o zonas con bucles anidados:\n\n```c\n#include <stdio.h>\n\nint
+        main() {\n    int mapa[2][3] = {\n        {1, 0, 1},\n        {0, 1, 0}\n
+        \   };\n    int i, j;\n\n    for (i = 0; i < 2; i++) {\n        for (j = 0;
+        j < 3; j++) {\n            printf(\"%d \", mapa[i][j]);\n        }\n        printf(\"\\n\");\n
+        \   }\n    return 0;\n}\n```\n\n---\n\n### Suma de una matriz\nPara sumar
+        el daño de cada ataque en un campo de batalla:\n\n```c\n#include <stdio.h>\n\nint
+        main() {\n    int dano[2][2] = {\n        {5, 3},\n        {7, 1}\n    };\n
+        \   int suma = 0;\n    int i, j;\n\n    for (i = 0; i < 2; i++) {\n        for
+        (j = 0; j < 2; j++) {\n            suma += dano[i][j];\n        }\n    }\n\n
+        \   printf(\"Daño total: %d\\n\", suma);\n    return 0;\n}\n```\n\n---\n\n###
+        Ejemplo completo\n```c\n#include <stdio.h>\n#include <string.h>\n#define MAX
+        3\n#define MAX_NOMBRE 12\n\nint main() {\n    // Recorrer array\n    int experiencia[4]
+        = {150, 300, 200, 400};\n    int i, j;\n    for (i = 0; i < 4; i++) {\n        printf(\"Experiencia
+        misión %d: %d\\n\", i + 1, experiencia[i]);\n    }\n\n    // Sumar array\n
+        \   int puntos[4] = {10, 20, 30, 40};\n    int suma = 0;\n    for (i = 0;
+        i < 4; i++) {\n        suma += puntos[i];\n    }\n    printf(\"Puntos totales:
+        %d\\n\", suma);\n\n    // Copiar nombres\n    char enemigos[MAX][MAX_NOMBRE];\n
+        \   char nombresBase[MAX][MAX_NOMBRE] = {\"Goblin\", \"Orco\", \"Troll\"};\n
+        \   for (i = 0; i < MAX; i++) {\n        strncpy(enemigos[i], nombresBase[i],
+        MAX_NOMBRE);\n    }\n\n    // Recorrer matriz\n    int mapa[2][3] = {\n        {1,
+        0, 1},\n        {0, 1, 0}\n    };\n    for (i = 0; i < 2; i++) {\n        for
+        (j = 0; j < 3; j++) {\n            printf(\"%d \", mapa[i][j]);\n        }\n
+        \       printf(\"\\n\");\n    }\n    return 0;\n}\n```\n\nEste programa muestra
+        cómo usar bucles para recorrer arrays y matrices en un videojuego.\n"
+      Pseudocode: "En este nivel aprenderás a **usar bucles** `for`, `while` y `do
+        while` en pseudocódigo para recorrer arrays y matrices.  \nSon muy útiles
+        en videojuegos para repetir acciones, calcular sumas o recorrer mapas.\n\n###
+        Bucle `for` básico\n```pseudocode\nalgorithm\n  var \n    i: integer;\n  end
+        var\n\n  for i = 1 to 10 do\n    writeInteger(i);\n  end for\nend algorithm\n```\n\n---\n\n###
+        Recorrer un array\n```pseudocode\nalgorithm\n  var\n    experiencia: vector[4]
+        of integer;\n    i: integer;\n  end var\n\n  experiencia[1] := 150;\n  experiencia[2]
+        := 300;\n  experiencia[3] := 200;\n  experiencia[4] := 400;\n\n  for i = 1
+        to 4 do\n    writeInteger(experiencia[i]);\n  end for\nend algorithm\n```\n\n---\n\n###
+        Leer un array con `for`\n```pseudocode\nalgorithm\n  var\n    tiempo: vector[3]
+        of real;\n    i: integer;\n  end var\n\n  for i = 1 to 3 do\n    writeString(\"Tiempo
+        misión \");\n    writeInteger(i);\n    writeString(\": \");\n    tiempo[i]
+        := readReal();\n  end for\nend algorithm\n```\n\n---\n\n### `while` y `do
+        while`\n```pseudocode\nalgorithm\n  var i: integer;\n  end var\n\n  i := 1;\n
+        \ while i <= 5 do\n    writeInteger(i);\n    i := i + 1;\n  end while\n\n
+        \ i := 1;\n  do\n    writeInteger(i);\n    i := i + 1;\n  while i <= 5;\nend
+        algorithm\n```\n\n---\n\n### Sumar los puntos obtenidos\n```pseudocode\nalgorithm\n
+        \ var\n    puntos: vector[4] of integer;\n    suma: integer;\n    i: integer;\n
+        \ end var\n\n  puntos[1] := 10;\n  puntos[2] := 20;\n  puntos[3] := 30;\n
+        \ puntos[4] := 40;\n  suma := 0;\n\n  for i = 1 to 4 do\n    suma := suma
+        + puntos[i];\n  end for\n\n  writeString(\"Total: \");\n  writeInteger(suma);\nend
+        algorithm\n```\n\n---\n\n### Imprimir nombres\n```pseudocode\nalgorithm\n
+        \ var\n    enemigos: vector[3] of string;\n    i: integer;\n  end var\n\n
+        \ enemigos[1] := \"Goblin\";\n  enemigos[2] := \"Orco\";\n  enemigos[3] :=
+        \"Troll\";\n\n  for i = 1 to 3 do\n    writeString(enemigos[i]);\n  end for\nend
+        algorithm\n```\n\n---\n\n### Matrices\n```pseudocode\nalgorithm\n  var\n    mapa:
+        vector[2][3] of integer;\n    i, j: integer;\n  end var\n\n  mapa[1][1] :=
+        1;\n  mapa[1][2] := 0;\n  mapa[1][3] := 1;\n  mapa[2][1] := 0;\n  mapa[2][2]
+        := 1;\n  mapa[2][3] := 0;\n\n  for i = 1 to 2 do\n    for j = 1 to 3 do\n
+        \     writeInteger(mapa[i][j]);\n    end for\n  end for\nend algorithm\n```\n\n---\n\n###
+        Sumar los valores de una matriz\n```pseudocode\nalgorithm\n  var\n    dano:
+        vector[2][2] of integer;\n    suma, i, j: integer;\n  end var\n\n  dano[1][1]
+        := 5;\n  dano[1][2] := 3;\n  dano[2][1] := 7;\n  dano[2][2] := 1;\n  suma
+        := 0;\n\n  for i = 1 to 2 do\n    for j = 1 to 2 do\n      suma := suma +
+        dano[i][j];\n    end for\n  end for\n\n  writeString(\"Daño total: \");\n
+        \ writeInteger(suma);\nend algorithm\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\nalgorithm
+        buclesVideojuego\n  var\n    experiencia: vector[4] of integer;\n    puntos:
+        vector[4] of integer;\n    enemigos: vector[3] of string;\n    mapa: vector[2][3]
+        of integer;\n    suma, i, j: integer;\n  end var\n\n  experiencia[1] := 150;\n
+        \ experiencia[2] := 300;\n  experiencia[3] := 200;\n  experiencia[4] := 400;\n\n
+        \ for i = 1 to 4 do\n    writeString(\"Experiencia misión \");\n    writeInteger(i);\n
+        \   writeString(\": \");\n    writeInteger(experiencia[i]);\n  end for\n\n
+        \ puntos[1] := 10;\n  puntos[2] := 20;\n  puntos[3] := 30;\n  puntos[4] :=
+        40;\n  suma := 0;\n\n  for i = 1 to 4 do\n    suma := suma + puntos[i];\n
+        \ end for\n  writeString(\"Puntos totales: \");\n  writeInteger(suma);\n\n
+        \ enemigos[1] := \"Goblin\";\n  enemigos[2] := \"Orco\";\n  enemigos[3] :=
+        \"Troll\";\n  for i = 1 to 3 do\n    writeString(enemigos[i]);\n  end for\n\n
+        \ mapa[1][1] := 1;\n  mapa[1][2] := 0;\n  mapa[1][3] := 1;\n  mapa[2][1] :=
+        0;\n  mapa[2][2] := 1;\n  mapa[2][3] := 0;\n  for i = 1 to 2 do\n    for j
+        = 1 to 3 do\n      writeInteger(mapa[i][j]);\n    end for\n  end for\nend
+        algorithm\n```\n\nEste algoritmo muestra cómo recorrer arrays y matrices con
+        diferentes bucles en un videojuego.\n"
+    questions:
+    - id: c-3-for-indice-basico
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.h.
+
+        Declara la constante MAXIMO = 10.
+
+        Dentro de main, declara una variable i.
+
+        Utiliza un bucle for para que i tome valores de 0 a 9, ambos incluidos, e imprime el valor de i en cada iteración.
+
+        La salida debe ser una línea por número, ejemplo:
+          0
+          1
+          2
+          ...
+          9
+      answer: |
+        #include <stdio.h>
+        #define MAXIMO 10
+
+        int main() {
+            int i;
+
+            for(i = 0; i < MAXIMO; i++) {
+                printf("%d\n", i);
+            }
+            return 0;
+        }
+      hint: 'El for clásico en C es: for(inicio; condicion; incremento)'
+      mode: judge_c
+      tests:
+      - input: ''
+        output: |
+          0
+          1
+          2
+          3
+          4
+          5
+          6
+          7
+          8
+          9
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-indice-basico
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAXIMO = 10.
+
+        Dentro del algoritmo principal, declara una variable i.
+
+        Utiliza un bucle for para que i tome valores de 1 a MAXIMO e imprime el valor de i en cada iteración.
+
+        La salida debe ser una línea por número del 1 al 10. Ejemplo
+        1
+        2
+        3
+        ...
+        10
+      answer: |
+        const
+          MAXIMO: integer = 10;
+        end const
+
+        algorithm
+          var
+            i: integer;
+          end var
+
+          for i := 1 to MAXIMO do
+            writeInteger(i);
+          end for
+        end algorithm
+      hint: En pseudocódigo los arrays y los índices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-array-imprimir
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAX_DATOS = 4.
+
+        Dentro de main, declara un array de enteros datos con MAX_DATOS inicializado con a 7, 2, 5, 8 usando { }.
+
+        Usa un bucle for para imprimir cada dato, uno por línea. Necesitaras una variable i.
+
+        Ejemplo de ejecución:
+          7
+          2
+          5
+          8
+      answer: |
+        #include <stdio.h>
+        #define MAX_DATOS 4
+
+        int main() {
+            int datos[MAX_DATOS] = {7, 2, 5, 8};
+            int i;
+            for(i = 0; i < MAX_DATOS; i++) {
+                printf("%d\n", datos[i]);
+            }
+            return 0;
+        }
+      hint: Recuerda que los arrays en C empiezan en 0.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: |
+          7
+          2
+          5
+          8
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-array-imprimir
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_DATOS = 4.
+
+        Dentro del algoritmo principal, declara un array de enteros datos con MAX_DATOS.
+
+        Inicialízalo a mano con los valores 7, 2, 5, 8.
+
+        Usa un bucle for para imprimir cada dato, uno por línea. Necesitarás una variable i.
+
+        Ejemplo de ejecución:
+          7
+          2
+          5
+          8
+      answer: |
+        const
+          MAX_DATOS: integer = 4;
+        end const
+
+        algorithm
+          var
+            datos: vector[MAX_DATOS] of integer;
+            i: integer;
+          end var
+
+          datos[1] := 7;
+          datos[2] := 2;
+          datos[3] := 5;
+          datos[4] := 8;
+
+          for i := 1 to MAX_DATOS do
+            writeInteger(datos[i]);
+          end for
+        end algorithm
+      hint: El índice comienza en 1 en pseudocódigo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-leer-array
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAXIMO = 3.
+
+        Dentro de main, declara un array de decimales valores con MAXIMO.
+
+        Usa un bucle for para pedir al usuario que ingrese 3 decimales y guardarlos en el array.
+
+        Necesitarás una variable i para usar de iterador.
+
+        Luego imprime los valores, uno por línea utilizando otro for.
+
+        Ejemplo de ejecución:
+          Ingresa valor 1: 3.2
+          Ingresa valor 2: 1.0
+          Ingresa valor 3: 4.8
+          3.2
+          1.0
+          4.8
+      answer: |
+        #include <stdio.h>
+        #define MAXIMO 3
+
+        int main() {
+            float valores[MAXIMO];
+            int i;
+            for(i = 0; i < MAXIMO; i++) {
+                printf("Ingresa valor %d: ", i+1);
+                scanf("%f", &valores[i]);
+            }
+            for(i = 0; i < MAXIMO; i++) {
+                printf("%.1f\n", valores[i]);
+            }
+            return 0;
+        }
+      hint: Usa dos bucles for, uno para leer y otro para imprimir. Imprime los valores
+        con 1 solo decimal.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-leer-array
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAXIMO = 3.
+
+        Dentro del algoritmo principal, declara un array de reales valores con MAXIMO.
+
+        Usa un bucle for para leer 3 decimales del usuario y guardarlos en el array.
+
+        Necesitarás una variable i para usar de iterador.
+
+        Luego usa otro bucle for para imprimir los valores, uno por línea.
+
+        Ejemplo de ejecución:
+          Ingresa valor 1: 3.2
+          Ingresa valor 2: 1.0
+          Ingresa valor 3: 4.8
+          3.2
+          1.0
+          4.8
+
+        El numero seguido de valor toma el valor del indice en cada iteración.
+      answer: |
+        const
+          MAXIMO: integer = 3;
+        end const
+
+        algorithm
+          var
+            valores: vector[MAXIMO] of real;
+            i: integer;
+          end var
+
+          for i := 1 to MAXIMO do
+            writeString("Ingresa valor ");
+            writeInteger(i);
+            writeString(": ");
+            valores[i] := readReal();
+          end for
+
+          for i := 1 to MAXIMO do
+            writeReal(valores[i]);
+          end for
+        end algorithm
+      hint: Usa dos bucles for, uno para leer y otro para imprimir. Recuerda que en
+        pseudocodigo debes imprimir los datos en diferentes lineas.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-while-indice-basico
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAXIMO = 10.
+
+        Dentro de main, declara una variable i inicializada a 0.
+
+        Utiliza un bucle while para imprimir el valor de i mientras i sea menor que MAXIMO.
+
+        La salida debe ser una línea por número, del 0 al 9.
+      answer: |
+        #include <stdio.h>
+        #define MAXIMO 10
+
+        int main() {
+            int i = 0;
+            while(i < MAXIMO) {
+                printf("%d\n", i);
+                i++;
+            }
+            return 0;
+        }
+      hint: Recuerda inicializar i antes del while e incrementarla antes de finalizar
+        cada iteración para no crear un bucle infinito.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: |
+          0
+          1
+          2
+          3
+          4
+          5
+          6
+          7
+          8
+          9
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-while-indice-basico
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAXIMO = 10.
+
+        Dentro del algoritmo principal, declara una variable i inicializada a 1.
+
+        Usa un bucle while para imprimir el valor de i mientras i sea menor o igual que MAXIMO.
+
+        La salida debe ser una línea por número del 1 al 10.
+      answer: |
+        const
+          MAXIMO: integer = 10;
+        end const
+
+        algorithm
+          var
+            i: integer;
+          end var
+
+          i := 1;
+          while i <= MAXIMO do
+            writeInteger(i);
+            i := i + 1;
+          end while
+        end algorithm
+      hint: En pseudocódigo los índices empiezan en 1 y se incrementan manualmente.
+        No olvides incrementar el indice.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-do-while-indice-basico
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAXIMO = 10.
+
+        Dentro de main, declara una variable i inicializada a 0.
+
+        Usa un bucle do while para imprimir el valor de i mientras i sea menor que MAXIMO.
+
+        La salida debe ser una línea por número, del 0 al 9.
+      answer: |
+        #include <stdio.h>
+        #define MAXIMO 10
+
+        int main() {
+            int i = 0;
+            do {
+                printf("%d\n", i);
+                i++;
+            } while(i < MAXIMO);
+            return 0;
+        }
+      hint: El cuerpo de do while siempre se ejecuta al menos una vez. No olvides
+        el salto de linea en el print.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: |
+          0
+          1
+          2
+          3
+          4
+          5
+          6
+          7
+          8
+          9
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-do-while-indice-basico
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAXIMO = 10.
+
+        Dentro del algoritmo principal, declara una variable e inicializala a 1.
+
+        Usa un bucle do while para imprimir el valor de i mientras i sea menor o igual que MAXIMO.
+
+        La salida debe ser una línea por número del 1 al 10.
+      answer: |
+        const
+          MAXIMO: integer = 10;
+        end const
+
+        algorithm
+          var
+            i: integer;
+          end var
+
+          i := 1;
+          do
+            writeInteger(i);
+            i := i + 1;
+          while i <= MAXIMO;
+        end algorithm
+      hint: En pseudocódigo los índices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-suma-array
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAX = 4.
+
+        Dentro de main, declara un array de enteros valores con MAX inicializado a 1, 2, 3, 4 usando { }.
+
+        Declara una variable suma para almacenar la suma de todos los elementos del array e inicializala en 0.
+
+        También necesitarás una variable i para utilizar en el bucle.
+
+        Usa un bucle for para calcular la suma de todos los elementos y al final imprime el resultado así:
+
+        Suma: x
+
+        Para la suma utiliza el operador compuesto.
+
+        Ejemplo de ejecución:
+          Suma: 10
+      answer: |
+        #include <stdio.h>
+        #define MAX 4
+
+        int main() {
+            int valores[MAX] = {1, 2, 3, 4};
+            int suma = 0;
+            int i;
+            for(i = 0; i < MAX; i++) {
+                suma += valores[i];
+            }
+            printf("Suma: %d\n", suma);
+            return 0;
+        }
+      hint: Acumula la suma con suma += . Imprime el resultado fuera del bucle y no
+        olvides el salto de linea.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Suma: 10
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-suma-array
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX = 4.
+
+        Declara un array de enteros valores con MAX.
+
+        Inicialízalo a mano con los valores 1, 2, 3, 4.
+
+        Declara una variable suma para almacenar la suma de todos los elementos del array e inicializala en 0.
+
+        También necesitarás una variable i para utilizar en el bucle.
+
+        Usa un bucle for para calcular la suma de todos los elementos y al final imprime el resultado así:
+
+        Suma: x
+
+        Ejemplo de ejecución:
+          Suma: 10
+      answer: |
+        const
+          MAX: integer = 4;
+        end const
+
+        algorithm
+          var
+            valores: vector[MAX] of integer;
+            suma: integer;
+            i: integer;
+          end var
+
+          valores[1] := 1;
+          valores[2] := 2;
+          valores[3] := 3;
+          valores[4] := 4;
+          suma := 0;
+
+          for i := 1 to MAX do
+            suma := suma + valores[i];
+          end for
+
+          writeString("Suma: ");
+          writeInteger(suma);
+        end algorithm
+      hint: Recuerda inicializar suma a 0. Imprime el resultado fuera del bucle. Los
+        indices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-strncpy-paralelo
+      language: C
+      week: 3
+      prompt: "Incluye stdio y string.\n\nDeclara la constante MAX = 3 y MAX_NOMBRE
+        = 12.\n\nDentro de main, declara un array de cadenas nombres con MAX y MAX_NOMBRE.\n\nDeclara
+        otro array de cadenas ejemplos con MAX y MAX_NOMBRE e inicializalo con los
+        siguientes nombres usando { }: \nAna\", \"Luis\" y \"Eva\"\n\nDeclara una
+        variable i para utilizar en los bucles.\n\nUsa strncpy para inicializar los
+        nombres con \"Ana\", \"Luis\" y \"Eva\" usando un bucle for.\n\nDespués, imprime
+        cada nombre, uno por línea con otro bucle for.\n\nEjemplo de ejecución:\n
+        \ Ana\n  Luis\n  Eva\n"
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+        #define MAX 3
+        #define MAX_NOMBRE 12
+
+        int main() {
+            char nombres[MAX][MAX_NOMBRE];
+            char ejemplos[MAX][MAX_NOMBRE]; = {"Ana", "Luis", "Eva"};
+            int i;
+            for(i = 0; i < MAX; i++) {
+                strncpy(nombres[i], ejemplos[i], MAX_NOMBRE);
+            }
+            for(i = 0; i < MAX; i++) {
+                printf("%s\n", nombres[i]);
+            }
+            return 0;
+        }
+      hint: Usa strncpy(destino, origen, tamaño).
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-array-paralelo
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX = 3.
+
+        Declara un array de strings nombres con MAX.
+
+        Inicialízalos a mano como "Ana", "Luis" y "Eva".
+
+        Usa un bucle for para imprimir cada nombre, uno por línea.
+
+        Ejemplo de ejecución:
+          Ana
+          Luis
+          Eva
+      answer: |
+        const
+          MAX: integer = 3;
+        end const
+
+        algorithm
+          var
+            nombres: vector[MAX] of string;
+            i: integer;
+          end var
+
+          nombres[1] := "Ana";
+          nombres[2] := "Luis";
+          nombres[3] := "Eva";
+
+          for i := 1 to MAX do
+            writeString(nombres[i]);
+          end for
+        end algorithm
+      hint: Los índices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-matriz-manual
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Dentro de main, declara una matriz de enteros tabla con FILAS x COLUMNAS e inicialízala manualmente usando asignaciones.
+
+        Declara dos variables i j para utilizar en los bucles.
+
+        Asigna manualmente los valores siguientes:
+          fila 1: 2, 4, 6
+          fila 2: 1, 3, 5
+
+        Usa dos bucles for anidados para imprimir la matriz como una tabla.
+
+        Después de cada bucle interno, imprime un salto de linea para lograr el output facilitado.
+
+        Ejemplo de ejecución:
+          2 4 6
+          1 3 5
+      answer: "#include <stdio.h>\n#define FILAS 2\n#define COLUMNAS 3\n\nint main()
+        {\n    int tabla[FILAS][COLUMNAS];\n    int i, j;\n\n    tabla[0][0] = 2;
+        \n    tabla[0][1] = 4; \n    tabla[0][2] = 6;\n    tabla[1][0] = 1; \n    tabla[1][1]
+        = 3; \n    tabla[1][2] = 5;\n\n    for(i = 0; i < FILAS; i++) {\n        for(j
+        = 0; j < COLUMNAS; j++) {\n            printf(\"%d \", tabla[i][j]);\n        }\n
+        \       printf(\"\\n\");\n    }\n    return 0;\n}\n"
+      hint: Inicializa cada elemento manualmente.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: "2 4 6 \n1 3 5 \n"
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-matriz-manual
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Declara una matriz de enteros tabla con FILAS x COLUMNAS.
+
+        Declara dos variables i j para utilizar en los bucles.
+
+        Asigna manualmente los valores:
+          fila 1: 2, 4, 6
+          fila 2: 1, 3, 5
+
+        Usa dos bucles for anidados para imprimir la matriz como una tabla.
+
+        Ejemplo de ejecución:
+          2 4 6
+          1 3 5
+      answer: "const\n  FILAS: integer = 2;\n  COLUMNAS: integer = 3;\nend const\n\nalgorithm\n
+        \ var\n    tabla: vector[FILAS][COLUMNAS] of integer;\n    i: integer;\n    j:
+        integer;\n  end var\n\n  tabla[1][1] := 2; \n  tabla[1][2] := 4; \n  tabla[1][3]
+        := 6;\n  tabla[2][1] := 1; \n  tabla[2][2] := 3; \n  tabla[2][3] := 5;\n\n
+        \ for i := 1 to FILAS do\n    for j := 1 to COLUMNAS do\n      writeInteger(tabla[i][j]);\n
+        \   end for\n  end for\nend algorithm\n"
+      hint: Los bucles anidados recorren filas y columnas.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-matriz-inicializa-llaves
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara las constantes FILAS = 2 y COLUMNAS = 2.
+
+        Dentro de main, declara una matriz de decimales temp con FILAS x COLUMNAS e inicialízala con { } con los valores:
+          22.1, 18.3 y 19.5, 20.0 (fila1 y fila2)
+
+        Declara dos variables i j para utilizar en los bucles.
+
+        Usa dos bucles for anidados para imprimir cada valor con un decimal, uno por línea.
+
+        Ejemplo de ejecución:
+          22.1
+          18.3
+          19.5
+          20.0
+      answer: |
+        #include <stdio.h>
+        #define FILAS 2
+        #define COLUMNAS 2
+
+        int main() {
+            float temp[FILAS][COLUMNAS] = {
+                {22.1, 18.3},
+                {19.5, 20.0}
+            };
+            int i, j;
+            for(i = 0; i < FILAS; i++) {
+                for(j = 0; j < COLUMNAS; j++) {
+                    printf("%.1f\n", temp[i][j]);
+                }
+            }
+            return 0;
+        }
+      hint: Usa inicialización con llaves y no olvides el salto de linea.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: |
+          22.1
+          18.3
+          19.5
+          20.0
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-matriz-inicializa-manual
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 2.
+
+        Declara una matriz de reales temp con FILAS x COLUMNAS.
+
+        Asigna manualmente los valores:
+          22.1, 18.3 y 19.5,20.0 (fila1 y fila2)
+
+        Declara dos variables i j para utilizar en los bucles.
+
+        Usa dos bucles for anidados para imprimir cada valor, uno por línea.
+
+        Ejemplo de ejecución:
+          22.1
+          18.3
+          19.5
+          20.0
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 2;
+        end const
+
+        algorithm
+          var
+            temp: vector[FILAS][COLUMNAS] of real;
+            i: integer;
+            j: integer;
+          end var
+
+          temp[1][1] := 22.1;
+          temp[1][2] := 18.3;
+          temp[2][1] := 19.5;
+          temp[2][2] := 20.0;
+
+          for i := 1 to FILAS do
+            for j := 1 to COLUMNAS do
+              writeReal(temp[i][j]);
+            end for
+          end for
+        end algorithm
+      hint: En pseudocódigo la inicialización es manual.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-suma-matriz
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara las constantes FILAS = 2 y COLUMNAS = 2.
+
+        Dentro de main, declara una matriz de enteros tabla con FILAS x COLUMNAS inicializada con (3, 1) y (5, 2).
+
+        Declara una variable suma e inicializala en 0.
+
+        Declara dos variables i, j en la misma linea para utilizar en los bucles.
+
+        Usa dos bucles for anidados para calcular la suma de todos los elementos y luego imprime:
+
+        Suma: x
+
+        La suma realizala con operador compuesto.
+
+        Ejemplo de ejecución:
+          Suma: 11
+      answer: |
+        #include <stdio.h>
+        #define FILAS 2
+        #define COLUMNAS 2
+
+        int main() {
+            int tabla[FILAS][COLUMNAS] = {
+                {3, 1},
+                {5, 2}
+            };
+            int suma = 0;
+            int i, j;
+            for(i = 0; i < FILAS; i++) {
+                for(j = 0; j < COLUMNAS; j++) {
+                    suma += tabla[i][j];
+                }
+            }
+            printf("Suma: %d\n", suma);
+            return 0;
+        }
+      hint: Suma con suma += tabla[i][j].
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Suma: 11
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-suma-matriz
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 2.
+
+        Dentro del algoritmo principal, declara una matriz de enteros tabla con FILAS x COLUMNAS inicializada con (3, 1) y (5, 2).
+
+        Declara una variable suma e inicializala en 0.
+
+        Declara dos variables i, j para utilizar en los bucles.
+
+        Usa dos bucles for anidados para calcular la suma de todos los elementos y luego imprime:
+
+        Suma: x
+
+        Ejemplo de ejecución:
+          Suma: 11
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 2;
+        end const
+
+        algorithm
+          var
+            tabla: vector[FILAS][COLUMNAS] of integer;
+            suma: integer;
+            i: integer;
+            j: integer;
+          end var
+
+          tabla[1][1] := 3;
+          tabla[1][2] := 1;
+          tabla[2][1] := 5;
+          tabla[2][2] := 2;
+          suma := 0;
+
+          for i := 1 to FILAS do
+            for j := 1 to COLUMNAS do
+              suma := suma + tabla[i][j];
+            end for
+          end for
+
+          writeString("Suma: ");
+          writeInteger(suma);
+        end algorithm
+      hint: Los indices empiezan en 1. Primero declara y luego inicializa
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+- number: 4
+  explanation: 'Explicación de semana 4
+
+    '
+  levels:
+  - number: 1
+    explanation:
+      C: "En este nivel aprenderás a **declarar y utilizar `structs`** para representar
+        datos complejos como una atracción de un parque, además de cómo declarar **arrays
+        de structs** y acceder a sus campos.  \nLos `structs` son muy útiles para
+        modelar entidades en videojuegos o parques temáticos.\n\n### ¿Qué es un `struct`?\nUn
+        `struct` permite agrupar múltiples variables relacionadas bajo un solo nombre.
+        \ \nEs ideal para representar personajes, ítems o atracciones.\n\n```c\ntypedef
+        struct {\n    char nombre[30];\n    int duracionMinutos;\n    float alturaMinima;\n}
+        tAtraccion;\n```\n\nEsto define un nuevo tipo `tAtraccion` con 3 campos.\n\n---\n\n###
+        Declarar una variable de tipo struct\n```c\nint main(){\n  tAtraccion torreCaida;\n
+        \ return 0;\n}\n```\n\n---\n\n### Asignar valores a los campos\nPara campos
+        `char[]`, usamos `strncpy`:\n\n```c\n#include <string.h>\n\nint main() {\n
+        \   tAtraccion torreCaida;\n    strncpy(torreCaida.nombre, \"Torre de Caída\",
+        30);\n    torreCaida.duracionMinutos = 3;\n    torreCaida.alturaMinima = 1.40;\n
+        \   return 0;\n}\n```\n\n---\n\n### Array de structs\nPuedes declarar un array
+        de structs para almacenar varias atracciones:\n\n```c\n#define MAX_ATRACCIONES
+        3\n\nint main(){\n  tAtraccion atracciones[MAX_ATRACCIONES];\n  return 0;\n}\n\n```\n\nPara
+        acceder al nombre de la primera atracción:\n\n```c\nint main(){\n  atracciones[0].nombre;\n
+        \ return 0;\n}\n```\n\n---\n\n### Relación entre arrays paralelos\nSupón que
+        tienes un array de `tAtraccion` y otro array con el número de visitantes.
+        \ \nSi el índice es el mismo, representan datos del mismo objeto:\n\n```c\n#include
+        <string.h>\n#define MAX_ATRACCIONES 3\n\nint main() {\n    tAtraccion atracciones[MAX_ATRACCIONES];\n
+        \   int visitantes[MAX_ATRACCIONES];\n\n    strncpy(atracciones[1].nombre,
+        \"Looping\", 30);\n    visitantes[1] = 1234;\n    return 0;\n}\n```\n\nAquí
+        el índice `1` se refiere a la misma atracción.\n\n---\n\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n#include <string.h>\n\n#define MAX_ATRACCIONES 3\n\ntypedef struct
+        {\n    char nombre[30];\n    int duracionMinutos;\n    float alturaMinima;\n}
+        tAtraccion;\n\nint main() {\n    tAtraccion parque[MAX_ATRACCIONES];\n    int
+        visitantes[MAX_ATRACCIONES];\n\n    // Asignar valores\n    strncpy(parque[0].nombre,
+        \"Torre de Caída\", 30);\n    parque[0].duracionMinutos = 3;\n    parque[0].alturaMinima
+        = 1.40;\n    visitantes[0] = 1200;\n\n    strncpy(parque[1].nombre, \"Looping\",
+        30);\n    parque[1].duracionMinutos = 2;\n    parque[1].alturaMinima = 1.30;\n
+        \   visitantes[1] = 1500;\n\n    strncpy(parque[2].nombre, \"Tazas Locas\",
+        30);\n    parque[2].duracionMinutos = 4;\n    parque[2].alturaMinima = 1.10;\n
+        \   visitantes[2] = 900;\n\n    // Mostrar datos\n    for (int i = 0; i <
+        MAX_ATRACCIONES; i++) {\n        printf(\"Atracción: %s\\n\", parque[i].nombre);\n
+        \       printf(\"Duración: %d minutos\\n\", parque[i].duracionMinutos);\n
+        \       printf(\"Altura mínima: %.2f m\\n\", parque[i].alturaMinima);\n        printf(\"Visitantes:
+        %d\\n\\n\", visitantes[i]);\n    }\n\n    return 0;\n}\n```\n\nEste programa
+        muestra cómo declarar structs, guardarlos en arrays y relacionarlos con otros
+        datos como número de visitantes.\n"
+      Pseudocode: "En este nivel aprenderás a **utilizar `record`** para representar
+        datos compuestos, como atracciones, y cómo trabajar con **arrays de registros**.
+        \ \nLos `record` permiten organizar la información de un parque o videojuego
+        de forma clara.\n\n### ¿Qué es un `record`?\nUn `record` es como una caja
+        que contiene distintos datos relacionados.  \nSirve para representar enemigos,
+        jefes o atracciones de parque.\n\n```pseudocode\ntype\n  tAtraccion = record\n
+        \   nombre: string;\n    duracionMinutos: integer;\n    alturaMinima: real;\n
+        \ end record\nend type\n```\n\n---\n\n### Declarar una variable de tipo record\n```pseudocode\nalgorithm\n
+        \ var\n    torreCaida: tAtraccion;\n  end var\nend algorithm\n```\n\n---\n\n###
+        Asignar valores a los campos\n```pseudocode\nalgorithm\n  var\n    torreCaida:
+        tAtraccion;\n  end var\n\n  torreCaida.nombre := \"Torre de Caída\";\n  torreCaida.duracionMinutos
+        := 3;\n  torreCaida.alturaMinima := 1.40;\nend algorithm\n```\n\n---\n\n###
+        Array de records\n```pseudocode\nconst\n  MAX_ATRACCIONES: integer = 3;\nend
+        const\n\nalgorithm\n  var\n    parque: vector[MAX_ATRACCIONES] of tAtraccion;\n
+        \ end var\nend algorithm\n```\n\nPara acceder al campo de la primera atracción:\n\n```pseudocode\nparque[1].nombre\n```\n\n---\n\n###
+        Relación entre arrays paralelos\nSi tienes un array `parque` y otro array
+        llamado `visitantes`, puedes almacenar información relacionada en la misma
+        posición:\n\n```pseudocode\nalgorithm\n  var\n    parque: vector[3] of tAtraccion;\n
+        \   visitantes: vector[3] of integer;\n  end var\n\n  parque[2].nombre :=
+        \"Tazas locas\";\n  parque[2].duracionMinutos := 4;\n  parque[2].alturaMinima
+        := 1.10;\n\n  visitantes[2] := 300;\nend algorithm\n```\n\nAquí, el índice
+        2 representa los datos de la misma atracción.\n\n---\n\n### Ejemplo completo\n```pseudocode\nconst\n
+        \ MAX_ATRACCIONES: integer = 3;\nend const\n\ntype\n  tAtraccion = record\n
+        \   nombre: string;\n    duracionMinutos: integer;\n    alturaMinima: real;\n
+        \ end record\nend type\n\nalgorithm parqueDiversiones\n  var\n    parque:
+        vector[MAX_ATRACCIONES] of tAtraccion;\n    visitantes: vector[MAX_ATRACCIONES]
+        of integer;\n    i: integer;\n  end var\n\n  parque[1].nombre := \"Torre de
+        Caída\";\n  parque[1].duracionMinutos := 3;\n  parque[1].alturaMinima := 1.40;\n
+        \ visitantes[1] := 1200;\n\n  parque[2].nombre := \"Looping\";\n  parque[2].duracionMinutos
+        := 2;\n  parque[2].alturaMinima := 1.30;\n  visitantes[2] := 1500;\n\n  parque[3].nombre
+        := \"Tazas Locas\";\n  parque[3].duracionMinutos := 4;\n  parque[3].alturaMinima
+        := 1.10;\n  visitantes[3] := 900;\n\n  for i := 1 to MAX_ATRACCIONES do\n
+        \   writeString(\"Atracción: \");\n    writeString(parque[i].nombre);\n    writeString(\",
+        Duración: \");\n    writeInteger(parque[i].duracionMinutos);\n    writeString(\"
+        min, Altura mínima: \");\n    writeReal(parque[i].alturaMinima);\n    writeString(\"
+        m, Visitantes: \");\n    writeInteger(visitantes[i]);\n  end for\nend algorithm\n```\n\nEste
+        algoritmo muestra cómo trabajar con registros y arrays paralelos para representar
+        un parque de atracciones.\n"
+    questions:
+    - id: c-4-atraccion-basica
+      language: C
+      week: 4
+      prompt: |
+        Crea un tipo de dato llamado tAtraccion para una atracción de parque con los siguientes campos exactos:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por la constante MAX_NOMBRE (valor 30).
+        - Un número decimal llamado alturaMinima.
+        - Un valor lógico llamado enMantenimiento.
+
+        Declara una variable llamada atraccion1 de tipo tAtraccion dentro de la función main.
+      answer: |
+        #include <stdbool.h>
+
+        #define MAX_NOMBRE 30
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            float alturaMinima;
+            bool enMantenimiento;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            return 0;
+        }
+      hint: Declara primero la constante, luego el typedef del struct y por último
+        la variable atraccion1 dentro de main. No olvides la biblioteca de booleanos
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-basica
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo de dato llamado tAtraccion para una atracción de parque con los siguientes campos exactos:
+        - Un texto llamado nombre.
+        - Un número real llamado alturaMinima.
+        - Un valor booleano llamado enMantenimiento.
+
+        Declara una variable llamada atraccion1 de tipo tAtraccion dentro del bloque principal.
+      answer: |
+        type
+          tAtraccion = record
+            nombre: string;
+            alturaMinima: real;
+            enMantenimiento: boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+        end algorithm
+      hint: En pseudocódigo no se especifica el tamaño del texto; usa string.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-con-tipo
+      language: C
+      week: 4
+      prompt: |
+        Crea un tipo enumerado llamado tTipoAtraccion con los valores MONTANA_RUSA, CARRUSEL y SIMULADOR.
+        Crea un tipo tAtraccion con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por la constante MAX_NOMBRE (valor 30).
+        - Un campo llamado tipo de tipo tTipoAtraccion.
+
+        Declara una variable llamada atraccion1 de tipo tAtraccion dentro de la función main.
+      answer: |
+        #define MAX_NOMBRE 30
+
+        typedef enum {
+            MONTANA_RUSA,
+            CARRUSEL,
+            SIMULADOR
+        } tTipoAtraccion;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tTipoAtraccion tipo;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            return 0;
+        }
+      hint: Declara primero la constante, luego el typedef del enum y luego el typedef
+        del struct que lo usa.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-con-tipo
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo enumerado llamado tTipoAtraccion con los valores MONTANA_RUSA, CARRUSEL y SIMULADOR.
+        Crea un tipo tAtraccion con:
+        - Un texto llamado nombre.
+        - Un campo llamado tipo de tipo tTipoAtraccion.
+
+        Declara una variable llamada atraccion1 de tipo tAtraccion dentro del bloque principal.
+      answer: |
+        type
+          tTipoAtraccion = { MONTANA_RUSA, CARRUSEL, SIMULADOR }
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            tipo: tTipoAtraccion;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+        end algorithm
+      hint: Declara el tipo enumerado antes del record que lo utiliza utiliza dos
+        bloques type diferentes.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atracciones-lista
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (30) y MAX_ATRACCIONES (5).
+
+        Crea un tipo tAtraccion con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 30).
+        - Un número entero llamado capacidadMaxima.
+
+        Dentro de la función principal, declara un array llamado lista de tipo tAtraccion con MAX_ATRACCIONES elementos.
+      answer: |
+        #define MAX_NOMBRE 30
+        #define MAX_ATRACCIONES 5
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            int capacidadMaxima;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion lista[MAX_ATRACCIONES];
+            return 0;
+        }
+      hint: Las constantes deben definirse antes del typedef del struct.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atracciones-lista
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 5.
+
+        Crea un tipo tAtraccion con:
+        - Un texto llamado nombre.
+        - Un número entero llamado capacidadMaxima.
+
+        En el bloque principal, declara un array llamado lista de tipo tAtraccion con MAX_ATRACCIONES elementos.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 5;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            capacidadMaxima: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            lista: vector[MAX_ATRACCIONES] of tAtraccion;
+          end var
+        end algorithm
+      hint: Usa vector[MAX_ATRACCIONES] of tAtraccion para el array de registros.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-horario
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_HORA (6) y MAX_NOMBRE (30).
+
+        Crea un tipo tHorario con:
+        - Una cadena de caracteres llamada apertura con tamaño máximo definido por MAX_HORA (valor 6).
+        - Una cadena de caracteres llamada cierre con tamaño máximo definido por MAX_HORA (valor 6).
+
+        Crea un tipo tAtraccion con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 30).
+        - Un campo llamado horario de tipo tHorario.
+
+
+        Declara dentro de main una variable llamada atraccion1 de tipo tAtraccion.
+      answer: |
+        #define MAX_HORA 6
+        #define MAX_NOMBRE 30
+
+        typedef struct {
+            char apertura[MAX_HORA];
+            char cierre[MAX_HORA];
+        } tHorario;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tHorario horario;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            return 0;
+        }
+      hint: Los structs anidados se declaran con un typedef para cada tipo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-horario
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo tHorario con:
+        - Un texto llamado apertura.
+        - Un texto llamado cierre.
+
+        Crea un tipo tAtraccion con:
+        - Un texto llamado nombre.
+        - Un campo llamado horario de tipo tHorario.
+
+        Declara una variable llamada atraccion1 de tipo tAtraccion en el bloque principal.
+      answer: |
+        type
+          tHorario = record
+            apertura: string;
+            cierre: string;
+          end record
+
+          tAtraccion = record
+            nombre: string;
+            horario: tHorario;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+        end algorithm
+      hint: Declara primero tHorario y luego úsalo como campo en tAtraccion, usa un
+        solo bloque type.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-ficha-seguridad
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 30.
+
+        Crea un tipo tFichaSeguridad con:
+        - Una cadena de caracteres llamada inspector con tamaño máximo definido por MAX_NOMBRE (valor 30).
+        - Un número decimal llamado puntaje.
+        - Un valor lógico llamado aprobada.
+
+        Declara dentro de main una variable llamada ficha1 de tipo tFichaSeguridad.
+      answer: |
+        #include <stdbool.h>
+
+        #define MAX_NOMBRE 30
+
+        typedef struct {
+            char inspector[MAX_NOMBRE];
+            float puntaje;
+            bool aprobada;
+        } tFichaSeguridad;
+
+        int main() {
+            tFichaSeguridad ficha1;
+            return 0;
+        }
+      hint: Recuerda incluir <stdbool.h> cuando uses bool en C.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-ficha-seguridad
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo tFichaSeguridad con:
+        - Un texto llamado inspector.
+        - Un número real llamado puntaje.
+        - Un valor booleano llamado aprobada.
+
+        Declara dentro del bloque principal una variable llamada ficha1 de tipo tFichaSeguridad.
+      answer: |
+        type
+          tFichaSeguridad = record
+            inspector: string;
+            puntaje: real;
+            aprobada: boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            ficha1: tFichaSeguridad;
+          end var
+        end algorithm
+      hint: El record agrupa campos de distintos tipos en un solo dato.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-restricciones
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 30.
+
+        Crea un tipo enumerado tDificultad con los valores BAJA, MEDIA y ALTA.
+        Crea un tipo tRestriccion con:
+        - Un número decimal llamado alturaMinima.
+        - Un valor lógico llamado embarazadasProhibido.
+
+        Crea un tipo tAtraccion con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 30).
+        - Un campo llamado dificultad de tipo tDificultad.
+        - Un campo llamado restriccion de tipo tRestriccion.
+
+
+        Declara dentro de main una variable llamada atraccion1 de tipo tAtraccion.
+      answer: |
+        #include <stdbool.h>
+
+        #define MAX_NOMBRE 30
+
+        typedef enum {
+            BAJA, MEDIA, ALTA
+        } tDificultad;
+
+        typedef struct {
+            float alturaMinima;
+            bool embarazadasProhibido;
+        } tRestriccion;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tDificultad dificultad;
+            tRestriccion restriccion;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            return 0;
+        }
+      hint: Declara enum y structs con typedef y en ese orden antes de main.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-restricciones
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo enumerado tDificultad con los valores BAJA, MEDIA y ALTA.
+        Crea un tipo tRestriccion con:
+        - Un número real llamado alturaMinima.
+        - Un valor booleano llamado embarazadasProhibido.
+
+        Crea un tipo tAtraccion con:
+        - Un texto llamado nombre.
+        - Un campo llamado dificultad de tipo tDificultad.
+        - Un campo llamado restriccion de tipo tRestriccion.
+
+        Declara dentro del bloque principal una variable llamada atraccion1 de tipo tAtraccion.
+      answer: |
+        type
+          tDificultad = { BAJA, MEDIA, ALTA }
+
+          tRestriccion = record
+            alturaMinima: real;
+            embarazadasProhibido: boolean;
+          end record
+
+          tAtraccion = record
+            nombre: string;
+            dificultad: tDificultad;
+            restriccion: tRestriccion;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+        end algorithm
+      hint: 'Define los tipos en orden: enum, record restricción y luego el record
+        atracción. Utiliza un solo bloque type end type.'
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-cartelera-atracciones
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (20) y MAX_ATRACCIONES (3).
+
+        Crea un tipo tAtraccion con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 20).
+        - Un número entero llamado duracionMinutos.
+
+        Declara dentro de main un array llamado cartelera de tipo tAtraccion con MAX_ATRACCIONES elementos.
+      answer: |
+        #define MAX_NOMBRE 20
+        #define MAX_ATRACCIONES 3
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            int duracionMinutos;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion cartelera[MAX_ATRACCIONES];
+            return 0;
+        }
+      hint: El array de structs se declara como cualquier array, usando el tipo tAtraccion.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-cartelera-atracciones
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (20) y MAX_ATRACCIONES (3).
+
+        Crea un tipo tAtraccion con:
+        - Un texto llamado nombre.
+        - Un número entero llamado duracionMinutos.
+
+        Declara dentro del bloque principal un array llamado cartelera de tipo tAtraccion con MAX_ATRACCIONES elementos.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 3;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            duracionMinutos: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            cartelera: vector[MAX_ATRACCIONES] of tAtraccion;
+          end var
+        end algorithm
+      hint: En pseudocódigo los arrays se declaran con vector[tamaño] of tipo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-mapa-zona
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (25), FILAS (2) y COLUMNAS (3).
+
+        Crea un tipo tMapaZona con:
+        - Una cadena de caracteres llamada nombreZona con tamaño máximo definido por MAX_NOMBRE (valor 25).
+        - Una matriz booleana llamada ocupacion con tamaño FILAS x COLUMNAS.
+
+        Declara dentro de main una variable llamada mapa1 de tipo tMapaZona.
+      answer: |
+        #include <stdbool.h>
+
+        #define MAX_NOMBRE 25
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        typedef struct {
+            char nombreZona[MAX_NOMBRE];
+            bool ocupacion[FILAS][COLUMNAS];
+        } tMapaZona;
+
+        int main() {
+            tMapaZona mapa1;
+            return 0;
+        }
+      hint: Para usar bool en C incluye <stdbool.h>. La matriz va como campo del struct.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-mapa-zona
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara las constantes FILAS con valor 2 y COLUMNAS con valor 3.
+
+        Crea un tipo tMapaZona con:
+        - Un texto llamado nombreZona.
+        - Una matriz booleana llamada ocupacion de tamaño FILAS x COLUMNAS.
+
+        Declara dentro del bloque principal una variable llamada mapa1 de tipo tMapaZona.
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 3;
+        end const
+
+        type
+          tMapaZona = record
+            nombreZona: string;
+            ocupacion: vector[FILAS][COLUMNAS] of boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            mapa1: tMapaZona;
+          end var
+        end algorithm
+      hint: En pseudocódigo, las matrices se representan como vector[FILAS][COLUMNAS]
+        of tipo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-snack-categoria
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 20.
+
+        Crea un tipo tSnack con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 20).
+        - Un carácter llamado categoria (por ejemplo 'A', 'B', 'C').
+
+        Declara dentro de main una variable llamada snack1 de tipo tSnack.
+      answer: |
+        #define MAX_NOMBRE 20
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            char categoria;
+        } tSnack;
+
+        int main() {
+            tSnack snack1;
+            return 0;
+        }
+      hint: Recuerda que un carácter en C es tipo char y ocupa un solo carácter.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-snack-categoria
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo tSnack con:
+        - Un texto llamado nombre.
+        - Un carácter llamado categoria.
+
+        Declara dentro del bloque principal una variable llamada snack1 de tipo tSnack.
+      answer: |
+        type
+          tSnack = record
+            nombre: string;
+            categoria: character;
+          end record
+        end type
+
+        algorithm
+          var
+            snack1: tSnack;
+          end var
+        end algorithm
+      hint: El campo categoria es de tipo character (un único símbolo).
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-puesto-precios
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (25) y NUM_PLATOS (4).
+
+        Crea un tipo tPuestoComida con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 25).
+        - Un array de números decimales llamado precios con tamaño NUM_PLATOS.
+
+        Declara dentro de main una variable llamada puesto1 de tipo tPuestoComida.
+      answer: |
+        #define MAX_NOMBRE 25
+        #define NUM_PLATOS 4
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            float precios[NUM_PLATOS];
+        } tPuestoComida;
+
+        int main() {
+            tPuestoComida puesto1;
+            return 0;
+        }
+      hint: Declara las constantes antes del typedef; el array precios es de longitud
+        fija.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-puesto-precios
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante NUM_PLATOS con valor 4.
+
+        Crea un tipo tPuestoComida con:
+        - Un texto llamado nombre.
+        - Un array de números reales llamado precios con tamaño NUM_PLATOS.
+
+        Declara dentro del bloque principal una variable llamada puesto1 de tipo tPuestoComida.
+      answer: |
+        const
+          NUM_PLATOS: integer = 4;
+        end const
+
+        type
+          tPuestoComida = record
+            nombre: string;
+            precios: vector[NUM_PLATOS] of real;
+          end record
+        end type
+
+        algorithm
+          var
+            puesto1: tPuestoComida;
+          end var
+        end algorithm
+      hint: En pseudocódigo usa vector[NUM_PLATOS] of real para el campo precios.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 2
+    explanation:
+      C: "En este nivel aprenderás a **declarar, inicializar y acceder a estructuras
+        (`struct`) en C**, usando ejemplos relacionados con atracciones de parques.
+        \ \nLas estructuras son muy útiles para agrupar información variada bajo un
+        mismo nombre.\n\n### ¿Qué es un `struct`?\nUna estructura (`struct`) te permite
+        agrupar distintos datos bajo un solo tipo.  \nPor ejemplo, para representar
+        una atracción con un nombre, tipo y duración:\n\n```c\ntypedef struct {\n
+        \   char nombre[30];\n    int tipo;\n    int duracion;\n} tAtraccion;\n```\n\nAquí
+        se definen tres campos:  \n- `nombre`: cadena de caracteres.  \n- `tipo`:
+        número entero que representa la categoría.  \n- `duracion`: entero con la
+        duración en minutos.  \n\n---\n\n### Declarar y asignar manualmente\n```c\n#include
+        <string.h>\n\nint main() {\n    tAtraccion a;\n\n    strncpy(a.nombre, \"Montaña
+        Rusa\", 30);\n    a.tipo = 1;\n    a.duracion = 5;\n\n    return 0;\n}\n```\n\n---\n\n###
+        Declarar e inicializar con llaves\n```c\nint main() {\n    tAtraccion a =
+        { \"Torre de Caída\", 2, 3 };\n    return 0;\n}\n```\n\n---\n\n### Acceso
+        a campos\nPara acceder a un campo de una estructura se usa el operador punto
+        (`.`):\n\n```c\n#include <stdio.h>\n#include <string.h>\n\nint main() {\n
+        \   tAtraccion a = { \"Noria\", 3, 4 };\n\n    printf(\"Nombre: %s\\n\", a.nombre);\n
+        \   printf(\"Duración: %d minutos\\n\", a.duracion);\n\n    return 0;\n}\n```\n\n---\n\n###
+        Array de estructuras\nTambién puedes crear un array de `structs`:\n\n```c\n#include
+        <string.h>\n\nint main() {\n    tAtraccion parque[2];\n\n    strncpy(parque[0].nombre,
+        \"Noria\", 30);\n    parque[0].tipo = 3;\n    parque[0].duracion = 4;\n\n
+        \   strncpy(parque[1].nombre, \"Montaña Rusa\", 30);\n    parque[1].tipo =
+        1;\n    parque[1].duracion = 5;\n\n    return 0;\n}\n```\n\nPara acceder a
+        un campo de un elemento concreto:\n```c\nprintf(\"Nombre primera atracción:
+        %s\\n\", parque[0].nombre);\n```\n\n---\n\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n#include <string.h>\n\ntypedef struct {\n    char nombre[30];\n
+        \   int tipo;\n    int duracion;\n} tAtraccion;\n\nint main() {\n    tAtraccion
+        parque[2];\n\n    strncpy(parque[0].nombre, \"Noria\", 30);\n    parque[0].tipo
+        = 3;\n    parque[0].duracion = 4;\n\n    strncpy(parque[1].nombre, \"Montaña
+        Rusa\", 30);\n    parque[1].tipo = 1;\n    parque[1].duracion = 5;\n\n    for
+        (int i = 0; i < 2; i++) {\n        printf(\"Atracción: %s\\n\", parque[i].nombre);\n
+        \       printf(\"Tipo: %d\\n\", parque[i].tipo);\n        printf(\"Duración:
+        %d minutos\\n\\n\", parque[i].duracion);\n    }\n\n    return 0;\n}\n```\n\nEste
+        programa muestra cómo definir, inicializar y recorrer un array de estructuras
+        para representar varias atracciones.\n"
+      Pseudocode: "En pseudocódigo también puedes usar **registros (`record`)** para
+        agrupar datos de una entidad.  \nSon útiles para representar objetos del juego,
+        como atracciones de un parque.\n\n### ¿Qué es un `record`?\nUn `record` es
+        una estructura con diferentes campos:\n\n```pseudocode\ntype\n  tAtraccion
+        = record\n    nombre: string;\n    tipo: integer;\n    duracion: integer;\n
+        \ end record\nend type\n```\n\n---\n\n### Declarar y asignar valores\n```pseudocode\nalgorithm\n
+        \ var\n    a: tAtraccion;\n  end var\n\n  a.nombre := \"Montaña Rusa\";\n
+        \ a.tipo := 1;\n  a.duracion := 5;\nend algorithm\n```\n\n---\n\n### Acceso
+        a campos\nPara acceder a los campos se usa el punto (`.`):\n\n```pseudocode\nalgorithm\n
+        \ var\n    a: tAtraccion;\n  end var\n\n  a.nombre := \"Noria\";\n  a.tipo
+        := 3;\n  a.duracion := 4;\n\n  writeString(a.nombre);\n  writeInteger(a.duracion);\nend
+        algorithm\n```\n\n---\n\n### Array de registros\nTambién puedes crear arrays
+        de registros para almacenar varias atracciones:\n\n```pseudocode\nalgorithm\n
+        \ var\n    parque: vector[2] of tAtraccion;\n  end var\n\n  parque[1].nombre
+        := \"Noria\";\n  parque[1].tipo := 3;\n  parque[1].duracion := 4;\n\n  parque[2].nombre
+        := \"Torre de Caída\";\n  parque[2].tipo := 2;\n  parque[2].duracion := 3;\nend
+        algorithm\n```\n\nPara acceder a un campo de un elemento concreto:\n```pseudocode\nwriteString(parque[1].nombre);\nwriteInteger(parque[1].duracion);\n```\n\n---\n\n###
+        Ejemplo completo\n```pseudocode\ntype\n  tAtraccion = record\n    nombre:
+        string;\n    tipo: integer;\n    duracion: integer;\n  end record\nend type\n\nalgorithm
+        parqueDiversiones\n  var\n    parque: vector[2] of tAtraccion;\n    i: integer;\n
+        \ end var\n\n  parque[1].nombre := \"Noria\";\n  parque[1].tipo := 3;\n  parque[1].duracion
+        := 4;\n\n  parque[2].nombre := \"Montaña Rusa\";\n  parque[2].tipo := 1;\n
+        \ parque[2].duracion := 5;\n\n  for i = 1 to 2 do\n    writeString(\"Atracción:
+        \");\n    writeString(parque[i].nombre);\n    writeString(\", Tipo: \");\n
+        \   writeInteger(parque[i].tipo);\n    writeString(\", Duración: \");\n    writeInteger(parque[i].duracion);\n
+        \   writeString(\" minutos\");\n  end for\nend algorithm\n```\n\nEste algoritmo
+        muestra cómo definir, asignar y recorrer un array de registros que representan
+        varias atracciones del parque.\n"
+    questions:
+    - id: c-4-atraccion-inicializa-imprime
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 30.
+
+        Declara el tipo tAtraccion con los campos exactos:
+        - nombre: cadena de caracteres de tamaño MAX_NOMBRE
+        - alturaMinima: número decimal
+        - enMantenimiento: booleano
+
+        Dentro de main, declara la variable atraccion1 de tipo tAtraccion e inicializa:
+        - nombre = "Cometa"
+        - alturaMinima = 1.20
+        - enMantenimiento = false
+
+        Imprime dos líneas:
+        - "Nombre: x"
+        - "Altura mínima: x" (Con dos decimales)
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 30
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            float alturaMinima;
+            bool enMantenimiento;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            strncpy(atraccion1.nombre, "Cometa", MAX_NOMBRE);
+            atraccion1.alturaMinima = 1.20;
+            atraccion1.enMantenimiento = false;
+
+            printf("Nombre: %s\n", atraccion1.nombre);
+            printf("Altura mínima: %.2f\n", atraccion1.alturaMinima);
+            return 0;
+        }
+      hint: Usa strncpy para copiar al campo nombre y printf en líneas separadas.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: |
+          Nombre: Cometa
+          Altura mínima: 1.20
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-inicializa-imprime
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara el tipo tAtraccion con los campos exactos:
+        - nombre: texto
+        - alturaMinima: real
+        - enMantenimiento: booleano
+
+        En el bloque principal, declara la variable atraccion1 de tipo tAtraccion e inicializa:
+        - nombre := "Cometa"
+        - alturaMinima := 1.20
+        - enMantenimiento := false
+
+        Imprime dos líneas:
+        - "Nombre: x"
+        - "Altura mínima: x"
+      answer: |
+        type
+          tAtraccion = record
+            nombre: string;
+            alturaMinima: real;
+            enMantenimiento: boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+
+          atraccion1.nombre := "Cometa";
+          atraccion1.alturaMinima := 1.20;
+          atraccion1.enMantenimiento := false;
+
+          writeString("Nombre: ");
+          writeString(atraccion1.nombre);
+          writeString("Altura mínima: ");
+          writeReal(atraccion1.alturaMinima);
+        end algorithm
+      hint: Cada operación en su propia línea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-con-enum-imprime
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 25.
+
+        Declara un tipo enumerado tTipoAtraccion con los valores RUEDA, BARCA y SIMULADOR.
+
+        Declara el tipo tAtraccion con:
+        - nombre: cadena de caracteres de tamaño MAX_NOMBRE
+        - tipo: tTipoAtraccion
+
+        Dentro de main, declara la variable atraccion1 de tipo tAtraccion e inicializa:
+        - nombre = "Rueda Panorámica"
+        - tipo = RUEDA
+
+        Imprime una sola línea con el formato "Tipo: x" mostrando Rueda, Barca o Simulador en texto.
+
+        Debes mapear el enum a string utilizando if else if.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 25
+
+        typedef enum { RUEDA, BARCA, SIMULADOR } tTipoAtraccion;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tTipoAtraccion tipo;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            strncpy(atraccion1.nombre, "Rueda Panorámica", MAX_NOMBRE);
+            atraccion1.tipo = RUEDA;
+
+            if (atraccion1.tipo == RUEDA) {
+                printf("Tipo: Rueda\n");
+            } else if (atraccion1.tipo == BARCA) {
+                printf("Tipo: Barca\n");
+            } else {
+                printf("Tipo: Simulador\n");
+            }
+            return 0;
+        }
+      hint: Hay 3 posibles casos en los que deberás imprimir el mensaje usando if
+        else if.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Tipo: Rueda
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-con-enum
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara el tipo enumerado tTipoAtraccion con los valores RUEDA, BARCA y SIMULADOR.
+        Declara el tipo tAtraccion con:
+        - nombre: texto
+        - tipo: tTipoAtraccion
+
+        En el bloque principal, declara la variable atraccion1 de tipo tAtraccion e inicializa:
+        - nombre := "Rueda Panorámica"
+        - tipo := RUEDA
+
+        Imprime dos líneas:
+        - "Nombre: x"
+        - "Tipo: x" (imprime el valor del enumerado tal cual)
+      answer: |
+        type
+          tTipoAtraccion = { RUEDA, BARCA, SIMULADOR }
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            tipo: tTipoAtraccion;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+
+          atraccion1.nombre := "Rueda Panorámica";
+          atraccion1.tipo := RUEDA;
+
+          writeString("Nombre: ");
+          writeString(atraccion1.nombre);
+          writeString("Tipo: ");
+          writeEnum(atraccion1.tipo);
+        end algorithm
+      hint: Usa writeEnum para mostrar el enumerado.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-horario-inicializa
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (30) y MAX_HORA (6).
+
+        Declara tHorario con:
+        - apertura: cadena de tamaño MAX_HORA
+        - cierre: cadena de tamaño MAX_HORA
+
+        Declara tAtraccion con:
+        - nombre: cadena de tamaño MAX_NOMBRE
+        - horario: tHorario
+
+        Dentro de main, declara atraccion1 e inicializa:
+        - nombre = "Dragón"
+        - horario - apertura = "10:00"
+        - horario - cierre = "19:30"
+
+        Imprime: "Cierra a: x"
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 30
+        #define MAX_HORA 6
+
+        typedef struct {
+            char apertura[MAX_HORA];
+            char cierre[MAX_HORA];
+        } tHorario;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tHorario horario;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            strncpy(atraccion1.nombre, "Dragón", MAX_NOMBRE);
+            strncpy(atraccion1.horario.apertura, "10:00", MAX_HORA);
+            strncpy(atraccion1.horario.cierre, "19:30", MAX_HORA);
+
+            printf("Cierra a: %s\n", atraccion1.horario.cierre);
+            return 0;
+        }
+      hint: Usa strncpy con el tamaño adecuado para cada campo.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Cierra a: 19:30
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-horario-inicializa
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara tHorario con:
+        - apertura: texto
+        - cierre: texto
+
+        Declara tAtraccion con:
+        - nombre: texto
+        - horario: tHorario
+
+        En el bloque principal, declara atraccion1 e inicializa:
+        - nombre := "Dragón"
+        - horario - apertura := "10:00"
+        - horario - cierre := "19:30"
+
+        Imprime: "Cierra a: x"
+      answer: |
+        type
+          tHorario = record
+            apertura: string;
+            cierre: string;
+          end record
+
+          tAtraccion = record
+            nombre: string;
+            horario: tHorario;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+
+          atraccion1.nombre := "Dragón";
+          atraccion1.horario.apertura := "10:00";
+          atraccion1.horario.cierre := "19:30";
+
+          writeString("Cierra a: ");
+          writeString(atraccion1.horario.cierre);
+        end algorithm
+      hint: Accede a campos anidados con punto.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-array-atracciones-suma-capacidad
+      language: C
+      week: 4
+      prompt: "Declara las constantes MAX_NOMBRE (20) y MAX_ATRACCIONES (2).\n\nDeclara
+        tAtraccion con:\n- nombre: cadena de tamaño MAX_NOMBRE\n- capacidadMaxima:
+        entero\n\nDentro de main, declara lista (array de tAtraccion con MAX_ATRACCIONES)
+        e inicializa:\n- lista 0 - nombre = \"Lanza\" y lista 0 - capacidadMaxima
+        = 12\n- lista 1 - nombre = \"Náutica\" y lista 1 - capacidadMaxima = 8\n\nDeclara
+        totalCapacidad (entero) y guarda la suma de ambas capacidades. \n\nImprime
+        \"Total: x\".\n"
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 20
+        #define MAX_ATRACCIONES 2
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            int capacidadMaxima;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion lista[MAX_ATRACCIONES];
+
+            strncpy(lista[0].nombre, "Lanza", MAX_NOMBRE);
+            lista[0].capacidadMaxima = 12;
+
+            strncpy(lista[1].nombre, "Náutica", MAX_NOMBRE);
+            lista[1].capacidadMaxima = 8;
+
+            int totalCapacidad = lista[0].capacidadMaxima + lista[1].capacidadMaxima;
+            printf("Total: %d\n", totalCapacidad);
+            return 0;
+        }
+      hint: Suma campos enteros y muestra el resultado.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Total: 20
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-array-atracciones-suma-capacidad
+      language: Pseudocode
+      week: 4
+      prompt: "Declara la constante MAX_ATRACCIONES con valor 2.\n\nDeclara tAtraccion
+        con:\n- nombre: texto\n- capacidadMaxima: entero\n\nEn el bloque principal,
+        declara lista (vector[MAX_ATRACCIONES] de tAtraccion) e inicializa:\n- lista
+        0 - nombre = \"Lanza\" y lista 0 - capacidadMaxima = 12\n- lista 1 - nombre
+        = \"Náutica\"; lista 1 - capacidadMaxima = 8\n\nDeclara totalCapacidad (entero)
+        como la suma de ambas capacidades. \n\nImprime \"Total: x\".\n"
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 2;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            capacidadMaxima: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            lista: vector[MAX_ATRACCIONES] of tAtraccion;
+            totalCapacidad: integer;
+          end var
+
+          lista[1].nombre := "Lanza";
+          lista[1].capacidadMaxima := 12;
+          lista[2].nombre := "Náutica";
+          lista[2].capacidadMaxima := 8;
+
+          totalCapacidad := lista[1].capacidadMaxima + lista[2].capacidadMaxima;
+
+          writeString("Total: ");
+          writeInteger(totalCapacidad);
+        end algorithm
+      hint: Índices desde 1 en pseudocódigo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-precios-promedio
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (25) y NUM_PRECIOS (3).
+
+        Declara tPuestoComida con:
+        - nombre: cadena de tamaño MAX_NOMBRE
+        - precios: array de decimales de tamaño NUM_PRECIOS
+
+        Dentro de main, declara puesto1 e inicializa:
+        - nombre = "Taco Loco"
+        - precios = (3.5, 4.0, 2.5)
+
+        Calcula el promedio en la variable promedio (decimal) e imprime "Promedio: x" con un decimal.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 25
+        #define NUM_PRECIOS 3
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            float precios[NUM_PRECIOS];
+        } tPuestoComida;
+
+        int main() {
+            tPuestoComida puesto1;
+            strncpy(puesto1.nombre, "Taco Loco", MAX_NOMBRE);
+            puesto1.precios[0] = 3.5;
+            puesto1.precios[1] = 4.0;
+            puesto1.precios[2] = 2.5;
+
+            float promedio = (puesto1.precios[0] + puesto1.precios[1] + puesto1.precios[2]) / 3;
+            printf("Promedio: %.1f\n", promedio);
+            return 0;
+        }
+      hint: El promedio se calcula con la suma de todos los precios dividido entre
+        3. Utiliza paréntesis en la suma.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Promedio: 3.3
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-precios-promedio
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante NUM_PRECIOS con valor 3.
+
+        Declara tPuestoComida con:
+        - nombre: texto
+        - precios: vector[NUM_PRECIOS] de reales
+
+        En el bloque principal, declara puesto1 e inicializa:
+        - nombre = "Taco Loco"
+        - precios = (3.5, 4.0, 2.5)
+
+        Calcula promedio (real) como la media de los tres precios e imprime "Promedio: x".
+      answer: |
+        const
+          NUM_PRECIOS: integer = 3;
+        end const
+
+        type
+          tPuestoComida = record
+            nombre: string;
+            precios: vector[NUM_PRECIOS] of real;
+          end record
+        end type
+
+        algorithm
+          var
+            puesto1: tPuestoComida;
+            promedio: real;
+          end var
+
+          puesto1.nombre := "Taco Loco";
+          puesto1.precios[1] := 3.5;
+          puesto1.precios[2] := 4.0;
+          puesto1.precios[3] := 2.5;
+
+          promedio := (puesto1.precios[1] + puesto1.precios[2] + puesto1.precios[3]) / 3;
+
+          writeString("Promedio: ");
+          writeReal(promedio);
+        end algorithm
+      hint: Una sentencia por línea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-ficha-booleano-ternario
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 30.
+
+        Declara tFichaSeguridad con:
+        - inspector: cadena de tamaño MAX_NOMBRE
+        - puntaje: decimal
+        - aprobada: booleano
+
+        Dentro de main, declara ficha1 e inicializa:
+        - inspector = "María"
+        - puntaje = 8.7
+        - aprobada = true
+
+        Imprime "Estado: Aprobada" si aprobada es true, o "Estado: Rechazada" si es false usando operador ternario.
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 30
+
+        typedef struct {
+            char inspector[MAX_NOMBRE];
+            float puntaje;
+            bool aprobada;
+        } tFichaSeguridad;
+
+        int main() {
+            tFichaSeguridad ficha1;
+            strncpy(ficha1.inspector, "María", MAX_NOMBRE);
+            ficha1.puntaje = 8.7;
+            ficha1.aprobada = true;
+
+            printf("Estado: %s\n", ficha1.aprobada ? "Aprobada" : "Rechazada");
+            return 0;
+        }
+      hint: Este ejercicio usa ternario.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Estado: Aprobada
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-ficha-booleano
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara tFichaSeguridad con:
+        - inspector: texto
+        - puntaje: real
+        - aprobada: booleano
+
+        En el bloque principal, declara ficha1 e inicializa:
+        - inspector := "María"
+        - puntaje := 8.7
+        - aprobada := true
+
+        Imprime:
+        - "Inspector: x"
+        - "Aprobada: x" (true o false)
+      answer: |
+        type
+          tFichaSeguridad = record
+            inspector: string;
+            puntaje: real;
+            aprobada: boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            ficha1: tFichaSeguridad;
+          end var
+
+          ficha1.inspector := "María";
+          ficha1.puntaje := 8.7;
+          ficha1.aprobada := true;
+
+          writeString("Inspector: ");
+          writeString(ficha1.inspector);
+          writeString("Aprobada: ");
+          writeBoolean(ficha1.aprobada);
+        end algorithm
+      hint: No hay operador ternario en pseudocódigo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-mapa-ocupacion-contar
+      language: C
+      week: 4
+      prompt: "Declara las constantes MAX_NOMBRE (20), FILAS (2) y COLUMNAS (2).\n\nDeclara
+        tMapaZona con:\n- nombreZona: cadena de tamaño MAX_NOMBRE\n- ocupacion: matriz
+        booleana de tamaño FILAS x COLUMNAS\n\nEn main, declara mapa1 e inicializa:\n-
+        nombreZona = \"Zona A\"\n- ocupacion 0-0 = true\n- ocupacion 0-1 = false\n-
+        ocupacion 1-0 = true\n- ocupacion 1-1 = true\n\nDeclara ocupadas (entero),
+        inicializa en 0 y cuenta cuántas casillas true hay con if y sumas ++ (sin
+        bucles ni operador ternario). \n\nImprime \"Ocupadas: x\".\n"
+      answer: "#include <stdio.h>\n#include <stdbool.h>\n#include <string.h>\n\n#define
+        MAX_NOMBRE 20\n#define FILAS 2\n#define COLUMNAS 2\n\ntypedef struct {\n    char
+        nombreZona[MAX_NOMBRE];\n    bool ocupacion[FILAS][COLUMNAS];\n} tMapaZona;\n\nint
+        main() {\n    tMapaZona mapa1;\n    strncpy(mapa1.nombreZona, \"Zona A\",
+        MAX_NOMBRE);\n    mapa1.ocupacion[0][0] = true;\n    mapa1.ocupacion[0][1]
+        = false;\n    mapa1.ocupacion[1][0] = true;\n    mapa1.ocupacion[1][1] = true;\n\n
+        \   int ocupadas = 0;\n    if (mapa1.ocupacion[0][0]) { \n      ocupadas++;
+        \n    }\n    if (mapa1.ocupacion[0][1]) { \n      ocupadas++; \n    }\n    if
+        (mapa1.ocupacion[1][0]) { \n      ocupadas++; \n    }\n    if (mapa1.ocupacion[1][1])
+        { \n      ocupadas++; \n    }\n\n    printf(\"Ocupadas: %d\\n\", ocupadas);\n
+        \   return 0;\n}\n"
+      hint: Usa if y acumulación con ++; no uses operador ternario.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Ocupadas: 3
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-mapa-ocupacion-contar
+      language: Pseudocode
+      week: 4
+      prompt: "Declara las constantes FILAS (2) y COLUMNAS (2).\n\nDeclara tMapaZona
+        con:\n- nombreZona: texto\n- ocupacion: matriz booleana FILAS x COLUMNAS\n\nEn
+        el bloque principal, declara mapa1 e inicializa:\n- nombreZona = \"Zona A\"\n-
+        ocupacion 0-0 = true\n- ocupacion 0-1 = false\n- ocupacion 1-0 = true\n- ocupacion
+        1-1 = true\n\nDeclara ocupadas (entero), inicializa en 0 y cuenta cuántas
+        casillas true hay con if (sin bucles). \n\nImprime \"Ocupadas: x\".\n"
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 2;
+        end const
+
+        type
+          tMapaZona = record
+            nombreZona: string;
+            ocupacion: vector[FILAS][COLUMNAS] of boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            mapa1: tMapaZona;
+            ocupadas: integer;
+          end var
+
+          mapa1.nombreZona := "Zona A";
+          mapa1.ocupacion[1][1] := true;
+          mapa1.ocupacion[1][2] := false;
+          mapa1.ocupacion[2][1] := true;
+          mapa1.ocupacion[2][2] := true;
+
+          ocupadas := 0;
+          if mapa1.ocupacion[1][1] = true then
+            ocupadas := ocupadas + 1;
+          end if
+          if mapa1.ocupacion[1][2] = true then
+            ocupadas := ocupadas + 1;
+          end if
+          if mapa1.ocupacion[2][1] = true then
+            ocupadas := ocupadas + 1;
+          end if
+          if mapa1.ocupacion[2][2] = true then
+            ocupadas := ocupadas + 1;
+          end if
+
+          writeString("Ocupadas: ");
+          writeInteger(ocupadas);
+        end algorithm
+      hint: 'Forma correcta del if en pseudocódigo: if … then / end if.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-dificultad-a-texto
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 20.
+
+        Declara tDificultad con valores BAJA, MEDIA y ALTA.
+
+        Declara tAtraccion con:
+        - nombre: cadena de tamaño MAX_NOMBRE
+        - dificultad: tDificultad
+
+        Dentro de main, declara atraccion1 e inicializa:
+        - nombre = "Vértigo"
+        - dificultad = ALTA
+
+        Declara tipoStr (cadena de tamaño 10) y copia "Baja", "Media" o "Alta" según la dificultad de la atracción usando if/else. Imprime "Dif: x".
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 20
+
+        typedef enum { BAJA, MEDIA, ALTA } tDificultad;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tDificultad dificultad;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            strncpy(atraccion1.nombre, "Vértigo", MAX_NOMBRE);
+            atraccion1.dificultad = ALTA;
+
+            char tipoStr[10];
+            if (atraccion1.dificultad == BAJA) {
+                strncpy(tipoStr, "Baja", 10);
+            } else if (atraccion1.dificultad == MEDIA) {
+                strncpy(tipoStr, "Media", 10);
+            } else {
+                strncpy(tipoStr, "Alta", 10);
+            }
+
+            printf("Dif: %s\n", tipoStr);
+            return 0;
+        }
+      hint: Usa if/else para seleccionar la cadena y strncpy para copiarla.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Dif: Alta
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-dificultad-texto
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara tDificultad con valores BAJA, MEDIA y ALTA.
+        Declara tAtraccion con:
+        - nombre: texto
+        - dificultad: tDificultad
+
+        En el bloque principal, declara atraccion1 e inicializa:
+        - nombre := "Vértigo"
+        - dificultad := ALTA
+
+        Declara tipoStr (texto) y asígnale:
+        - "Baja" si la dificultad es BAJA, "Media" si es MEDIA, o "Alta" si es ALTA.
+        Imprime "Dif: x".
+      answer: |
+        type
+          tDificultad = { BAJA, MEDIA, ALTA }
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            dificultad: tDificultad;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+            tipoStr: string;
+          end var
+
+          atraccion1.nombre := "Vértigo";
+          atraccion1.dificultad := ALTA;
+
+          if atraccion1.dificultad = BAJA then
+            tipoStr := "Baja";
+          else
+            if atraccion1.dificultad = MEDIA then
+              tipoStr := "Media";
+            else
+                tipoStr := "Alta";
+            end if
+          end if
+
+          writeString("Dif: ");
+          writeString(tipoStr);
+        end algorithm
+      hint: Un if por caso también es válido en pseudocódigo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-precio-mayor
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (20) y NUM_PRECIOS (3).
+
+        Declara tPuestoComida con:
+        - nombre: cadena de tamaño MAX_NOMBRE
+        - precios: array de decimales de tamaño NUM_PRECIOS
+
+        En main, declara puesto1 e inicializa:
+        - nombre = "Papas Xpress"
+        - precios = (2.5, 3.0, 1.8)
+
+        Declara mayor (decimal) y calcula el mayor de los tres precios usando comparaciones e if (sin bucles ni operador ternario). Imprime "Mayor: x" con un decimal.
+      answer: "#include <stdio.h>\n#include <string.h>\n\n#define MAX_NOMBRE 20\n#define
+        NUM_PRECIOS 3\n\ntypedef struct {\n    char nombre[MAX_NOMBRE];\n    float
+        precios[NUM_PRECIOS];\n} tPuestoComida;\n\nint main() {\n    tPuestoComida
+        puesto1;\n    strncpy(puesto1.nombre, \"Papas Xpress\", MAX_NOMBRE);\n    puesto1.precios[0]
+        = 2.5;\n    puesto1.precios[1] = 3.0;\n    puesto1.precios[2] = 1.8;\n\n    float
+        mayor = puesto1.precios[0];\n    if (puesto1.precios[1] > mayor) { \n      mayor
+        = puesto1.precios[1]; \n    }\n    if (puesto1.precios[2] > mayor) { \n      mayor
+        = puesto1.precios[2]; \n    }\n\n    printf(\"Mayor: %.1f\\n\", mayor);\n
+        \   return 0;\n}\n"
+      hint: Actualiza mayor si encuentras un valor superior.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Mayor: 3.0
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-precio-mayor
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante NUM_PRECIOS (3).
+
+        Declara tPuestoComida con:
+        - nombre: texto
+        - precios: vector[NUM_PRECIOS] de reales
+
+        En el bloque principal, declara puesto1 e inicializa:
+        - puesto1.nombre := "Papas Xpress"
+        - puesto1.precios[1] := 2.5
+        - puesto1.precios[2] := 3.0
+        - puesto1.precios[3] := 1.8
+
+        Declara mayor (real) y calcula el mayor de los tres precios con comparaciones (sin bucles). Imprime "Mayor: x".
+      answer: |
+        const
+          NUM_PRECIOS: integer = 3;
+        end const
+
+        type
+          tPuestoComida = record
+            nombre: string;
+            precios: vector[NUM_PRECIOS] of real;
+          end record
+        end type
+
+        algorithm
+          var
+            puesto1: tPuestoComida;
+            mayor: real;
+          end var
+
+          puesto1.nombre := "Papas Xpress";
+          puesto1.precios[1] := 2.5;
+          puesto1.precios[2] := 3.0;
+          puesto1.precios[3] := 1.8;
+
+          mayor := puesto1.precios[1];
+          if puesto1.precios[2] > mayor then
+            mayor := puesto1.precios[2];
+          end if
+          if puesto1.precios[3] > mayor then
+            mayor := puesto1.precios[3];
+          end if
+
+          writeString("Mayor: ");
+          writeReal(mayor);
+        end algorithm
+      hint: Una sentencia por línea; if con then / end if.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-cartelera-inicializa-imprime-primera
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (20) y MAX_ATRACCIONES (2).
+
+        Declara tAtraccion con:
+        - nombre: cadena de tamaño MAX_NOMBRE
+        - duracionMinutos: entero
+
+        En main, declara cartelera (array de tAtraccion con MAX_ATRACCIONES) e inicializa:
+        - cartelera 0 - nombre = "Fantasmagoría" y cartelera 0 - duracionMinutos = 7
+        - cartelera 1 - nombre = "Aqua Rush" y cartelera 1 - duracionMinutos = 12
+
+        Imprime una línea con el formato: "Primera: x (y min)" mostrando el nombre y la duración de la primera atracción.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 20
+        #define MAX_ATRACCIONES 2
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            int duracionMinutos;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion cartelera[MAX_ATRACCIONES];
+
+            strncpy(cartelera[0].nombre, "Fantasmagoría", MAX_NOMBRE);
+            cartelera[0].duracionMinutos = 7;
+
+            strncpy(cartelera[1].nombre, "Aqua Rush", MAX_NOMBRE);
+            cartelera[1].duracionMinutos = 12;
+
+            printf("Primera: %s (%d min)\n", cartelera[0].nombre, cartelera[0].duracionMinutos);
+            return 0;
+        }
+      hint: Recuerda usar strncpy para los nombres.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Primera: Fantasmagoría (7 min)
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-cartelera-inicializa-imprime-primera
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 2.
+
+        Declara tAtraccion con:
+        - nombre: texto
+        - duracionMinutos: entero
+
+        En el bloque principal, declara cartelera (vector de MAX_ATRACCIONES) e inicializa:
+        - cartelera 0 - nombre = "Fantasmagoría" y cartelera 0 - duracionMinutos = 7
+        - cartelera 1 - nombre = "Aqua Rush" y cartelera 1 - duracionMinutos = 12
+
+        Imprime una línea con el formato: "Primera: x (y min)" mostrando el nombre y duración de la primera atracción.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 2;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            duracionMinutos: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            cartelera: vector[MAX_ATRACCIONES] of tAtraccion;
+          end var
+
+          cartelera[1].nombre := "Fantasmagoría";
+          cartelera[1].duracionMinutos := 7;
+          cartelera[2].nombre := "Aqua Rush";
+          cartelera[2].duracionMinutos := 12;
+
+          writeString("Primera: ");
+          writeString(cartelera[1].nombre);
+          writeString(" (");
+          writeInteger(cartelera[1].duracionMinutos);
+          writeString(" min)");
+        end algorithm
+      hint: En pseudocódigo imprimimos por partes, cada llamada en su línea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 3
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **estructuras (`struct`) más avanzadas
+        en C**, incluyendo:\n- **enumerados (`enum`)** para representar categorías
+        de atracciones,  \n- **arrays de estructuras** para almacenar varias entidades,
+        \ \n- **estructuras anidadas** (structs dentro de structs),  \n- y su uso
+        con **bucles** y **estructuras de control** (`if`, `while`, `for`, `switch`)
+        para realizar operaciones.\n\nEstos conceptos son esenciales para modelar
+        un parque de atracciones en un programa.\n\n---\n\n### Enumerados\nUn `enum`
+        define un conjunto de valores con nombres más claros que los números.  \nPor
+        ejemplo, los tipos de atracciones:\n\n```c\ntypedef enum {\n    MONTANA_RUSA,\n
+        \   CARRUSEL,\n    SIMULADOR\n} tTipoAtraccion;\n```\n\n---\n\n### Estructuras
+        básicas\nUn `struct` agrupa datos relacionados.  \nUna atracción puede tener
+        nombre, tipo y duración:\n\n```c\n#define MAX_NOMBRE 20\n\ntypedef struct
+        {\n    char nombre[MAX_NOMBRE];\n    tTipoAtraccion tipo;\n    int duracionMinutos;\n}
+        tAtraccion;\n```\n\n---\n\n### Arrays de estructuras\nPara manejar varias
+        atracciones a la vez, usamos un array:\n\n```c\n#define MAX_ATRACCIONES 3\n\nint
+        main() {\n    tAtraccion atracciones[MAX_ATRACCIONES];\n    return 0;\n}\n```\n\n---\n\n###
+        Estructuras anidadas\nUna estructura puede contener otra.  \nPor ejemplo,
+        cada atracción puede tener un horario con apertura y cierre:\n\n```c\n#define
+        MAX_HORA 6\n\ntypedef struct {\n    char apertura[MAX_HORA];\n    char cierre[MAX_HORA];\n}
+        tHorario;\n\ntypedef struct {\n    char nombre[MAX_NOMBRE];\n    tTipoAtraccion
+        tipo;\n    int duracionMinutos;\n    tHorario horario;\n} tAtraccion;\n```\n\n---\n\n###
+        Bucles con estructuras\nPodemos recorrer arrays de `structs` con `for` o `while`
+        para pedir datos y realizar cálculos:\n\n```c\nint main() {\n    tAtraccion
+        atracciones[MAX_ATRACCIONES];\n    int i, totalDuracion = 0;\n\n    for(i
+        = 0; i < MAX_ATRACCIONES; i++) {\n        printf(\"Duración (min): \");\n
+        \       scanf(\"%d\", &atracciones[i].duracionMinutos);\n        totalDuracion
+        += atracciones[i].duracionMinutos;\n    }\n\n    printf(\"Total: %d\\n\",
+        totalDuracion);\n    return 0;\n}\n```\n\n---\n\n### Condicionales y switch\nPodemos
+        tomar decisiones con `if` y `switch`.  \nEjemplo de menú con `do while`:\n\n```c\nint
+        main() {\n    int opcion;\n    do {\n        printf(\"Opción (1=MONTANA_RUSA,2=CARRUSEL,3=SIMULADOR,0=Salir):
+        \");\n        scanf(\"%d\", &opcion);\n\n        switch(opcion) {\n            case
+        1: printf(\"Montaña rusa\\n\"); break;\n            case 2: printf(\"Carrusel\\n\");
+        break;\n            case 3: printf(\"Simulador\\n\"); break;\n            case
+        0: printf(\"Saliendo...\\n\"); break;\n            default: printf(\"Inválida\\n\");\n
+        \       }\n    } while(opcion != 0);\n    return 0;\n}\n```\n\n---\n\n###
+        Comparación de cadenas\nPara comparar nombres de atracciones usamos `strcmp`:\n\n```c\nint
+        main() {\n    tAtraccion a1, a2;\n    printf(\"Nombre 1: \");\n    scanf(\"%s\",
+        a1.nombre);\n    printf(\"Nombre 2: \");\n    scanf(\"%s\", a2.nombre);\n\n
+        \   if(strcmp(a1.nombre, a2.nombre) == 0) {\n        printf(\"Iguales\\n\");\n
+        \   } else {\n        printf(\"Diferentes\\n\");\n    }\n    return 0;\n}\n```\n\n---\n\n###
+        Promedios y ternario\nSe puede calcular un promedio y decidir con `?:`:\n\n```c\nint
+        main() {\n    tAtraccion atracciones[MAX_ATRACCIONES];\n    int i, suma =
+        0;\n    float promedio;\n\n    for(i = 0; i < MAX_ATRACCIONES; i++) {\n        printf(\"Duración
+        (min): \");\n        scanf(\"%d\", &atracciones[i].duracionMinutos);\n        suma
+        += atracciones[i].duracionMinutos;\n    }\n\n    promedio = suma / (float)MAX_ATRACCIONES;\n
+        \   printf(\"Promedio: %.1f\\n\", promedio);\n    printf(\"%s\\n\", (promedio
+        >= 120.0) ? \"Larga\" : \"Corta\");\n\n    return 0;\n}\n```\n\n---\n\n###
+        Ejemplo completo\n```c\n#include <stdio.h>\n#include <string.h>\n#include
+        <stdbool.h>\n\n#define MAX_ATRACCIONES 3\n#define MAX_NOMBRE 20\n#define MAX_HORA
+        6\n\ntypedef enum {\n    MONTANA_RUSA,\n    CARRUSEL,\n    SIMULADOR\n} tTipoAtraccion;\n\ntypedef
+        struct {\n    char apertura[MAX_HORA];\n    char cierre[MAX_HORA];\n} tHorario;\n\ntypedef
+        struct {\n    char nombre[MAX_NOMBRE];\n    tTipoAtraccion tipo;\n    int
+        duracionMinutos;\n    bool enMantenimiento;\n    tHorario horario;\n} tAtraccion;\n\nint
+        main() {\n    tAtraccion atracciones[MAX_ATRACCIONES];\n    int i, totalDuracion
+        = 0, contador = 0;\n\n    for(i = 0; i < MAX_ATRACCIONES; i++) {\n        printf(\"Nombre:
+        \");\n        scanf(\"%s\", atracciones[i].nombre);\n        printf(\"Tipo
+        (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): \");\n        scanf(\"%u\", &atracciones[i].tipo);\n
+        \       printf(\"Duración (min): \");\n        scanf(\"%d\", &atracciones[i].duracionMinutos);\n
+        \       printf(\"¿En mantenimiento? (1 sí / 0 no): \");\n        int temp;
+        scanf(\"%d\", &temp);\n        atracciones[i].enMantenimiento = (temp != 0);\n
+        \       printf(\"Apertura: \");\n        scanf(\"%s\", atracciones[i].horario.apertura);\n
+        \       printf(\"Cierre: \");\n        scanf(\"%s\", atracciones[i].horario.cierre);\n\n
+        \       totalDuracion += atracciones[i].duracionMinutos;\n        if(atracciones[i].enMantenimiento)
+        contador++;\n    }\n\n    float promedio = totalDuracion / (float)MAX_ATRACCIONES;\n
+        \   printf(\"Duración total: %d\\n\", totalDuracion);\n    printf(\"Promedio:
+        %.1f\\n\", promedio);\n    printf(\"%s\\n\", (promedio >= 120.0) ? \"Larga\"
+        : \"Corta\");\n    printf(\"En mantenimiento: %d\\n\", contador);\n\n    for(i
+        = 0; i < MAX_ATRACCIONES; i++) {\n        switch(atracciones[i].tipo) {\n
+        \           case MONTANA_RUSA: printf(\"Montaña rusa\\n\"); break;\n            case
+        CARRUSEL:     printf(\"Carrusel\\n\");     break;\n            case SIMULADOR:
+        \   printf(\"Simulador\\n\");    break;\n        }\n    }\n\n    return 0;\n}\n```\n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **registros (`record`)
+        más avanzados en pseudocódigo**, incluyendo:\n- **enumerados** para tipos
+        de atracción,  \n- **arrays de registros** para manejar varias atracciones,
+        \ \n- **registros anidados**,  \n- y el uso de **bucles y estructuras de control**
+        (`for`, `while`, `switch`, `if`) para operaciones.\n\n---\n\n### Enumerados\n```pseudocode\ntype\n
+        \ tTipoAtraccion = { MONTANA_RUSA, CARRUSEL, SIMULADOR }\nend type\n```\n\n---\n\n###
+        Registros\n```pseudocode\ntype\n  tAtraccion = record\n    nombre: string;\n
+        \   tipo: tTipoAtraccion;\n    duracionMinutos: integer;\n  end record\nend
+        type\n```\n\n---\n\n### Registros anidados\n```pseudocode\ntype\n  tHorario
+        = record\n    apertura: string;\n    cierre: string;\n  end record\nend type\n\ntype\n
+        \ tAtraccion = record\n    nombre: string;\n    tipo: tTipoAtraccion;\n    duracionMinutos:
+        integer;\n    enMantenimiento: boolean;\n    horario: tHorario;\n  end record\nend
+        type\n```\n\n---\n\n### Arrays de registros\n```pseudocode\nconst\n  MAX_ATRACCIONES:
+        integer = 3;\nend const\n\nalgorithm\n  var\n    parque: vector[MAX_ATRACCIONES]
+        of tAtraccion;\n  end var\nend algorithm\n```\n\n---\n\n### Bucles y operaciones\n```pseudocode\nalgorithm\n
+        \ var\n    parque: vector[MAX_ATRACCIONES] of tAtraccion;\n    i, totalDuracion:
+        integer;\n  end var\n\n  totalDuracion := 0;\n  for i := 1 to MAX_ATRACCIONES
+        do\n    writeString(\"Duración (min): \");\n    parque[i].duracionMinutos
+        := readInteger();\n    totalDuracion := totalDuracion + parque[i].duracionMinutos;\n
+        \ end for\n\n  writeString(\"Total: \");\n  writeInteger(totalDuracion);\nend
+        algorithm\n```\n\n---\n\n### Condicionales y switch\n```pseudocode\nalgorithm\n
+        \ var\n    atraccion: tAtraccion;\n  end var\n\n  atraccion.tipo := MONTANA_RUSA;\n\n
+        \ switch atraccion.tipo\n    case MONTANA_RUSA then\n      writeString(\"Montaña
+        rusa\");\n    end case\n    case CARRUSEL then\n      writeString(\"Carrusel\");\n
+        \   end case\n    case SIMULADOR then\n      writeString(\"Simulador\");\n
+        \   end case\n  end switch\nend algorithm\n```\n\n---\n\n### Comparación de
+        cadenas\n```pseudocode\nalgorithm\n  var\n    a1, a2: tAtraccion;\n  end var\n\n
+        \ writeString(\"Nombre 1: \");\n  a1.nombre := readString();\n  writeString(\"Nombre
+        2: \");\n  a2.nombre := readString();\n\n  if a1.nombre = a2.nombre then\n
+        \   writeString(\"Iguales\");\n  else\n    writeString(\"Diferentes\");\n
+        \ end if\nend algorithm\n```\n\n---\n\n### Promedios\n```pseudocode\nalgorithm\n
+        \ var\n    parque: vector[MAX_ATRACCIONES] of tAtraccion;\n    i, suma: integer;\n
+        \   promedio: real;\n  end var\n\n  suma := 0;\n  for i := 1 to MAX_ATRACCIONES
+        do\n    writeString(\"Duración (min): \");\n    parque[i].duracionMinutos
+        := readInteger();\n    suma := suma + parque[i].duracionMinutos;\n  end for\n\n
+        \ promedio := suma / integerToReal(MAX_ATRACCIONES);\n  writeString(\"Promedio:
+        \");\n  writeReal(promedio);\nend algorithm\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\nconst\n
+        \ MAX_ATRACCIONES: integer = 3;\nend const\n\ntype\n  tTipoAtraccion = { MONTANA_RUSA,
+        CARRUSEL, SIMULADOR };\nend type\n\ntype\n  tHorario = record\n    apertura:
+        string;\n    cierre: string;\n  end record\nend type\n\ntype\n  tAtraccion
+        = record\n    nombre: string;\n    tipo: tTipoAtraccion;\n    duracionMinutos:
+        integer;\n    enMantenimiento: boolean;\n    horario: tHorario;\n  end record\nend
+        type\n\nalgorithm parqueDiversiones\n  var\n    parque: vector[MAX_ATRACCIONES]
+        of tAtraccion;\n    i, contador, suma: integer;\n    promedio: real;\n  end
+        var\n\n  suma := 0;\n  contador := 0;\n\n  for i := 1 to MAX_ATRACCIONES do\n
+        \   writeString(\"Nombre: \");\n    parque[i].nombre := readString();\n\n
+        \   writeString(\"Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): \");\n    parque[i].tipo
+        := readEnum();\n\n    writeString(\"Duración (min): \");\n    parque[i].duracionMinutos
+        := readInteger();\n    suma := suma + parque[i].duracionMinutos;\n\n    writeString(\"¿En
+        mantenimiento? (true/false): \");\n    parque[i].enMantenimiento := readBoolean();\n
+        \   if parque[i].enMantenimiento then\n      contador := contador + 1;\n    end
+        if\n\n    writeString(\"Apertura: \");\n    parque[i].horario.apertura :=
+        readString();\n    writeString(\"Cierre: \");\n    parque[i].horario.cierre
+        := readString();\n  end for\n\n  promedio := suma / integerToReal(MAX_ATRACCIONES);\n\n
+        \ writeString(\"Duración total: \");\n  writeInteger(suma);\n  writeString(\"Promedio:
+        \");\n  writeReal(promedio);\n  writeString(\"En mantenimiento: \");\n  writeInteger(contador);\n\n
+        \ for i := 1 to MAX_ATRACCIONES do\n    switch parque[i].tipo\n      case
+        MONTANA_RUSA then\n        writeString(\"Montaña rusa\");\n      end case\n
+        \     case CARRUSEL then\n        writeString(\"Carrusel\");\n      end case\n
+        \     case SIMULADOR then\n        writeString(\"Simulador\");\n      end
+        case\n    end switch\n  end for\nend algorithm\n```\n"
+    questions:
+    - id: c-4-l3-registro-basico-for
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 3 y MAX_NOMBRE con valor 20.
+
+        Crea un tipo enumerado llamado tTipoAtraccion con los valores MONTANA_RUSA, CARRUSEL y SIMULADOR.
+
+        Crea un tipo tAtraccion con los campos exactos:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+        - tipo: de tipo tTipoAtraccion.
+        - duracionMinutos: número entero.
+
+        Dentro de la función principal, declara un array llamado atracciones de tipo tAtraccion con MAX_ATRACCIONES elementos y una variable entera llamada i.
+
+        Recorre el array con un bucle for y, en cada iteración, pide al usuario:
+        - el nombre (muestra "Nombre: ") y guarda el texto en el campo de nombre de la atracción actual,
+        - el tipo (muestra "Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): ") y guarda el valor en el campo de tipo,
+        - la duración en minutos (muestra "Duración (min): ") y guarda el número en el campo correspondiente.
+
+        Al final, muestra por pantalla el nombre de la primera atracción en su propia línea.
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ATRACCIONES 3
+        #define MAX_NOMBRE 20
+
+        typedef enum {
+            MONTANA_RUSA,
+            CARRUSEL,
+            SIMULADOR
+        } tTipoAtraccion;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tTipoAtraccion tipo;
+            int duracionMinutos;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            int i;
+
+            for(i = 0; i < MAX_ATRACCIONES; i++) {
+                printf("Nombre: ");
+                scanf("%s", atracciones[i].nombre);
+                printf("Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): ");
+                scanf("%u", &atracciones[i].tipo);
+                printf("Duración (min): ");
+                scanf("%d", &atracciones[i].duracionMinutos);
+            }
+
+            printf("%s\n", atracciones[0].nombre);
+            return 0;
+        }
+      hint: 'Limita la lectura del nombre con %19s (si MAX_NOMBRE es 20).
+
+        '
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-registro-basico-for
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Tema Parque de Atracciones.
+
+        Declara la constante MAX_ATRACCIONES con valor 3.
+
+        Crea un tipo enumerado llamado tTipoAtraccion con los valores MONTANA_RUSA, CARRUSEL y SIMULADOR.
+
+        Crea un tipo tAtraccion con los campos exactos:
+        - nombre: texto.
+        - tipo: de tipo tTipoAtraccion.
+        - duracionMinutos: número entero.
+
+        En el bloque principal, declara un array llamado atracciones de tipo tAtraccion con MAX_ATRACCIONES elementos y una variable entera i.
+
+        Recorre el array con un bucle for (de 1 a MAX_ATRACCIONES) y, en cada iteración, pide al usuario:
+        - el nombre (muestra "Nombre: ") y guarda el texto en el campo de nombre de la atracción actual,
+        - el tipo (muestra "Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): "); lee un número auxiliar y asígnalo al campo de tipo mediante un switch,
+        - la duración en minutos (muestra "Duración (min): ") y guarda el número en el campo correspondiente.
+
+        Al final, muestra el nombre de la primera atracción en su propia línea.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 3;
+        end const
+
+        type
+          tTipoAtraccion = { MONTANA_RUSA, CARRUSEL, SIMULADOR };
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            tipo: tTipoAtraccion;
+            duracionMinutos: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+            auxTipo: integer;
+          end var
+
+          for i := 1 to MAX_ATRACCIONES do
+            writeString("Nombre: ");
+            atracciones[i].nombre := readString();
+
+            writeString("Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): ");
+            atracciones[i].tipo := readEnum();
+
+            writeString("Duración (min): ");
+            atracciones[i].duracionMinutos := readInteger();
+          end for
+
+          writeString(atracciones[1].nombre);
+        end algorithm
+      hint: 'En pseudocodigo contamos con la funcion readEnum();
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-suma-duraciones-while
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 3 y MAX_NOMBRE con valor 15.
+
+        Define el tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+        - duracionMinutos: número entero.
+
+        En la función principal, declara un array atracciones de tipo tAtraccion. Asigna manualmente las duraciones 10, 15 y 20 a sus tres elementos.
+        Declara una variable entera i y otra llamada totalDuracion inicializada a 0. Usando un bucle while, recorre el array y acumula en totalDuracion
+        la suma de las duraciones. Al terminar, imprime en una línea: "Total: x".
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ATRACCIONES 3
+        #define MAX_NOMBRE 15
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            int duracionMinutos;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            int i = 0;
+            int totalDuracion = 0;
+
+            atracciones[0].duracionMinutos = 10;
+            atracciones[1].duracionMinutos = 15;
+            atracciones[2].duracionMinutos = 20;
+
+            while(i < MAX_ATRACCIONES) {
+                totalDuracion += atracciones[i].duracionMinutos;
+                i++;
+            }
+
+            printf("Total: %d\n", totalDuracion);
+            return 0;
+        }
+      hint: 'Inicializa i en 0 antes del while.
+
+        '
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Total: 45
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-suma-duraciones-while
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 3.
+
+        Define el tipo tAtraccion con:
+        - nombre: texto.
+        - duracionMinutos: número entero.
+
+        En el bloque principal, declara un array atracciones de tipo tAtraccion. Asigna manualmente a sus tres elementos las duraciones 10, 15 y 20.
+        Declara una variable i e inicialízala a 1, y otra llamada totalDuracion con valor 0. Recorre el array con un bucle while sumando las duraciones
+        en totalDuracion. Al final, escribe "Total: " y en la línea siguiente el valor acumulado.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 3;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            duracionMinutos: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+            totalDuracion: integer;
+          end var
+
+          atracciones[1].duracionMinutos := 10;
+          atracciones[2].duracionMinutos := 15;
+          atracciones[3].duracionMinutos := 20;
+
+          i := 1;
+          totalDuracion := 0;
+          while i <= MAX_ATRACCIONES do
+            totalDuracion := totalDuracion + atracciones[i].duracionMinutos;
+            i := i + 1;
+          end while
+
+          writeString("Total: ");
+          writeInteger(totalDuracion);
+        end algorithm
+      hint: 'En pseudocódigo los índices de arrays empiezan en 1.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-menu-switch-do-while
+      language: C
+      week: 4
+      prompt: |
+        Declara un tipo enumerado tTipoAtraccion con los valores MONTANA_RUSA, CARRUSEL y SIMULADOR.
+
+        En la función principal, crea un menú dentro de un bucle do-while:
+        - Pide una opción entera mostrando "Opción (1=MONTANA_RUSA,2=CARRUSEL,3=SIMULADOR,0=Salir): ".
+        - Con un switch, muestra exactamente una de estas líneas según la opción:
+          "Montaña rusa", "Carrusel", "Simulador", "Saliendo..." o "Inválida".
+
+        El bucle termina cuando la opción sea 0.
+      answer: "#include <stdio.h>\n\ntypedef enum {\n    MONTANA_RUSA,\n    CARRUSEL,\n
+        \   SIMULADOR\n} tTipoAtraccion;\n\nint main() {\n    int opcion;\n    do
+        {\n        printf(\"Opción (1=MONTANA_RUSA,2=CARRUSEL,3=SIMULADOR,0=Salir):
+        \");\n        scanf(\"%d\", &opcion);\n\n        switch(opcion) {\n            case
+        1: \n              printf(\"Montaña rusa\\n\"); \n              break;\n            case
+        2: \n              printf(\"Carrusel\\n\"); \n              break;\n            case
+        3: \n              printf(\"Simulador\\n\"); \n              break;\n            case
+        0: \n              printf(\"Saliendo...\\n\"); \n              break;\n            default:
+        \n              printf(\"Inválida\\n\");\n        }\n    } while(opcion !=
+        0);\n    return 0;\n}\n"
+      hint: 'do-while ejecuta el cuerpo al menos una vez.
+
+        '
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-menu-switch-do-while
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un menú en un bucle do-while:
+        - Pide una opción entera mostrando "Opción (1=Montaña rusa,2=Carrusel,3=Simulador,0=Salir): ".
+        - Con un switch, muestra exactamente una de estas líneas:
+          "Montaña rusa", "Carrusel", "Simulador", "Saliendo..." o "Inválida".
+
+        El bucle termina cuando la opción sea 0.
+      answer: |
+        algorithm
+          var
+            opcion: integer;
+          end var
+
+          do
+            writeString("Opción (1=Montaña rusa,2=Carrusel,3=Simulador,0=Salir): ");
+            opcion := readInteger();
+
+            switch opcion
+              case 1 then
+                writeString("Montaña rusa");
+              end case
+              case 2 then
+                writeString("Carrusel");
+              end case
+              case 3 then
+                writeString("Simulador");
+              end case
+              case 0 then
+                writeString("Saliendo...");
+              end case
+              case default then
+                writeString("Inválida");
+              end case
+            end switch
+          while opcion <> 0;
+        end algorithm
+      hint: 'La condición del do-while va después del bloque.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-strcmp-dos-atracciones
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 25.
+
+        Define el tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+
+        En la función main, declara dos variables a1 y a2 de tipo tAtraccion. Pide al usuario dos nombres:
+        - muestra "Nombre 1: " y guarda el texto en el nombre de a1,
+        - muestra "Nombre 2: " y guarda el texto en el nombre de a2.
+
+        Compara ambos nombres y muestra "Iguales" si son exactamente iguales, o "Diferentes" en caso contrario.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 25
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+        } tAtraccion;
+
+        int main() {
+            tAtraccion a1, a2;
+
+            printf("Nombre 1: ");
+            scanf("%s", a1.nombre);
+            printf("Nombre 2: ");
+            scanf("%s", a2.nombre);
+
+            if(strcmp(a1.nombre, a2.nombre) == 0) {
+                printf("Iguales\n");
+            } else {
+                printf("Diferentes\n");
+            }
+
+            return 0;
+        }
+      hint: 'strcmp devuelve 0 si las cadenas son iguales.
+
+        '
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-compara-nombres-simple
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Define el tipo tAtraccion con:
+        - nombre: texto.
+
+        En el bloque principal, declara a1 y a2 de tipo tAtraccion. Pide al usuario dos nombres:
+        - muestra "Nombre 1: " y guarda el texto en el nombre de a1,
+        - muestra "Nombre 2: " y guarda el texto en el nombre de a2.
+
+        Si ambos nombres son iguales, muestra "Iguales"; en caso contrario, muestra "Diferentes".
+      answer: |
+        type
+          tAtraccion = record
+            nombre: string;
+          end record
+        end type
+
+        algorithm
+          var
+            a1: tAtraccion;
+            a2: tAtraccion;
+          end var
+
+          writeString("Nombre 1: ");
+          a1.nombre := readString();
+          writeString("Nombre 2: ");
+          a2.nombre := readString();
+
+          if a1.nombre = a2.nombre then
+            writeString("Iguales");
+          else
+            writeString("Diferentes");
+          end if
+        end algorithm
+      hint: 'La comparación de textos se realiza con = y <>.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-horarios-for
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 2, MAX_NOMBRE con valor 20 y MAX_HORA con valor 6.
+
+        Crea un tipo tHorario con:
+        - apertura: texto con tamaño máximo MAX_HORA.
+        - cierre: texto con tamaño máximo MAX_HORA.
+
+        Crea un tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+        - horario: de tipo tHorario.
+
+        En la función principal, declara un array atracciones de tipo tAtraccion y una variable entera i.
+        Recorre el array con un bucle for y para cada elemento pide al usuario:
+        - el nombre (muestra "Nombre: "),
+        - la hora de apertura (muestra "Apertura: "),
+        - la hora de cierre (muestra "Cierre: ").
+
+        Al finalizar, muestra en una línea la hora de cierre de la segunda atracción.
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ATRACCIONES 2
+        #define MAX_NOMBRE 20
+        #define MAX_HORA 6
+
+        typedef struct {
+            char apertura[MAX_HORA];
+            char cierre[MAX_HORA];
+        } tHorario;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tHorario horario;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            int i;
+            for(i = 0; i < MAX_ATRACCIONES; i++) {
+                printf("Nombre: ");
+                scanf("%s", atracciones[i].nombre);
+                printf("Apertura: ");
+                scanf("%s", atracciones[i].horario.apertura);
+                printf("Cierre: ");
+                scanf("%s", atracciones[i].horario.cierre);
+            }
+            printf("%s\n", atracciones[1].horario.cierre);
+            return 0;
+        }
+      hint: 'Respeta el orden del enunciado para declarar los datos
+
+        '
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-horarios-for
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 2.
+
+        Crea un tipo tHorario con:
+        - apertura: texto.
+        - cierre: texto.
+
+        Crea un tipo tAtraccion con:
+        - nombre: texto.
+        - horario: de tipo tHorario.
+
+        En el bloque principal, declara un array atracciones de tipo tAtraccion y una variable entera i.
+        Recorre el array con un bucle for (de 1 a MAX_ATRACCIONES) y para cada elemento pide al usuario:
+        - el nombre (muestra "Nombre: "),
+        - la hora de apertura (muestra "Apertura: "),
+        - la hora de cierre (muestra "Cierre: ").
+
+        Al finalizar, muestra en una línea la hora de cierre de la segunda atracción.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 2;
+        end const
+
+        type
+          tHorario = record
+            apertura: string;
+            cierre: string;
+          end record
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            horario: tHorario;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+          end var
+
+          for i := 1 to MAX_ATRACCIONES do
+            writeString("Nombre: ");
+            atracciones[i].nombre := readString();
+            writeString("Apertura: ");
+            atracciones[i].horario.apertura := readString();
+            writeString("Cierre: ");
+            atracciones[i].horario.cierre := readString();
+          end for
+
+          writeString(atracciones[2].horario.cierre);
+        end algorithm
+      hint: 'Un campo puede ser otro record anidado.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-contar-mantenimiento-for
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 4 y MAX_NOMBRE con valor 20.
+
+        Crea un tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+        - enMantenimiento: valor lógico.
+
+        En la función principal, declara un array atracciones de tipo tAtraccion, una variable entera i y otra entera contador inicializada a 0.
+        Recorre el array con un bucle for. Para cada posición, pide al usuario:
+        - el nombre (muestra "Nombre: ") y guárdalo en el campo de nombre,
+        - si está en mantenimiento (muestra "¿En mantenimiento? (1 sí / 0 no): "); lee un número y conviértelo a valor lógico para el campo enMantenimiento.
+
+        Luego, con otro bucle for, cuenta cuántas atracciones tienen enMantenimiento verdadero y muestra en una línea: "En mantenimiento: x".
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+
+        #define MAX_ATRACCIONES 4
+        #define MAX_NOMBRE 20
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            bool enMantenimiento;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            int i, contador = 0;
+            int temp;
+
+            for(i = 0; i < MAX_ATRACCIONES; i++) {
+                printf("Nombre: ");
+                scanf("%s", atracciones[i].nombre);
+                printf("¿En mantenimiento? (1 sí / 0 no): ");
+                scanf("%d", &temp);
+                atracciones[i].enMantenimiento = (temp != 0);
+            }
+
+            for(i = 0; i < MAX_ATRACCIONES; i++) {
+                if(atracciones[i].enMantenimiento) {
+                    contador++;
+                }
+            }
+
+            printf("En mantenimiento: %d\n", contador);
+            return 0;
+        }
+      hint: 'Lee 0/1 y asigna al bool con una comparación.
+
+        '
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-contar-mantenimiento-for
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 4.
+
+        Crea un tipo tAtraccion con:
+        - nombre: texto.
+        - enMantenimiento: valor booleano.
+
+        En el bloque principal, declara un array atracciones de tipo tAtraccion, una variable entera i, una entera contador (inicial 0) y una booleana temp.
+        Recorre el array con un bucle for y, para cada posición, pide:
+        - el nombre (muestra "Nombre: ") y guárdalo en el campo de nombre,
+        - si está en mantenimiento (muestra "¿En mantenimiento? (true/false): "); lee el valor en temp y asígnalo al campo enMantenimiento.
+
+        Después, con otro for, cuenta cuántas atracciones tienen enMantenimiento verdadero y escribe:
+        "En mantenimiento: " y, en la línea siguiente, el número contado.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 4;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            enMantenimiento: boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+            contador: integer;
+            temp: boolean;
+          end var
+
+          for i := 1 to MAX_ATRACCIONES do
+            writeString("Nombre: ");
+            atracciones[i].nombre := readString();
+            writeString("¿En mantenimiento? (true/false): ");
+            atracciones[i].enMantenimiento := readBoolean();
+          end for
+
+          contador := 0;
+          for i := 1 to MAX_ATRACCIONES do
+            if atracciones[i].enMantenimiento then
+              contador := contador + 1;
+            end if
+          end for
+
+          writeString("En mantenimiento: ");
+          writeInteger(contador);
+        end algorithm
+      hint: 'Una sentencia por línea en pseudocódigo.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-switch-por-tipo
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 3 y MAX_NOMBRE con valor 18.
+
+        Declara el tipo enumerado tTipoAtraccion con MONTANA_RUSA, CARRUSEL y SIMULADOR.
+        Declara el tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+        - tipo: de tipo tTipoAtraccion.
+
+        En la función principal, lee los datos de tres atracciones usando un bucle for (nombre y tipo numérico 0..2).
+        Después recorre el array con un bucle for y, para cada atracción, muestra exactamente una línea con el texto del tipo:
+        "Montaña rusa", "Carrusel" o "Simulador". Usa un switch para decidir el texto.
+      answer: "#include <stdio.h>\n\n#define MAX_ATRACCIONES 3\n#define MAX_NOMBRE
+        18\n\ntypedef enum {\n    MONTANA_RUSA,\n    CARRUSEL,\n    SIMULADOR\n} tTipoAtraccion;\n\ntypedef
+        struct {\n    char nombre[MAX_NOMBRE];\n    tTipoAtraccion tipo;\n} tAtraccion;\n\nint
+        main() {\n    tAtraccion atracciones[MAX_ATRACCIONES];\n    int i;\n\n    for(i
+        = 0; i < MAX_ATRACCIONES; i++) {\n        printf(\"Nombre: \");\n        scanf(\"%s\",
+        atracciones[i].nombre);\n        printf(\"Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR):
+        \");\n        scanf(\"%u\", &atracciones[i].tipo;\n        \n    }\n\n    for(i
+        = 0; i < MAX_ATRACCIONES; i++) {\n        switch(atracciones[i].tipo) {\n
+        \           case MONTANA_RUSA: \n                printf(\"Montaña rusa\\n\");
+        \n                break;\n            case CARRUSEL:     \n                printf(\"Carrusel\\n\");
+        \    \n                break;\n            case SIMULADOR:    \n                printf(\"Simulador\\n\");
+        \   \n                break;\n            default:           \n                printf(\"Desconocido\\n\");\n
+        \       }\n    }\n    return 0;\n}\n"
+      hint: 'Un switch por cada elemento del array.
+
+        '
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-switch-por-tipo
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 3.
+
+        Declara el tipo enumerado tTipoAtraccion con MONTANA_RUSA, CARRUSEL y SIMULADOR.
+        Declara el tipo tAtraccion con:
+        - nombre: texto.
+        - tipo: de tipo tTipoAtraccion.
+
+        En el bloque principal, pide al usuario los datos de tres atracciones con un bucle (nombre y un número 0..2 para el tipo; usa un switch para asignarlo).
+        Recorre el array con un bucle for y, para cada atracción, muestra exactamente una línea con el texto del tipo:
+        "Montaña rusa", "Carrusel" o "Simulador".
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 3;
+        end const
+
+        type
+          tTipoAtraccion = { MONTANA_RUSA, CARRUSEL, SIMULADOR };
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            tipo: tTipoAtraccion;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+          end var
+
+          for i := 1 to MAX_ATRACCIONES do
+            writeString("Nombre: ");
+            atracciones[i].nombre := readString();
+            writeString("Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): ");
+            atracciones[i].tipo := readEnum();
+          end for
+
+          for i := 1 to MAX_ATRACCIONES do
+            switch atracciones[i].tipo
+              case MONTANA_RUSA then
+                writeString("Montaña rusa");
+              end case
+              case CARRUSEL then
+                writeString("Carrusel");
+              end case
+              case SIMULADOR then
+                writeString("Simulador");
+              end case
+              case default then
+                writeString("Desconocido");
+              end case
+            end switch
+          end for
+        end algorithm
+      hint: 'Mantén una sola salida por línea.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-entrada-hasta-fin-strcmp
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 4 y MAX_NOMBRE con valor 20.
+
+        Define el tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+
+        En la función principal, declara un array atracciones de tipo tAtraccion, un búfer temporal llamado tempNombre (texto de tamaño MAX_NOMBRE) y una variable entera i inicializada a 0.
+
+        Usa un bucle while y repite mientras haya espacio disponible ( i menor que MAX_ATRACCIONES):
+        - pide un nombre mostrando "Nombre (FIN para terminar): " y guárdalo en el búfer temporal,
+        - si el usuario escribe la palabra FIN, detén la repetición (Usando break para detener el bucle),
+        - en caso contrario (No uses else), copia el contenido del búfer temporal al campo de nombre del siguiente elemento y avanza al siguiente índice.
+
+        Al terminar, muestra en una línea "Guardados: x" con la cantidad de elementos almacenados.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_ATRACCIONES 4
+        #define MAX_NOMBRE 20
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            char tempNombre[MAX_NOMBRE];
+            int i = 0;
+
+            while(i < MAX_ATRACCIONES) {
+                printf("Nombre (FIN para terminar): ");
+                scanf("%s", tempNombre);
+                if(strcmp(tempNombre, "FIN") == 0) {
+                    break;
+                }
+                strncpy(atracciones[i].nombre, tempNombre, MAX_NOMBRE);
+                i++;
+            }
+
+            printf("Guardados: %d\n", i);
+            return 0;
+        }
+      hint: 'Usa strcmp para comparar con "FIN" y strncpy para copiar.
+
+        '
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-entrada-hasta-vacio
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 4.
+
+        Define el tipo tAtraccion con:
+        - nombre: texto.
+
+        En el bloque principal, declara un array atracciones de tipo tAtraccion, una variable de texto tempNombre y una entera i inicializada a 1.
+
+        Mientras no se supere el límite y el usuario no escriba "FIN":
+        - pide un nombre mostrando "Nombre (FIN para terminar): " y guárdalo en tempNombre,
+        - si no es "FIN", guarda el texto en el nombre del siguiente elemento del array y avanza al siguiente índice.
+
+        Al terminar, muestra "Guardados: " y, en la línea siguiente, la cantidad de elementos realmente guardados.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 4;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            tempNombre: string;
+            i: integer;
+          end var
+
+          i := 1;
+          tempNombre := "";
+          while (i <= MAX_ATRACCIONES and tempNombre <> "FIN") do
+            writeString("Nombre (FIN para terminar): ");
+            tempNombre := readString();
+            if tempNombre <> "FIN" then
+              atracciones[i].nombre := tempNombre;
+              i := i + 1;
+            end if
+          end while
+
+          writeString("Guardados: ");
+          writeInteger(i - 1);
+        end algorithm
+      hint: 'Controla fin por palabra y por límite.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-promedio-y-ternario
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 3.
+
+        Define el tipo tAtraccion con:
+        - duracionMinutos: número entero.
+
+        En la función principal, declara un array atracciones de tipo tAtraccion, una variable entera i , otra llamada suma con valor inicial 0 y un float promedio.
+        Con un bucle for, pide al usuario tres duraciones mostrando "Duración (min): " y guarda cada valor en el campo de duración del elemento actual, acumulándolo en suma.
+
+        Calcula el promedio como un número decimal dividiendo la suma entre 3 (Castea a float) y muestra:
+        - en una línea: "Promedio: x.x" (con un decimal),
+        - en la siguiente línea, usa un operador ternario para imprimir "Larga" si el promedio es mayor o igual que 120, o "Corta" en caso contrario.
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ATRACCIONES 3
+
+        typedef struct {
+            int duracionMinutos;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            int i;
+            suma = 0;
+            float promedio;
+
+            for(i = 0; i < MAX_ATRACCIONES; i++) {
+                printf("Duración (min): ");
+                scanf("%d", &atracciones[i].duracionMinutos);
+                suma += atracciones[i].duracionMinutos;
+            }
+
+            promedio = suma / (float)3;
+            printf("Promedio: %.1f\n", promedio);
+            printf("%s\n", (promedio >= 120.0) ? "Larga" : "Corta");
+            return 0;
+        }
+      hint: 'Recuerda castear a (float) el numero 3 en la division
+
+        '
+      mode: judge_c
+      tests:
+      - input: ''
+        output: ''
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-promedio-simple
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 3.
+
+        Define el tipo tAtraccion con:
+        - duracionMinutos: número entero.
+
+        En el bloque principal, declara un array atracciones de tipo tAtraccion, una variable entera i, otra entera suma y otra real promedio.
+        Con un bucle for, pide al usuario tres duraciones mostrando "Duración (min): " y guarda cada valor en el campo de duración del elemento actual, acumulándolo en suma.
+
+        Calcula el promedio como número real dividiendo suma entre 3 (Casteando a real) y muestra:
+        - en una línea: "Promedio: "
+        - en la línea siguiente, el valor del promedio.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 3;
+        end const
+
+        type
+          tAtraccion = record
+            duracionMinutos: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+            suma: integer;
+            promedio: real;
+          end var
+
+          suma := 0;
+          for i := 1 to MAX_ATRACCIONES do
+            writeString("Duración (min): ");
+            atracciones[i].duracionMinutos := readInteger();
+            suma := suma + atracciones[i].duracionMinutos;
+          end for
+
+          promedio := suma / integerToReal(3);
+          writeString("Promedio: ");
+          writeReal(promedio);
+        end algorithm
+      hint: 'Una sentencia por línea; no hay operador ternario en pseudocódigo.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+- number: 5
+  explanation: 'Explicacion semana 5
+
+    '
+  levels:
+  - number: 1
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **funciones** en C.  \nLas funciones
+        permiten dividir un programa en partes más pequeñas y reutilizables.  \nEn
+        videojuegos, por ejemplo, puedes tener una función que calcule la vida restante
+        de un personaje o la puntuación obtenida tras derrotar a un enemigo.\n\n###
+        ¿Qué es una función?\nUna **función** es un bloque de código independiente
+        que:\n- Tiene un **nombre** que la identifica.\n- Puede recibir **parámetros
+        de entrada** (valores con los que trabaja).  \n  ⚠️ Los parámetros de entrada
+        son **solo de lectura**: la función puede usarlos internamente, pero no modifica
+        la variable original del programa que la llamó.\n- Devuelve un **valor de
+        salida** (resultado).\n- Puede llamarse tantas veces como quieras.\n\n---\n\n###
+        Prototipos de funciones (encabezados)\nAntes de `main`, se declaran los **prototipos**.
+        \ \nUn prototipo indica el nombre, parámetros y tipo de retorno, pero no contiene
+        el cuerpo.\n\n```c\nint calcularPuntos(int enemigos, int bonus);\nint factorial(int
+        number);\n```\n\n---\n\n### Sintaxis general de una función\n```c\ntipo nombreFuncion(tipo
+        param1, tipo param2, ...) {\n    // instrucciones\n    return valor;\n}\n```\n\n*El
+        `return` devuelve el resultado al punto del programa donde se llamó a la función.*\n\n---\n\n###
+        Ejemplo completo\n```c\n#include <stdio.h>\n\n// Prototipos\nint calcularPuntos(int
+        enemigos, int bonus);\nint factorial(int number);\n\n// main primero\nint
+        main() {\n    int puntos, combinaciones;\n\n    // Uso de función para puntos\n
+        \   puntos = calcularPuntos(5, 20);\n    printf(\"Puntos obtenidos: %d\\n\",
+        puntos);\n\n    // Uso de función factorial para combinaciones de ítems\n
+        \   int totalItems = 6;\n    int itemsElegidos = 2;\n    combinaciones = factorial(totalItems)
+        / \n                    (factorial(itemsElegidos) * factorial(totalItems -
+        itemsElegidos));\n\n    printf(\"Posibles combinaciones: %d\\n\", combinaciones);\n\n
+        \   return 0;\n}\n\n// Implementaciones al final\nint calcularPuntos(int enemigos,
+        int bonus) {\n    int total = enemigos * 10 + bonus;\n    return total;\n}\n\nint
+        factorial(int number) {\n    int fact = 1;\n    int i = 1;\n    while (i <=
+        number) {\n        fact = fact * i;\n        i = i + 1;\n    }\n    return
+        fact;\n}\n```\n\nEste programa sigue la estructura usada en la universidad:
+        \ \nprimero los **prototipos**, luego el `main`, y finalmente las **implementaciones**.
+        \ \n\n**Qué hace el programa:**  \n- Calcula la **puntuación** del jugador
+        con la función `calcularPuntos`, multiplicando enemigos derrotados por 10
+        y sumando un bonus.  \n- Calcula las **combinaciones posibles de ítems** en
+        un inventario usando la función `factorial`.  \n- Muestra por pantalla tanto
+        los puntos obtenidos como el número de combinaciones.  \n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **funciones** en pseudocódigo.
+        \ \nLas funciones permiten dividir un algoritmo en partes más pequeñas y reutilizables.
+        \ \nEn videojuegos, puedes usarlas para calcular la vida restante de un personaje
+        o la puntuación obtenida tras derrotar a enemigos.\n\n### ¿Qué es una función?\nUna
+        **función**:\n- Tiene un **nombre** que la identifica.\n- Puede recibir **parámetros
+        de entrada**.  \n  ⚠️ Los parámetros de entrada son **solo de lectura**: el
+        algoritmo puede usarlos internamente, pero no cambia el valor de la variable
+        que se pasó desde fuera.\n- Devuelve un **valor** como resultado.\n- Puede
+        llamarse tantas veces como quieras.\n\n---\n\n### Prototipos de funciones\nEn
+        pseudocódigo no existen prototipos reales, pero podemos simularlos indicando
+        solo la firma.  \nEsto ayuda a organizar el código cuando usamos varias funciones.\n\n```pseudocode\nfunction
+        calcularPuntos(enemigos: integer, bonus: integer): integer end function\nfunction
+        factorial(number: integer): integer end function\n```\n\n---\n\n### Sintaxis
+        general de una función\n```pseudocode\nfunction nombreFuncion(param1: tipo,
+        param2: tipo): tipo\n  ...\n  return valor\nend function\n```\n\n---\n\n###
+        Ejemplo completo\n```pseudocode\n{ Implementaciones }\nfunction calcularPuntos(enemigos:
+        integer, bonus: integer): integer\n  var\n    total: integer;\n  end var\n
+        \ total := enemigos * 10 + bonus;\n  return total;\nend function\n\nfunction
+        factorial(number: integer): integer\n  var\n    fact: integer;\n    i: integer;\n
+        \ end var\n  fact := 1;\n  i := 1;\n  while i <= number do\n    fact := fact
+        * i;\n    i := i + 1;\n  end while\n  return fact;\nend function\n\nalgorithm
+        funcionesVideojuego\n  var\n    puntos: integer;\n    combinaciones: integer;\n
+        \   totalItems: integer;\n    itemsElegidos: integer;\n  end var\n\n  puntos
+        := calcularPuntos(5, 20);\n  writeString(\"Puntos obtenidos: \");\n  writeInteger(puntos);\n\n
+        \ totalItems := 6;\n  itemsElegidos := 2;\n  combinaciones := factorial(totalItems)
+        div \n                   (factorial(itemsElegidos) * factorial(totalItems
+        - itemsElegidos));\n\n  writeString(\"Posibles combinaciones: \");\n  writeInteger(combinaciones);\nend
+        algorithm\n```\n\n**Qué hace el programa:**  \n- Usa `calcularPuntos` para
+        obtener la **puntuación** del jugador (enemigos derrotados × 10 + bonus).
+        \ \n- Usa `factorial` para calcular las **combinaciones posibles de ítems**
+        en el inventario.  \n- Finalmente escribe en pantalla tanto los puntos obtenidos
+        como el número de combinaciones.  \n"
+    questions:
+    - id: c-5-l1-prototipo-xp
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo de una función llamada addXP que reciba dos enteros xp1 y xp2
+        y devuelva un entero con la experiencia total del jugador.
+        No implementes la función, solo el prototipo.
+      answer: 'int addXP(int xp1, int xp2);
+
+        '
+      hint: Un prototipo siempre incluye tipo de retorno, nombre, parámetros y termina
+        con ;
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-prototipo-xp
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe únicamente el encabezado de una función llamada addXP que reciba dos enteros xp1 y xp2
+        y devuelva un entero con la experiencia total.
+      answer: |
+        function addXP(xp1: integer, xp2: integer): integer
+        end function
+      hint: En pseudocódigo se escribe function ... end function.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-prototipo-bonus
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo de una función llamada applyBonus que reciba un número decimal base
+        y devuelva un número decimal aumentado en 10%.
+        No implementes la función, solo el prototipo.
+      answer: 'float applyBonus(float base);
+
+        '
+      hint: Usa float como tipo de retorno y de parámetro.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-prototipo-bonus
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe solo el encabezado de una función llamada applyBonus que reciba un real base
+        y devuelva un real aumentado en 10%.
+      answer: |
+        function applyBonus(base: real): real
+        end function
+      hint: Aquí solo se pide encabezado, no implementación.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-prototipo-enum-level
+      language: C
+      week: 5
+      prompt: |
+        Declara un tipo enumerado tLevel con los valores NOVATO, GUERRERO y MAESTRO.
+        Luego declara el prototipo de una función llamada levelToValue que reciba un tLevel
+        y devuelva un entero con el valor del nivel (ejemplo: NOVATO=1, GUERRERO=2, MAESTRO=3).
+      answer: |
+        typedef enum { NOVATO, GUERRERO, MAESTRO } tLevel;
+        int levelToValue(tLevel l);
+      hint: Aquí devolvemos un entero en lugar de un string.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-prototipo-enum-level
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo enumerado tLevel con los valores NOVATO, GUERRERO y MAESTRO.
+        Luego escribe solo el encabezado de una función llamada levelToValue que reciba un tLevel
+        y devuelva un entero con el valor del nivel (ejemplo: NOVATO=1, GUERRERO=2, MAESTRO=3).
+      answer: |
+        type
+          tLevel = { NOVATO, GUERRERO, MAESTRO }
+        end type
+
+        function levelToValue(l: tLevel): integer
+        end function
+      hint: El tipo enumerado se define antes de usarlo en la función.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-prototipo-struct-item
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_ITEM = 15.
+        Declara una estructura tItem con los campos:
+        - nombre: array de chars
+        - valor: entero
+        Declara además el prototipo de una función getValor que reciba un tItem
+        y devuelva un entero con su valor.
+      answer: |
+        #define MAX_ITEM 15
+
+        typedef struct {
+            char nombre[MAX_ITEM];
+            int valor;
+        } tItem;
+
+        int getValor(tItem i);
+      hint: Los textos se representan con arrays de char.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-prototipo-struct-item
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo tItem con los campos:
+        - nombre: string
+        - valor: integer
+        Luego escribe el encabezado de una función llamada getValor que reciba un tItem
+        y devuelva un entero con su valor.
+      answer: |
+        type
+          tItem = record
+            nombre: string;
+            valor: integer;
+          end record
+        end type
+
+        function getValor(i: tItem): integer
+        end function
+      hint: El encabezado solo indica parámetros y tipo de retorno.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-main-powerup
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo de una función llamada calcPowerUp que reciba un entero base
+        y devuelva un entero con el doble de poder.
+        En main declara base=40, llama a calcPowerUp y guarda el resultado en power.
+        No implementes la función, solo el prototipo y la llamada.
+      answer: |
+        #include <stdio.h>
+
+        int calcPowerUp(int base);
+
+        int main() {
+            int base = 40;
+            int power = calcPowerUp(base);
+            return 0;
+        }
+      hint: Solo se pide prototipo y llamada, no la implementación.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-main-powerup
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe el encabezado de una función llamada calcPowerUp que reciba un entero base
+        y devuelva un entero con el doble de poder.
+        En el bloque principal declara base=40, llama a calcPowerUp y guarda el resultado en power.
+        No implementes la función.
+      answer: |
+        function calcPowerUp(base: integer): integer
+        end function
+
+        algorithm
+          var
+            base: integer;
+            power: integer;
+          end var
+
+          base := 40;
+          power := calcPowerUp(base);
+        end algorithm
+      hint: Aquí solo se pide encabezado y llamada, no implementación.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-funcion-critical
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo de una función llamada criticalHit que reciba un número decimal dmg
+        y devuelva un número decimal.
+        Implementa la función devolviendo dmg * 1.5 (aumenta el daño en 50%).
+      answer: |
+        float criticalHit(float dmg);
+
+        float criticalHit(float dmg) {
+            return dmg * 1.5;
+        }
+      hint: Incluye prototipo antes de la implementación.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-funcion-critical
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe el encabezado de una función llamada criticalHit que reciba un real dmg
+        y devuelva un real.
+        Implementa la función devolviendo dmg * 1.5.
+      answer: |
+        function criticalHit(dmg: real): real
+          return dmg * 1.5;
+        end function
+      hint: Aquí sí se incluye return dentro de la función.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-funcion-checkmana
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tMage con el campo mana (entero).
+        Declara el prototipo de una función hasMana que reciba un tMage
+        y devuelva un entero (1 si mana > 0, 0 si no).
+        En main declara un mago con mana=20 usando {}, llama a hasMana y guarda el resultado en estado.
+        Implementa la función.
+      answer: |
+        #include <stdio.h>
+
+        typedef struct {
+            int mana;
+        } tMage;
+
+        int hasMana(tMage m);
+
+        int main() {
+            tMage mago = {20};
+            int estado = hasMana(mago);
+            return 0;
+        }
+
+        int hasMana(tMage m) {
+            if(m.mana > 0) return 1;
+            else return 0;
+        }
+      hint: Devuelve 1 si tiene maná, 0 si no.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-funcion-checkmana
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo tMage con el campo mana (entero).
+        Escribe el encabezado de una función hasMana que reciba un tMage
+        y devuelva un entero (1 si mana > 0, 0 si no).
+        En el bloque principal declara un mago con mana=20, llama a hasMana y guarda el resultado en estado.
+        Implementa la función devolviendo 1 o 0 según corresponda.
+      answer: |
+        type
+          tMage = record
+            mana: integer;
+          end record
+        end type
+
+        function hasMana(m: tMage): integer
+          if m.mana > 0 then
+            return 1;
+          else
+            return 0;
+          end if
+        end function
+
+        algorithm
+          var
+            mago: tMage;
+            estado: integer;
+          end var
+
+          mago.mana := 20;
+          estado := hasMana(mago);
+        end algorithm
+      hint: Usa un if para devolver 1 o 0 según el maná.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-funcion-sum-hp
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tPlayer con los campos:
+        - vida: real
+        - nivel: entero
+        Declara el prototipo e implementa una función totalLife que reciba dos tPlayer
+        y devuelva un real con la suma de sus vidas.
+      answer: |
+        typedef struct {
+            float vida;
+            int nivel;
+        } tPlayer;
+
+        float totalLife(tPlayer p1, tPlayer p2);
+
+        float totalLife(tPlayer p1, tPlayer p2) {
+            return p1.vida + p2.vida;
+        }
+      hint: Los structs pueden pasarse como parámetros en las funciones.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-funcion-sum-hp
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo tPlayer con los campos:
+        - vida: real
+        - nivel: integer
+        Escribe e implementa una función totalLife que reciba dos tPlayer
+        y devuelva un real con la suma de sus vidas.
+      answer: |
+        type
+          tPlayer = record
+            vida: real;
+            nivel: integer;
+          end record
+        end type
+
+        function totalLife(p1: tPlayer, p2: tPlayer): real
+          return p1.vida + p2.vida;
+        end function
+      hint: Usa return para devolver la suma de las vidas.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-main-attack
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo de una función llamada attack que reciba dos enteros atk y def
+        y devuelva un entero con el daño (atk - def).
+        En main declara atk=50 y def=20, llama a attack y guarda el resultado en dmg.
+        Implementa la función.
+      answer: |
+        #include <stdio.h>
+
+        int attack(int atk, int def);
+
+        int main() {
+            int atk = 50;
+            int def = 20;
+            int dmg = attack(atk, def);
+            return 0;
+        }
+
+        int attack(int atk, int def) {
+            return atk - def;
+        }
+      hint: El daño se calcula como ataque menos defensa.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-main-attack
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe el encabezado de una función attack que reciba dos enteros atk y def
+        y devuelva un entero con el daño (atk - def).
+        En el bloque principal declara atk=50 y def=20, llama a attack y guarda el resultado en dmg.
+        Implementa la función.
+      answer: |
+        function attack(atk: integer, def: integer): integer
+          return atk - def;
+        end function
+
+        algorithm
+          var
+            atk: integer;
+            def: integer;
+            dmg: integer;
+          end var
+
+          atk := 50;
+          def := 20;
+          dmg := attack(atk, def);
+        end algorithm
+      hint: Usa return para devolver atk - def.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 2
+    explanation:
+      C: "En este nivel aprenderás a usar **punteros en C**. Los punteros permiten
+        guardar la **dirección de memoria** de una variable, acceder a su contenido,
+        modificarlo, y trabajar con arrays y estructuras de forma más flexible.  \nSon
+        muy útiles en videojuegos para gestionar objetos, personajes y recursos.\n\n---\n###
+        ¿Qué es un puntero?\nUn puntero es una variable que almacena la dirección
+        de otra variable.  \nPara declarar un puntero se usa `*` y para obtener la
+        dirección de una variable se usa `&`.\n\n```c\nint score = 500;        //
+        variable normal\nint *pScore = &score;   // puntero que apunta a score\n```\n\n---\n###
+        Acceso al valor con el operador `*`\nUsando `*` podemos **leer** o **modificar**
+        el valor al que apunta el puntero.\n\n```c\nint health = 100;\nint *pHealth
+        = &health;\n\n*pHealth = 80;  // cambia health a 80\n```\n\n---\n### Imprimir
+        valores y direcciones\nCon `printf` podemos imprimir el contenido (`%d`) o
+        la dirección (`%p`).\n\n```c\nint coins = 250;\nint *pCoins = &coins;\n\nprintf(\"%d\",
+        *pCoins); // imprime 250\nprintf(\"%p\", pCoins);  // imprime la dirección
+        de coins\n```\n\n---\n### Punteros y estructuras\nUn puntero a una estructura
+        permite acceder a sus campos con `->`.\n\n```c\ntypedef struct {\n    int
+        valor;\n} tItem;\n\ntItem espada = {100};\ntItem *pEspada = &espada;\n\nprintf(\"%d\",
+        pEspada->valor); // imprime 100\n```\n\nTambién se pueden modificar los campos:\n\n```c\ntypedef
+        struct {\n    int hp;\n} tPlayer;\n\ntPlayer heroe = {120};\ntPlayer *pHeroe
+        = &heroe;\n\npHeroe->hp = 200; // cambia hp del héroe a 200\n```\n\n---\n###
+        Punteros y arrays\nEl nombre de un array es equivalente a un puntero a su
+        primer elemento.  \nPodemos recorrerlo o modificarlo usando aritmética de
+        punteros.\n\n```c\nint scores[3] = {10, 20, 30};\nint *pScores = scores;\n\nprintf(\"%d\",
+        *(pScores + 1)); // imprime 20\n```\n\nY también modificar elementos:\n\n```c\nint
+        inventory[3] = {5, 10, 15};\nint *pInv = inventory;\n\n*(pInv + 2) = 50; //
+        cambia el tercer valor a 50\n```\n\n---\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n\ntypedef struct {\n    int valor;\n} tItem;\n\ntypedef struct
+        {\n    int hp;\n} tPlayer;\n\nint main() {\n    // Variable y puntero\n    int
+        score = 500;\n    int *pScore = &score;\n\n    // Modificación con puntero\n
+        \   int health = 100;\n    int *pHealth = &health;\n    *pHealth = 80;\n\n
+        \   // Impresión con puntero\n    int coins = 250;\n    int *pCoins = &coins;\n
+        \   printf(\"Coins: %d\\n\", *pCoins);\n    printf(\"Coins address: %p\\n\",
+        pCoins);\n\n    // Puntero a struct y acceso\n    tItem espada = {100};\n
+        \   tItem *pEspada = &espada;\n    printf(\"Espada valor: %d\\n\", pEspada->valor);\n\n
+        \   // Modificación de struct\n    tPlayer heroe = {120};\n    tPlayer *pHeroe
+        = &heroe;\n    pHeroe->hp = 200;\n    printf(\"Heroe HP: %d\\n\", heroe.hp);\n\n
+        \   // Array y punteros\n    int scores[3] = {10, 20, 30};\n    int *pScores
+        = scores;\n    printf(\"Segundo score: %d\\n\", *(pScores + 1));\n\n    int
+        inventory[3] = {5, 10, 15};\n    int *pInv = inventory;\n    *(pInv + 2) =
+        50;\n    printf(\"Tercer valor inventory: %d\\n\", inventory[2]);\n\n    return
+        0;\n}\n```\n\nEste programa muestra cómo usar punteros para acceder y modificar
+        variables, estructuras y arrays, simulando elementos de un videojuego como
+        vida, inventario o armas.\n"
+    questions:
+    - id: c-5-l2-pointer-basic
+      language: C
+      week: 5
+      prompt: |
+        Declara un entero score con valor 500.
+        Declara un puntero pScore que apunte a score.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int score = 500;
+            int *pScore = &score;
+            return 0;
+        }
+      hint: Usa * para declarar punteros y & para obtener la dirección.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-pointer-dereference
+      language: C
+      week: 5
+      prompt: |
+        Declara un entero health con valor 100.
+        Declara un puntero pHealth que apunte a health.
+        Usando el puntero, asigna el valor 80 a health.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int health = 100;
+            int *pHealth = &health;
+            *pHealth = 80;
+            return 0;
+        }
+      hint: El operador * permite acceder al valor apuntado.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-pointer-print
+      language: C
+      week: 5
+      prompt: |
+        Declara un entero coins con valor 250.
+        Declara un puntero pCoins que apunte a coins.
+        Imprime con printf el valor de coins usando el puntero.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int coins = 250;
+            int *pCoins = &coins;
+            printf("%d", *pCoins);
+            return 0;
+        }
+      hint: printf muestra el contenido con %d.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: '250'
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-pointer-address
+      language: C
+      week: 5
+      prompt: |
+        Declara un entero stamina con valor 40.
+        Declara un puntero pStamina que apunte a stamina.
+        Imprime con printf la dirección almacenada en pStamina.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int stamina = 40;
+            int *pStamina = &stamina;
+            printf("%p", pStamina);
+            return 0;
+        }
+      hint: Usa %p para imprimir direcciones.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: '0x7fff474b854c'
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-pointer-change
+      language: C
+      week: 5
+      prompt: |
+        Declara un entero level con valor 3.
+        Declara un puntero pLevel que apunte a level.
+        Cambia el valor de level a 4 usando el puntero.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int level = 3;
+            int *pLevel = &level;
+            *pLevel = 4;
+            return 0;
+        }
+      hint: Con *pLevel accedes al contenido de level.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-struct-pointer
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tItem con un campo valor (entero).
+        En main declara un objeto pocion con valor=50.
+        Declara un puntero pItem que apunte a pocion.
+      answer: |
+        #include <stdio.h>
+
+        typedef struct {
+            int valor;
+        } tItem;
+
+        int main() {
+            tItem pocion = {50};
+            tItem *pItem = &pocion;
+            return 0;
+        }
+      hint: Para punteros a struct, usa el nombre del tipo seguido de *.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-struct-pointer-access
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tItem con un campo valor (entero).
+        En main declara un objeto espada con valor=100.
+        Declara un puntero pEspada que apunte a espada.
+        Imprime el valor usando pEspada con el operador ->.
+      answer: |
+        #include <stdio.h>
+
+        typedef struct {
+            int valor;
+        } tItem;
+
+        int main() {
+            tItem espada = {100};
+            tItem *pEspada = &espada;
+            printf("%d", pEspada->valor);
+            return 0;
+        }
+      hint: Usa -> para acceder a campos desde un puntero a struct.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: '100'
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-struct-modify
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tPlayer con un campo hp (entero).
+        En main declara un objeto heroe con hp=120.
+        Declara un puntero pHeroe que apunte a heroe.
+        Usa el puntero para cambiar hp a 200.
+      answer: |
+        #include <stdio.h>
+
+        typedef struct {
+            int hp;
+        } tPlayer;
+
+        int main() {
+            tPlayer heroe = {120};
+            tPlayer *pHeroe = &heroe;
+            pHeroe->hp = 200;
+            return 0;
+        }
+      hint: Con -> puedes modificar campos del struct.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-array-pointer
+      language: C
+      week: 5
+      prompt: |
+        Declara un array de enteros scores con valores {10, 20, 30}.
+        Declara un puntero pScores que apunte al primer elemento del array.
+        Imprime con printf el segundo valor usando el puntero.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int scores[3] = {10, 20, 30};
+            int *pScores = scores;
+            printf("%d", *(pScores + 1));
+            return 0;
+        }
+      hint: Los arrays se comportan como punteros al primer elemento.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: '20'
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-array-pointer-change
+      language: C
+      week: 5
+      prompt: |
+        Declara un array de enteros inventory con valores {5, 10, 15}.
+        Declara un puntero pInv que apunte al primer elemento.
+        Cambia el tercer valor del array a 50 usando el puntero.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int inventory[3] = {5, 10, 15};
+            int *pInv = inventory;
+            *(pInv + 2) = 50;
+            return 0;
+        }
+      hint: " *(p + i) accede al elemento i del array. "
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 3
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **acciones (procedimientos)** en
+        C.  \nUna acción es similar a una función, pero **no devuelve un valor**.
+        \ \nEn videojuegos, las acciones son útiles para mostrar información en pantalla,
+        actualizar la vida de un jugador o aplicar un efecto, sin necesidad de devolver
+        un resultado directo.\n\n### ¿Qué es una acción?\nUna **acción** (también
+        llamada procedimiento) es un bloque de código independiente que:\n- Tiene
+        un **nombre** que la identifica.  \n- Puede recibir **parámetros**:  \n  -
+        `in` (entrada → solo lectura).  \n  - `out` (salida → el valor se escribe
+        dentro del parámetro y afecta a la variable original).  \n  - `inout` (entrada/salida
+        → se lee y se modifica, actualizando la variable original).  \n- No devuelve
+        un valor con `return`.  \n\n---\n\n### Prototipos de acciones (encabezados)\nIgual
+        que en las funciones, se declara el encabezado antes de `main`.  \nEjemplo:\n```c\nvoid
+        mostrarPuntos(int puntos);\nvoid aplicarBonus(int enemigos, int bonus, int
+        *resultado);       // salida\nvoid acumularPuntos(int enemigos, int bonus,
+        int *resultado);    // entrada/salida\n```\n\n---\n\n### Sintaxis general
+        de una acción\n```c\nvoid nombreAccion(tipo parametros) {\n    // instrucciones\n}\n```\n\n*Se
+        utiliza `void` porque no devuelve ningún valor.*\n\n---\n\n### Ejemplo en
+        código\nAcción que recibe un parámetro de entrada y lo muestra:\n```c\nvoid
+        mostrarPuntos(int puntos) {\n    printf(\"Puntos actuales: %d\\n\", puntos);\n}\n```\n\n---\n\n###
+        Ejemplo completo\n```c\n#include <stdio.h>\n\n// Prototipos\nvoid mostrarPuntos(int
+        puntos);                       // entrada\nvoid aplicarBonus(int enemigos,
+        int bonus, int *res); // salida\nvoid acumularPuntos(int enemigos, int bonus,
+        int *res); // entrada/salida\n\n// main primero\nint main() {\n    int puntos;\n
+        \   int total = 100; // puntos iniciales del jugador\n\n    // Acción de salida:
+        calcula puntos a partir de enemigos y bonus\n    aplicarBonus(5, 20, &puntos);\n
+        \   mostrarPuntos(puntos);\n\n    // Acción de entrada/salida: acumula puntos
+        en el total del jugador\n    acumularPuntos(3, 10, &total);\n    mostrarPuntos(total);\n\n
+        \   return 0;\n}\n\n// Implementaciones al final\n// Acción de entrada\nvoid
+        mostrarPuntos(int puntos) {\n    printf(\"Puntos actuales: %d\\n\", puntos);\n}\n\n//
+        Acción con parámetro de salida\nvoid aplicarBonus(int enemigos, int bonus,
+        int *res) {\n    int calculo = enemigos * 10 + bonus;\n    *res = calculo;
+        // modifica la variable original\n}\n\n// Acción con parámetro entrada/salida\nvoid
+        acumularPuntos(int enemigos, int bonus, int *res) {\n    int calculo = enemigos
+        * 5 + bonus;\n    *res = *res + calculo; // suma al valor original\n}\n```\n\n**Qué
+        hace el programa:**  \n- `aplicarBonus` (salida) calcula puntos en base a
+        enemigos derrotados y bonus, guardándolos en una variable.  \n- `mostrarPuntos`
+        (entrada) imprime los puntos actuales del jugador.  \n- `acumularPuntos` (entrada/salida)
+        suma más puntos al total existente.  \n- Se simula cómo un jugador gana puntos
+        por enemigos derrotados y acumula un total.  \n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **acciones** en pseudocódigo.
+        \ \nUna acción es similar a una función, pero **no devuelve un valor**.  \nEn
+        videojuegos, las acciones sirven para mostrar mensajes, actualizar variables
+        de juego o aplicar efectos sobre los personajes.\n\n### ¿Qué es una acción?\nUna
+        **acción**:\n- Tiene un **nombre** que la identifica.  \n- Puede recibir **parámetros**:
+        \ \n  - `in` (entrada → solo lectura).  \n  - `out` (salida → el valor se
+        escribe dentro del parámetro y afecta a la variable original).  \n  - `inout`
+        (entrada/salida → se lee y se modifica, actualizando la variable original).
+        \ \n- No devuelve un valor.  \n\n---\n\n### Sintaxis general de una acción\n```pseudocode\naction
+        nombreAccion(parametros)\n  ...\nend action\n```\n\n---\n\n### Ejemplo en
+        pseudocódigo\nAcción de entrada para mostrar puntos:\n```pseudocode\naction
+        mostrarPuntos(in puntos: integer)\n  writeString(\"Puntos actuales: \");\n
+        \ writeInteger(puntos);\nend action\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\n{
+        Implementaciones }\n\naction mostrarPuntos(in puntos: integer)\n  writeString(\"Puntos
+        actuales: \");\n  writeInteger(puntos);\nend action\n\naction aplicarBonus(in
+        enemigos: integer, in bonus: integer, out res: integer)\n  var\n    calculo:
+        integer;\n  end var\n  calculo := enemigos * 10 + bonus;\n  res := calculo;
+        \  { modifica la variable original }\nend action\n\naction acumularPuntos(in
+        enemigos: integer, in bonus: integer, inout res: integer)\n  var\n    calculo:
+        integer;\n  end var\n  calculo := enemigos * 5 + bonus;\n  res := res + calculo;
+        \  { suma al valor original }\nend action\n\nalgorithm accionesVideojuego\n
+        \ var\n    puntos: integer;\n    total: integer;\n  end var\n\n  total :=
+        100;  { puntos iniciales }\n\n  aplicarBonus(5, 20, puntos);    { calcula
+        puntos con salida }\n  mostrarPuntos(puntos);\n\n  acumularPuntos(3, 10, total);
+        \  { acumula puntos en total }\n  mostrarPuntos(total);\nend algorithm\n```\n\n**Qué
+        hace el programa:**  \n- `aplicarBonus` (salida) calcula los puntos por enemigos
+        derrotados y bonus, y los asigna a una variable.  \n- `mostrarPuntos` (entrada)
+        escribe en pantalla los puntos actuales.  \n- `acumularPuntos` (entrada/salida)
+        suma más puntos al total acumulado del jugador.  \n- Se simula un sistema
+        de puntuación en un videojuego, donde el jugador gana y acumula puntos progresivamente.
+        \ \n"
+    questions:
+    - id: c-5-l2-action-welcome
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción en C llamada showWelcome que no reciba parámetros.
+        Dentro de la acción imprime con printf el mensaje "Bienvenido al RPG".
+        En main llama a showWelcome.
+      answer: |
+        #include <stdio.h>
+
+        void showWelcome();
+
+        int main() {
+            showWelcome();
+            return 0;
+        }
+
+        void showWelcome() {
+            printf("Bienvenido al RPG\n");
+        }
+      hint: Una acción en C se define con void, no devuelve valores.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Bienvenido al RPG
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-welcome
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción llamada showWelcome que no reciba parámetros.
+        Dentro de la acción escribe el mensaje "Bienvenido al RPG".
+        En el bloque principal llama a showWelcome.
+      answer: |
+        action showWelcome()
+          writeString("Bienvenido al RPG");
+        end action
+
+        algorithm
+          showWelcome();
+        end algorithm
+      hint: Una acción no devuelve valores, solo ejecuta instrucciones.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-in-score
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción printScore que reciba como entrada un entero score.
+        Dentro de la acción muestra con printf "Puntuacion: <score>".
+        En main declara un entero score=300 y llama a printScore con esa variable.
+      answer: |
+        #include <stdio.h>
+
+        void printScore(int score);
+
+        int main() {
+            int score = 300;
+            printScore(score);
+            return 0;
+        }
+
+        void printScore(int score) {
+            printf("Puntuacion: %d\n", score);
+        }
+      hint: Los parámetros de entrada en C se pasan como variables normales.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Puntuacion: 300
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-in-score
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción printScore que reciba como entrada un entero score.
+        Dentro de la acción escribe el mensaje "Puntuacion: " seguido del valor.
+        En el bloque principal declara un entero score=300 y llama a printScore.
+      answer: |
+        action printScore(in score: integer)
+          writeString("Puntuacion: ");
+          writeInteger(score);
+        end action
+
+        algorithm
+          var
+            score: integer;
+          end var
+
+          score := 300;
+          printScore(score);
+        end algorithm
+      hint: Usa "in" para los parámetros de entrada.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-out-health
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción initHealth que reciba como salida un entero *health.
+        Dentro de la acción asigna a *health el valor 100.
+        En main declara un entero hp sin inicializar, llama a initHealth con &hp
+        y luego muestra hp con printf.
+      answer: |
+        #include <stdio.h>
+
+        void initHealth(int *health);
+
+        int main() {
+            int hp;
+            initHealth(&hp);
+            printf("%d\n", hp);
+            return 0;
+        }
+
+        void initHealth(int *health) {
+            *health = 100;
+        }
+      hint: Los parámetros de salida en C se pasan como punteros.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: '100
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-out-health
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción initHealth que reciba como salida un entero health.
+        Dentro de la acción asigna a health el valor 100.
+        En el bloque principal declara un entero hp sin inicializar, llama a initHealth con hp
+        y luego muestra hp.
+      answer: |
+        action initHealth(out health: integer)
+          health := 100;
+        end action
+
+        algorithm
+          var
+            hp: integer;
+          end var
+
+          initHealth(hp);
+          writeInteger(hp);
+        end algorithm
+      hint: Usa "out" cuando la acción debe inicializar un valor.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-inout-heal
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción heal que reciba como entrada/salida un entero *hp.
+        Dentro de la acción suma 50 al valor apuntado por hp usando operador compuesto.
+        En main declara un entero hp=120, llama a heal con &hp
+        y luego imprime el nuevo valor.
+      answer: |
+        #include <stdio.h>
+
+        void heal(int *hp);
+
+        int main() {
+            int hp = 120;
+            heal(&hp);
+            printf("%d\n", hp);
+            return 0;
+        }
+
+        void heal(int *hp) {
+            *hp += 50;
+        }
+      hint: Usa inout cuando el valor inicial se modifica.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: '170
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-inout-heal
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción heal que reciba como entrada/salida un entero hp.
+        Dentro de la acción suma 50 al valor de hp.
+        En el bloque principal declara hp=120, llama a heal con hp
+        y muestra el nuevo valor.
+      answer: |
+        action heal(inout hp: integer)
+          hp := hp + 50;
+        end action
+
+        algorithm
+          var
+            hp: integer;
+          end var
+
+          hp := 120;
+          heal(hp);
+          writeInteger(hp);
+        end algorithm
+      hint: Usa "inout" cuando el parámetro se actualiza.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-struct-revive
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tPlayer con los campos:
+        - nombre: texto de 20 chars
+        - hp: entero
+        Declara una acción revive que reciba como salida un puntero a tPlayer
+        y lo inicialice con hp=100 y nombre="Heroe".
+        En main declara un jugador sin inicializar y llama a revive.
+        Imprime los valores "Nombre: x Hp: x".
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        typedef struct {
+            char nombre[20];
+            int hp;
+        } tPlayer;
+
+        void revive(tPlayer *p);
+
+        int main() {
+            tPlayer jugador;
+            revive(&jugador);
+            printf("Nombre: %s Hp: %d\n", jugador.nombre, jugador.hp);
+            return 0;
+        }
+
+        void revive(tPlayer *p) {
+            strcpy(p->nombre, "Heroe");
+            p->hp = 100;
+        }
+      hint: Con punteros a structs se usa -> para asignar.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 'Nombre: Heroe Hp: 100
+
+          '
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-struct-revive
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo tPlayer con los campos:
+        - nombre: string
+        - hp: integer
+        Declara una acción revive que reciba un tPlayer por salida
+        y lo inicialice con nombre="Heroe" y hp=100.
+        En el bloque principal declara un jugador y llama a revive.
+        Imprime los valores "Nombre: x Hp: x"
+      answer: |
+        type
+          tPlayer = record
+            nombre: string;
+            hp: integer;
+          end record
+        end type
+
+        action revive(out p: tPlayer)
+          p.nombre := "Heroe";
+          p.hp := 100;
+        end action
+
+        algorithm
+          var
+            jugador: tPlayer;
+          end var
+
+          revive(jugador);
+          writeString("Nombre: ");
+          writeString(jugador.nombre);
+          writeString("Hp: ");
+          writeInteger(jugador.hp);
+        end algorithm
+      hint: Usa "out" cuando la acción debe devolver un struct completo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-array-reset
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción resetInventory que reciba como entrada/salida un array de 3 enteros items.
+        Dentro de la acción usa un bucle for para poner todos sus valores a 0.
+        En main declara el array items con {10,20,30}, llama a resetInventory e imprime los valores separados
+        por un espacio "x x x".
+      answer: |
+        #include <stdio.h>
+
+        void resetInventory(int *items);
+
+        int main() {
+            int items[3] = {10, 20, 30};
+            resetInventory(items);
+            printf("%d %d %d", items[0], items[1], items[2]);
+            return 0;
+        }
+
+        void resetInventory(int *items) {
+            for(int i=0; i<3; i++) {
+                items[i] = 0;
+            }
+        }
+      hint: Los arrays en C se pasan como punteros.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: 0 0 0
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-array-reset
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción resetInventory que reciba como entrada/salida un array de 3 enteros items.
+        Dentro de la acción usa un bucle for que itere 3 veces y ponga en 0 los valores del array.
+        En el bloque principal declara items con los valores {10,20,30}, llama a resetInventory
+        y muestra los 3 valores "x x x".
+      answer: |
+        action resetInventory(inout items: array[3] of integer)
+          var
+            i: integer;
+          end var
+
+          for i = 1 to 3 do
+            items[i] := 0;
+          end for
+        end action
+
+        algorithm
+          var
+            items: array[3] of integer;
+          end var
+
+          items[1] := 10;
+          items[2] := 20;
+          items[3] := 30;
+
+          resetInventory(items);
+
+          writeInteger(items[1]);
+          writeInteger(items[2]);
+          writeInteger(items[3]);
+        end algorithm
+      hint: En pseudocódigo los arrays de 3 posiciones se definen como array[3].
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-two-in
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción showAttack que reciba dos enteros atk y def como entrada.
+        Dentro de la acción declara una variable entera total y calcula atk-def.
+        Muestra el valor de total con printf.
+        En main declara atk=50 y def=20 y llama a showAttack.
+      answer: |
+        #include <stdio.h>
+
+        void showAttack(int atk, int def);
+
+        int main() {
+            int atk = 50;
+            int def = 20;
+            showAttack(atk, def);
+            return 0;
+        }
+
+        void showAttack(int atk, int def) {
+            int total = atk - def;
+            printf("%d", total);
+        }
+      hint: Puedes pasar más de un parámetro in a la acción.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: '30'
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-two-in
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción showAttack que reciba dos enteros atk y def como entrada.
+        Dentro de la acción declara una variable entera total y calcula atk-def.
+        Imprime el valor de total.
+        En el bloque principal declara atk=50 y def=20 y llama a showAttack.
+      answer: |
+        action showAttack(in atk: integer, in def: integer)
+          var
+            tota: integer;
+          end var
+
+          total := atk - def;
+          writeInteger(total);
+        end action
+
+        algorithm
+          var
+            atk: integer;
+            def: integer;
+          end var
+
+          atk := 50;
+          def := 20;
+          showAttack(atk, def);
+        end algorithm
+      hint: Usa "in" para ambos parámetros.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-in-out
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción grantXP que reciba como entrada un entero base
+        y como salida un entero *xp.
+        Dentro de la acción asigna *xp = base * 10.
+        En main declara base=5 y una variable xp, llama a grantXP y muestra xp.
+      answer: |
+        #include <stdio.h>
+
+        void grantXP(int base, int *xp);
+
+        int main() {
+            int base = 5;
+            int xp;
+            grantXP(base, &xp);
+            printf("%d", xp);
+            return 0;
+        }
+
+        void grantXP(int base, int *xp) {
+            *xp = base * 10;
+        }
+      hint: Combina parámetros in y out.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: '50'
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-in-out
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción grantXP que reciba como entrada un entero base
+        y como salida un entero xp.
+        Dentro de la acción asigna xp = base * 10.
+        En el bloque principal declara base=5 y xp, llama a grantXP y muestra xp.
+      answer: |
+        action grantXP(in base: integer, out xp: integer)
+          xp := base * 10;
+        end action
+
+        algorithm
+          var
+            base: integer;
+            xp: integer;
+          end var
+
+          base := 5;
+          grantXP(base, xp);
+          writeInteger(xp);
+        end algorithm
+      hint: Usa una mezcla de in y out.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-in-inout
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción powerUp que reciba como entrada un entero bonus
+        y como entrada/salida un entero *atk.
+        Dentro de la acción suma bonus al valor apuntado por atk.
+        En main declara atk=40 y bonus=15, llama a powerUp y muestra atk.
+      answer: |
+        #include <stdio.h>
+
+        void powerUp(int bonus, int *atk);
+
+        int main() {
+            int atk = 40;
+            int bonus = 15;
+            powerUp(bonus, &atk);
+            printf("%d", atk);
+            return 0;
+        }
+
+        void powerUp(int bonus, int *atk) {
+            *atk = *atk + bonus;
+        }
+      hint: Combina un parámetro in y uno inout.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: '55'
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-in-inout
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción powerUp que reciba como entrada un entero bonus
+        y como entrada/salida un entero atk.
+        Dentro de la acción suma bonus al valor de atk.
+        En el bloque principal declara atk=40 y bonus=15, llama a powerUp y muestra atk.
+      answer: |
+        action powerUp(in bonus: integer, inout atk: integer)
+          atk := atk + bonus;
+        end action
+
+        algorithm
+          var
+            atk: integer;
+            bonus: integer;
+          end var
+
+          atk := 40;
+          bonus := 15;
+          powerUp(bonus, atk);
+          writeInteger(atk);
+        end algorithm
+      hint: Mezcla in y inout en la acción.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-struct-inout
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tEnemy con el campo hp (entero).
+        Declara una acción damage que reciba como entrada un entero dmg
+        y como entrada/salida un puntero a tEnemy.
+        Dentro de la acción resta dmg a hp.
+        En main declara un enemigo con hp= {200}.
+        Llama a damage con 30 y enemigo.
+        Imprime el valor del hp de enemigo.
+      answer: |
+        #include <stdio.h>
+
+        typedef struct {
+            int hp;
+        } tEnemy;
+
+        void damage(int dmg, tEnemy *e);
+
+        int main() {
+            tEnemy enemigo = {200};
+            damage(30, &enemigo);
+            printf("%d", enemigo.hp);
+            return 0;
+        }
+
+        void damage(int dmg, tEnemy *e) {
+            e->hp = e->hp - dmg;
+        }
+      hint: Usa -> para modificar un struct desde un puntero.
+      mode: judge_c
+      tests:
+      - input: ''
+        output: '170'
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-struct-inout
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo tEnemy con el campo hp (entero).
+        Declara una acción damage que reciba como entrada un entero dmg
+        y como entrada/salida un tEnemy e.
+        Dentro de la acción resta dmg al campo hp.
+        En el bloque principal declara un enemigo con hp=200.
+        Llama a damage con 30 y enemigo.
+        Imprime el valor del hp de enemigo.
+      answer: |
+        type
+          tEnemy = record
+            hp: integer;
+          end record
+        end type
+
+        action damage(in dmg: integer, inout e: tEnemy)
+          e.hp := e.hp - dmg;
+        end action
+
+        algorithm
+          var
+            enemigo: tEnemy;
+          end var
+
+          enemigo.hp := 200;
+          damage(30, enemigo);
+          writeInteger(enemigo.hp);
+        end algorithm
+      hint: Usa in para dmg y inout para el struct.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+- number: 7
+  explanation:
+  levels:
+  - number: 1
+    explanation:
+      C: 'Explicacion C
+
+        '
+      Pseudocode: 'Explicacion Pseudocode
+
+        '
+    questions:
+    - id: c-5-l1-table-enemy
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_ENEMIES = 50.
+        Declara una estructura tEnemy con los campos:
+        - name: texto (usa MAX_NAME = 30)
+        - health: entero
+        Declara una tabla tEnemyTable con:
+        - data: array de MAX_ENEMIES de tEnemy
+        - count: entero con el número de enemigos almacenados.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_ENEMIES 50
+
+        typedef struct {
+            char name[MAX_NAME];
+            int health;
+        } tEnemy;
+
+        typedef struct {
+            tEnemy data[MAX_ENEMIES];
+            int count;
+        } tEnemyTable;
+      hint: Recuerda que una tabla combina el array y un contador.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-enemy
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_ENEMIES = 50.
+        Declara un tipo tEnemy con los campos:
+        - name: string
+        - health: integer
+        Declara un tipo tEnemyTable con:
+        - data: vector[MAX_ENEMIES] de tEnemy
+        - count: integer
+      answer: |
+        const
+          MAX_ENEMIES: integer = 50;
+        end const
+
+        type
+          tEnemy = record
+            name: string;
+            health: integer;
+          end record
+        end type
+
+        type
+          tEnemyTable = record
+            data: vector[MAX_ENEMIES] of tEnemy;
+            count: integer;
+          end record
+        end type
+      hint: La tabla es un record con el array y el contador.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-init-enemytable
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo e implementación de una función initEnemyTable que reciba
+        un puntero a tEnemyTable y lo inicialice con count = 0.
+      answer: |
+        void initEnemyTable(tEnemyTable* table);
+
+        void initEnemyTable(tEnemyTable* table) {
+            table->count = 0;
+        }
+      hint: Usa -> para acceder a count porque es un puntero.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-init-enemytable
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe el encabezado e implementación de una acción initEnemyTable
+        que reciba un parámetro de tipo inout tEnemyTable y lo inicialice con count = 0.
+      answer: |
+        action initEnemyTable(inout table: tEnemyTable)
+          table.count := 0;
+        end action
+      hint: Una acción en pseudocódigo no devuelve valor.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-item
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_ITEMS = 100.
+        Declara una estructura tItem con los campos:
+        - name: texto (usa MAX_NAME = 30)
+        - value: entero
+        Declara un tipo tInventory con:
+        - data: array de MAX_ITEMS de tItem
+        - count: entero
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_ITEMS 100
+
+        typedef struct {
+            char name[MAX_NAME];
+            int value;
+        } tItem;
+
+        typedef struct {
+            tItem data[MAX_ITEMS];
+            int count;
+        } tInventory;
+      hint: El inventario es otra tabla similar a los enemigos.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-item
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_ITEMS = 100.
+        Declara un tipo tItem con los campos:
+        - name: string
+        - value: integer
+        Declara un tipo tInventory con:
+        - data: vector[MAX_ITEMS] de tItem
+        - count: integer
+      answer: |
+        const
+          MAX_ITEMS: integer = 100;
+        end const
+
+        type
+          tItem = record
+            name: string;
+            value: integer;
+          end record
+        end type
+
+        type
+          tInventory = record
+            data: vector[MAX_ITEMS] of tItem;
+            count: integer;
+          end record
+        end type
+      hint: Las tablas siempre combinan vector y contador.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-main-init-inventory
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo e implementación de una función initInventory que ponga count=0.
+        En main declara una variable inv de tipo tInventory, inicialízala con initInventory
+        y devuelve 0.
+      answer: |
+        void initInventory(tInventory* inv);
+
+        void initInventory(tInventory* inv) {
+            inv->count = 0;
+        }
+
+        int main() {
+            tInventory inv;
+            initInventory(&inv);
+            return 0;
+        }
+      hint: Pasa la dirección de inv al llamar a initInventory.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-main-init-inventory
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe la acción initInventory que ponga count=0 en un tInventory.
+        En el bloque principal declara una variable inv de tipo tInventory
+        e inicialízala llamando a initInventory.
+      answer: |
+        action initInventory(inout inv: tInventory)
+          inv.count := 0;
+        end action
+
+        algorithm
+          var
+            inv: tInventory;
+          end var
+
+          initInventory(inv);
+        end algorithm
+      hint: Pasa inv como inout para que se inicialice.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-player
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_PLAYERS = 20.
+        Declara una estructura tPlayer con:
+        - username: texto (usa MAX_NAME = 30)
+        - level: entero
+        Declara una tabla tPlayerTable con:
+        - data: array de MAX_PLAYERS de tPlayer
+        - count: entero
+        En main declara un tPlayerTable players y pon count=0.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_PLAYERS 20
+
+        typedef struct {
+            char username[MAX_NAME];
+            int level;
+        } tPlayer;
+
+        typedef struct {
+            tPlayer data[MAX_PLAYERS];
+            int count;
+        } tPlayerTable;
+
+        int main() {
+            tPlayerTable players;
+            players.count = 0;
+            return 0;
+        }
+      hint: La inicialización directa se hace con .count = 0.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-player
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_PLAYERS = 20.
+        Declara un tipo tPlayer con:
+        - username: string
+        - level: integer
+        Declara un tipo tPlayerTable con:
+        - data: vector[MAX_PLAYERS] de tPlayer
+        - count: integer
+        En el bloque principal declara un tPlayerTable players y pon count=0.
+      answer: |
+        const
+          MAX_PLAYERS: integer = 20;
+        end const
+
+        type
+          tPlayer = record
+            username: string;
+            level: integer;
+          end record
+        end type
+
+        type
+          tPlayerTable = record
+            data: vector[MAX_PLAYERS] of tPlayer;
+            count: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            players: tPlayerTable;
+          end var
+
+          players.count := 0;
+        end algorithm
+      hint: Se inicializa el contador a 0 en el bloque principal.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-weapon
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_WEAPONS = 40.
+        Declara un enum tWeaponType con los valores SWORD, BOW y STAFF.
+        Declara un struct tWeapon con:
+        - name: texto (usa MAX_NAME = 30)
+        - type: tWeaponType
+        Declara una tabla tWeaponTable con data[MAX_WEAPONS] y count.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_WEAPONS 40
+
+        typedef enum { SWORD, BOW, STAFF } tWeaponType;
+
+        typedef struct {
+            char name[MAX_NAME];
+            tWeaponType type;
+        } tWeapon;
+
+        typedef struct {
+            tWeapon data[MAX_WEAPONS];
+            int count;
+        } tWeaponTable;
+      hint: Un enum se define antes de usarlo dentro del struct.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-weapon
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_WEAPONS = 40.
+        Declara un tipo enumerado tWeaponType con valores SWORD, BOW y STAFF.
+        Declara un tipo tWeapon con:
+        - name: string
+        - type: tWeaponType
+        Declara un tipo tWeaponTable con:
+        - data: vector[MAX_WEAPONS] de tWeapon
+        - count: integer
+      answer: |
+        const
+          MAX_WEAPONS: integer = 40;
+        end const
+
+        type
+          tWeaponType = { SWORD, BOW, STAFF };
+        end type
+
+        type
+          tWeapon = record
+            name: string;
+            type: tWeaponType;
+          end record
+        end type
+
+        type
+          tWeaponTable = record
+            data: vector[MAX_WEAPONS] of tWeapon;
+            count: integer;
+          end record
+        end type
+      hint: Recuerda cerrar cada tipo con end type.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-init-weapon-main
+      language: C
+      week: 5
+      prompt: |
+        Declara la función initWeaponTable que inicialice count=0 en un tWeaponTable.
+        En main declara una variable armas de tipo tWeaponTable e inicialízala con initWeaponTable.
+      answer: |
+        void initWeaponTable(tWeaponTable* table);
+
+        void initWeaponTable(tWeaponTable* table) {
+            table->count = 0;
+        }
+
+        int main() {
+            tWeaponTable armas;
+            initWeaponTable(&armas);
+            return 0;
+        }
+      hint: Se pasa la dirección de la tabla con &.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-init-weapon-main
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara la acción initWeaponTable que inicialice count=0 en un tWeaponTable.
+        En el bloque principal declara una variable armas de tipo tWeaponTable e inicialízala con initWeaponTable.
+      answer: |
+        action initWeaponTable(inout table: tWeaponTable)
+          table.count := 0;
+        end action
+
+        algorithm
+          var
+            armas: tWeaponTable;
+          end var
+
+          initWeaponTable(armas);
+        end algorithm
+      hint: En pseudocódigo las acciones se llaman igual que en C.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-npc
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_NPCS = 60.
+        Declara una estructura tNPC con:
+        - name: texto (usa MAX_NAME = 30)
+        - dialogue: texto (usa MAX_MSG = 100)
+        Declara una tabla tNPCTable con:
+        - data: array[MAX_NPCS] de tNPC
+        - count: entero
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_MSG 100
+        #define MAX_NPCS 60
+
+        typedef struct {
+            char name[MAX_NAME];
+            char dialogue[MAX_MSG];
+        } tNPC;
+
+        typedef struct {
+            tNPC data[MAX_NPCS];
+            int count;
+        } tNPCTable;
+      hint: Cada NPC tiene nombre y diálogo como strings.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-npc
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_NPCS = 60.
+        Declara un tipo tNPC con:
+        - name: string
+        - dialogue: string
+        Declara un tipo tNPCTable con:
+        - data: vector[MAX_NPCS] de tNPC
+        - count: integer
+      answer: |
+        const
+          MAX_NPCS: integer = 60;
+        end const
+
+        type
+          tNPC = record
+            name: string;
+            dialogue: string;
+          end record
+        end type
+
+        type
+          tNPCTable = record
+            data: vector[MAX_NPCS] of tNPC;
+            count: integer;
+          end record
+        end type
+      hint: Un NPC tiene cadenas de texto como atributos.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-quest
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_QUESTS = 25.
+        Declara una estructura tQuest con:
+        - title: texto (usa MAX_NAME = 30)
+        - reward: entero
+        Declara una tabla tQuestTable con:
+        - data: array[MAX_QUESTS] de tQuest
+        - count: entero
+        En main declara una variable quests de tipo tQuestTable e inicialízala poniendo count=0.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_QUESTS 25
+
+        typedef struct {
+            char title[MAX_NAME];
+            int reward;
+        } tQuest;
+
+        typedef struct {
+            tQuest data[MAX_QUESTS];
+            int count;
+        } tQuestTable;
+
+        int main() {
+            tQuestTable quests;
+            quests.count = 0;
+            return 0;
+        }
+      hint: La inicialización directa de count se hace en main.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-quest
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_QUESTS = 25.
+        Declara un tipo tQuest con:
+        - title: string
+        - reward: integer
+        Declara un tipo tQuestTable con:
+        - data: vector[MAX_QUESTS] de tQuest
+        - count: integer
+        En el bloque principal declara una variable quests de tipo tQuestTable e inicialízala poniendo count=0.
+      answer: |
+        const
+          MAX_QUESTS: integer = 25;
+        end const
+
+        type
+          tQuest = record
+            title: string;
+            reward: integer;
+          end record
+        end type
+
+        type
+          tQuestTable = record
+            data: vector[MAX_QUESTS] of tQuest;
+            count: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            quests: tQuestTable;
+          end var
+
+          quests.count := 0;
+        end algorithm
+      hint: El contador siempre comienza en 0 al declarar la tabla.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-boss
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_BOSSES = 10.
+        Declara una estructura tBoss con:
+        - name: texto (usa MAX_NAME = 30)
+        - hp: real
+        - stage: entero
+        Declara una tabla tBossTable con:
+        - data: array[MAX_BOSSES] de tBoss
+        - count: entero
+        Declara e implementa una función initBossTable que reciba un puntero a tBossTable
+        e inicialice count=0.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_BOSSES 10
+
+        typedef struct {
+            char name[MAX_NAME];
+            float hp;
+            int stage;
+        } tBoss;
+
+        typedef struct {
+            tBoss data[MAX_BOSSES];
+            int count;
+        } tBossTable;
+
+        void initBossTable(tBossTable* table);
+
+        void initBossTable(tBossTable* table) {
+            table->count = 0;
+        }
+      hint: Usa float para hp porque es un valor decimal.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-boss
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_BOSSES = 10.
+        Declara un tipo tBoss con:
+        - name: string
+        - hp: real
+        - stage: integer
+        Declara un tipo tBossTable con:
+        - data: vector[MAX_BOSSES] de tBoss
+        - count: integer
+        Declara e implementa una acción initBossTable que reciba un inout tBossTable
+        e inicialice count=0.
+      answer: |
+        const
+          MAX_BOSSES: integer = 10;
+        end const
+
+        type
+          tBoss = record
+            name: string;
+            hp: real;
+            stage: integer;
+          end record
+        end type
+
+        type
+          tBossTable = record
+            data: vector[MAX_BOSSES] of tBoss;
+            count: integer;
+          end record
+        end type
+
+        action initBossTable(inout table: tBossTable)
+          table.count := 0;
+        end action
+      hint: La acción no devuelve nada, solo modifica la tabla.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 2
+    explanation:
+      C:
+      Pseudocode:
+    questions:
+    - id: c-5-l2-insert-skill
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_SKILLS = 30 y MAX_NAME = 30.
+        Declara una estructura tSkill con:
+        - name: texto
+        - level: entero
+        Declara una tabla tSkillTable con:
+        - data: array[MAX_SKILLS] de tSkill
+        - count: entero
+        Implementa la función addSkill que reciba un puntero a tSkillTable (table)
+        y un tSkill (s), lo inserte al final de la tabla y aumente count.
+      answer: |
+        #include <string.h>
+        #define MAX_NAME 30
+        #define MAX_SKILLS 30
+
+        typedef struct {
+            char name[MAX_NAME];
+            int level;
+        } tSkill;
+
+        typedef struct {
+            tSkill data[MAX_SKILLS];
+            int count;
+        } tSkillTable;
+
+        void addSkill(tSkillTable* table, tSkill s) {
+            table->data[table->count] = s;
+            table->count++;
+        }
+      hint: Inserta al final usando table->count como índice.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-insert-skill
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_SKILLS = 30.
+        Declara un tipo tSkill con:
+        - name: string
+        - level: integer
+        Declara un tipo tSkillTable con:
+        - data: vector[MAX_SKILLS] de tSkill
+        - count: integer
+        Implementa una acción addSkill que reciba un inout tSkillTable (table)
+        y un tSkill (s), lo inserte al final de la tabla y aumente count.
+      answer: |
+        const
+          MAX_SKILLS: integer = 30;
+        end const
+
+        type
+          tSkill = record
+            name: string;
+            level: integer;
+          end record
+        end type
+
+        type
+          tSkillTable = record
+            data: vector[MAX_SKILLS] of tSkill;
+            count: integer;
+          end record
+        end type
+
+        action addSkill(inout table: tSkillTable, in s: tSkill)
+          table.data[table.count + 1] := s;
+          table.count := table.count + 1;
+        end action
+      hint: En pseudocódigo los índices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-insert-potion
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_POTIONS = 50 y MAX_NAME = 30.
+        Declara un struct tPotion con:
+        - name: texto
+        - power: real
+        Declara una tabla tPotionTable con data[MAX_POTIONS] y count.
+        Implementa la función addPotion que reciba un puntero a tPotionTable (table)
+        y un tPotion (p), lo inserte al final y aumente count.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_POTIONS 50
+
+        typedef struct {
+            char name[MAX_NAME];
+            float power;
+        } tPotion;
+
+        typedef struct {
+            tPotion data[MAX_POTIONS];
+            int count;
+        } tPotionTable;
+
+        void addPotion(tPotionTable* table, tPotion p) {
+            table->data[table->count] = p;
+            table->count++;
+        }
+      hint: Usa float para power.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-insert-potion
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_POTIONS = 50.
+        Declara un tipo tPotion con:
+        - name: string
+        - power: real
+        Declara un tipo tPotionTable con data[MAX_POTIONS] y count.
+        Implementa una acción addPotion que reciba un inout tPotionTable (table)
+        y un tPotion (p), lo inserte al final y aumente count.
+      answer: |
+        const
+          MAX_POTIONS: integer = 50;
+        end const
+
+        type
+          tPotion = record
+            name: string;
+            power: real;
+          end record
+        end type
+
+        type
+          tPotionTable = record
+            data: vector[MAX_POTIONS] of tPotion;
+            count: integer;
+          end record
+        end type
+
+        action addPotion(inout table: tPotionTable, in p: tPotion)
+          table.data[table.count + 1] := p;
+          table.count := table.count + 1;
+        end action
+      hint: Recuerda aumentar count tras insertar.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-insert-achievement
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_ACHIEVEMENTS = 40 y MAX_NAME = 30.
+        Declara un struct tAchievement con:
+        - title: texto
+        - points: entero
+        Declara un tAchievementTable con data[MAX_ACHIEVEMENTS] y count.
+        Implementa la función addAchievement que reciba un puntero a tAchievementTable (table)
+        y un tAchievement (a), lo inserte al final y aumente count.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_ACHIEVEMENTS 40
+
+        typedef struct {
+            char title[MAX_NAME];
+            int points;
+        } tAchievement;
+
+        typedef struct {
+            tAchievement data[MAX_ACHIEVEMENTS];
+            int count;
+        } tAchievementTable;
+
+        void addAchievement(tAchievementTable* table, tAchievement a) {
+            table->data[table->count] = a;
+            table->count++;
+        }
+      hint: Similar a insertar skills o potions.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-insert-achievement
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_ACHIEVEMENTS = 40.
+        Declara un tipo tAchievement con:
+        - title: string
+        - points: integer
+        Declara un tipo tAchievementTable con data[MAX_ACHIEVEMENTS] y count.
+        Implementa una acción addAchievement que reciba un inout tAchievementTable (table)
+        y un tAchievement (a), lo inserte al final y aumente count.
+      answer: |
+        const
+          MAX_ACHIEVEMENTS: integer = 40;
+        end const
+
+        type
+          tAchievement = record
+            title: string;
+            points: integer;
+          end record
+        end type
+
+        type
+          tAchievementTable = record
+            data: vector[MAX_ACHIEVEMENTS] of tAchievement;
+            count: integer;
+          end record
+        end type
+
+        action addAchievement(inout table: tAchievementTable, in a: tAchievement)
+          table.data[table.count + 1] := a;
+          table.count := table.count + 1;
+        end action
+      hint: No olvides incrementar el contador.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-search-skill
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función searchSkill que reciba un tSkillTable (table) y un nombre (name),
+        y devuelva la posición en el array (o -1 si no existe).
+        Usa un while con booleano found, inicializa pos=-1, i=0.
+      answer: |
+        #include <stdbool.h>
+        #include <string.h>
+
+        int searchSkill(tSkillTable table, const char* name) {
+            int i = 0;
+            int pos = -1;
+            bool found = false;
+            while(i < table.count && !found) {
+                if(strcmp(table.data[i].name, name) == 0) {
+                    pos = i;
+                    found = true;
+                } else {
+                    i++;
+                }
+            }
+            return pos;
+        }
+      hint: Sigue el esquema de búsqueda lineal de la teoría.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-search-skill
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una función searchSkill que reciba un tSkillTable (table) y un string (name),
+        y devuelva un integer con la posición encontrada o -1 si no existe.
+        Usa un while con variable booleana found, inicializa pos=-1, i=1.
+      answer: |
+        function searchSkill(table: tSkillTable, name: string): integer
+          var
+            i: integer;
+            pos: integer;
+            found: boolean;
+          end var
+
+          i := 1;
+          pos := -1;
+          found := false;
+
+          while i ≤ table.count and not found do
+            if table.data[i].name = name then
+              pos := i;
+              found := true;
+            else
+              i := i + 1;
+            end if
+          end while
+
+          return pos;
+        end function
+      hint: Recuerda que los índices en pseudocódigo comienzan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-search-potion
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función searchPotion que reciba un tPotionTable (table) y un real power,
+        y devuelva la posición encontrada o -1 si no existe.
+        Usa while con booleano found.
+      answer: |
+        #include <stdbool.h>
+
+        int searchPotion(tPotionTable table, float power) {
+            int i = 0;
+            int pos = -1;
+            bool found = false;
+            while(i < table.count && !found) {
+                if(table.data[i].power == power) {
+                    pos = i;
+                    found = true;
+                } else {
+                    i++;
+                }
+            }
+            return pos;
+        }
+      hint: Inicializa pos en -1 como valor por defecto.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-search-potion
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una función searchPotion que reciba un tPotionTable (table) y un real (power),
+        y devuelva un integer con la posición encontrada o -1 si no existe.
+        Usa el esquema de búsqueda lineal con while y booleano found.
+      answer: |
+        function searchPotion(table: tPotionTable, power: real): integer
+          var
+            i: integer;
+            pos: integer;
+            found: boolean;
+          end var
+
+          i := 1;
+          pos := -1;
+          found := false;
+
+          while i ≤ table.count and not found do
+            if table.data[i].power = power then
+              pos := i;
+              found := true;
+            else
+              i := i + 1;
+            end if
+          end while
+
+          return pos;
+        end function
+      hint: Usa pos=-1 como valor inicial de no encontrado.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-search-achievement
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función searchAchievement que reciba un tAchievementTable (table) y un integer points,
+        y devuelva la posición de un logro con esos puntos o -1 si no existe.
+        Usa while con booleano found.
+      answer: |
+        #include <stdbool.h>
+
+        int searchAchievement(tAchievementTable table, int points) {
+            int i = 0;
+            int pos = -1;
+            bool found = false;
+            while(i < table.count && !found) {
+                if(table.data[i].points == points) {
+                    pos = i;
+                    found = true;
+                } else {
+                    i++;
+                }
+            }
+            return pos;
+        }
+      hint: Devuelve -1 si no encuentra el valor buscado.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-search-achievement
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una función searchAchievement que reciba un tAchievementTable (table) y un integer (points),
+        y devuelva un integer con la posición encontrada o -1 si no existe.
+        Usa while con booleano found.
+      answer: |
+        function searchAchievement(table: tAchievementTable, points: integer): integer
+          var
+            i: integer;
+            pos: integer;
+            found: boolean;
+          end var
+
+          i := 1;
+          pos := -1;
+          found := false;
+
+          while i ≤ table.count and not found do
+            if table.data[i].points = points then
+              pos := i;
+              found := true;
+            else
+              i := i + 1;
+            end if
+          end while
+
+          return pos;
+        end function
+      hint: Usa el esquema de búsqueda lineal de la teoría.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-delete-skill
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función deleteSkill que reciba un puntero a tSkillTable (table) y un string (name).
+        Primero busca el nombre con searchSkill. Si se encuentra, desplaza los elementos a la izquierda
+        y disminuye count en 1.
+      answer: |
+        void deleteSkill(tSkillTable* table, const char* name) {
+            int pos = searchSkill(*table, name);
+            if(pos != -1) {
+                for(int i = pos; i < table->count - 1; i++) {
+                    table->data[i] = table->data[i+1];
+                }
+                table->count--;
+            }
+        }
+      hint: Desplaza todos los elementos posteriores una posición a la izquierda.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-delete-skill
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una acción deleteSkill que reciba un inout tSkillTable (table) y un string (name).
+        Primero busca con searchSkill. Si se encuentra, desplaza todos los elementos a la izquierda
+        y reduce count en 1.
+      answer: |
+        action deleteSkill(inout table: tSkillTable, in name: string)
+          var
+            pos: integer;
+            i: integer;
+          end var
+
+          pos := searchSkill(table, name);
+
+          if pos ≠ -1 then
+            for i := pos to table.count - 1 do
+              table.data[i] := table.data[i+1];
+            end for
+            table.count := table.count - 1;
+          end if
+        end action
+      hint: Sigue el patrón de la teoría para eliminación.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-delete-potion
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función deletePotion que reciba un puntero a tPotionTable (table) y un real (power).
+        Usa searchPotion. Si encuentra el elemento, desplaza hacia la izquierda
+        y reduce count en 1.
+      answer: |
+        void deletePotion(tPotionTable* table, float power) {
+            int pos = searchPotion(*table, power);
+            if(pos != -1) {
+                for(int i = pos; i < table->count - 1; i++) {
+                    table->data[i] = table->data[i+1];
+                }
+                table->count--;
+            }
+        }
+      hint: Usa la búsqueda antes de eliminar.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-delete-potion
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una acción deletePotion que reciba un inout tPotionTable (table) y un real (power).
+        Usa searchPotion. Si existe, mueve todos los elementos a la izquierda desde pos
+        y reduce count en 1.
+      answer: |
+        action deletePotion(inout table: tPotionTable, in power: real)
+          var
+            pos: integer;
+            i: integer;
+          end var
+
+          pos := searchPotion(table, power);
+
+          if pos ≠ -1 then
+            for i := pos to table.count - 1 do
+              table.data[i] := table.data[i+1];
+            end for
+            table.count := table.count - 1;
+          end if
+        end action
+      hint: Elimina compactando la tabla.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-delete-achievement
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función deleteAchievement que reciba un puntero a tAchievementTable (table) y un integer (points).
+        Usa searchAchievement. Si se encuentra, desplaza hacia la izquierda
+        y reduce count en 1.
+      answer: |
+        void deleteAchievement(tAchievementTable* table, int points) {
+            int pos = searchAchievement(*table, points);
+            if(pos != -1) {
+                for(int i = pos; i < table->count - 1; i++) {
+                    table->data[i] = table->data[i+1];
+                }
+                table->count--;
+            }
+        }
+      hint: Desplaza desde la posición encontrada hasta el final.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-delete-achievement
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una acción deleteAchievement que reciba un inout tAchievementTable (table) y un integer (points).
+        Usa searchAchievement. Si existe, desplaza a la izquierda los elementos posteriores
+        y reduce count en 1.
+      answer: |
+        action deleteAchievement(inout table: tAchievementTable, in points: integer)
+          var
+            pos: integer;
+            i: integer;
+          end var
+
+          pos := searchAchievement(table, points);
+
+          if pos ≠ -1 then
+            for i := pos to table.count - 1 do
+              table.data[i] := table.data[i+1];
+            end for
+            table.count := table.count - 1;
+          end if
+        end action
+      hint: El contador se decrementa al final.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-traverse-skill-sum
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función sumSkillLevels que reciba un tSkillTable (table)
+        y devuelva la suma de todos los niveles de las habilidades.
+        Usa un for desde 0 hasta count-1.
+      answer: |
+        int sumSkillLevels(tSkillTable table) {
+            int i;
+            int total = 0;
+            for(i = 0; i < table.count; i++) {
+                total = total + table.data[i].level;
+            }
+            return total;
+        }
+      hint: El esquema de recorrido es con for porque sabemos count.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-traverse-skill-sum
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una función sumSkillLevels que reciba un tSkillTable (table)
+        y devuelva un integer con la suma de todos los niveles.
+        Usa un for de 1 hasta count.
+      answer: |
+        function sumSkillLevels(table: tSkillTable): integer
+          var
+            i: integer;
+            total: integer;
+          end var
+
+          total := 0;
+
+          for i := 1 to table.count do
+            total := total + table.data[i].level;
+          end for
+
+          return total;
+        end function
+      hint: En pseudocódigo el recorrido va de 1 a count.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }

--- a/src/data/quiz_questions_modes.yaml
+++ b/src/data/quiz_questions_modes.yaml
@@ -1,0 +1,10142 @@
+---
+weeks:
+- number: 1
+  explanation: 'Explicación de semana 1
+
+    '
+  levels:
+  - number: 1
+    explanation:
+      C: "En este nivel aprenderás a **declarar constantes y variables en C**, entender
+        la diferencia entre ambas, y cómo usarlas en un programa con temática de videojuegos.\n\n###
+        Constantes con `#define` (preprocesador)\nSirven para definir valores constantes
+        globales sin tipo.  \nSon reemplazadas por su valor antes de compilar y no
+        ocupan memoria.  \nNo llevan `;` al final.  \n\n```c\n#define MAX_JUGADORES
+        4\n#define PUNTOS_VICTORIA 1000\n\nint main() {\n    return 0;\n}\n```\n\nEn
+        un videojuego, `MAX_JUGADORES` puede representar el número máximo de jugadores
+        en una partida multijugador, y `PUNTOS_VICTORIA` la puntuación necesaria para
+        ganar.\n\n---\n\n### Constantes locales con `const` (con tipo)\nSe definen
+        dentro de una función, tienen tipo y deben inicializarse al declararse.  \n\n```c\nint
+        main() {\n    const float VELOCIDAD_JUGADOR = 5.5;\n    const int VIDAS_INICIALES
+        = 3;\n    return 0;\n}\n```\n\nAquí `VELOCIDAD_JUGADOR` podría representar
+        la velocidad base de un personaje y `VIDAS_INICIALES` el número de vidas con
+        las que empieza un jugador.\n\n---\n\n### Declaración de variables\nLas variables
+        se usan para almacenar datos que pueden cambiar durante el juego.  \nCada
+        tipo se declara con una palabra clave:\n\n- `int` → enteros  \n- `float` →
+        decimales  \n- `bool` → booleanos (requiere `#include <stdbool.h>`)  \n- `char`
+        → un carácter individual  \n- `char[]` → cadenas de caracteres con tamaño
+        fijo  \n\n```c\nint main() {\n    int puntuacion;\n    float energia;\n    bool
+        nivelCompletado;\n    char inicialJugador;\n    char nombreJugador[30];\n
+        \   return 0;\n}\n```\n\n---\n\n### Inicialización y asignación\nPuedes **inicializar
+        al declarar**:\n\n```c\nint main() {\n    int puntuacion = 500;\n    float
+        energia = 5.5;\n    char inicialJugador = 'L';\n    char nombreJugador[30]
+        = \"Link\";\n    return 0;\n}\n```\n\nO **declarar primero y asignar después**:\n\n```c\nint
+        main() {\n    int puntuacion;\n    puntuacion = 500;\n\n    float energia;\n
+        \   energia = 5.5;\n\n    char inicialJugador;\n    inicialJugador = 'L';\n\n
+        \   return 0;\n}\n```\n\n---\n\n### Ejemplo completo\n```c\n#include <stdio.h>\n#include
+        <stdbool.h>\n#define MAX_JUGADORES 4\n#define PUNTOS_VICTORIA 1000\n\nint
+        main() {\n    const float VELOCIDAD_JUGADOR = 5.5;\n    const int VIDAS_INICIALES
+        = 3;\n\n    int puntuacion = 500;\n    float energia = VELOCIDAD_JUGADOR;\n
+        \   bool nivelCompletado = false;\n    char inicialJugador = 'L';\n    char
+        nombreJugador[30] = \"Link\";\n\n    printf(\"Jugador %c (%s) empieza con
+        %d vidas y velocidad %.1f.\\n\", \n           inicialJugador, nombreJugador,
+        VIDAS_INICIALES, VELOCIDAD_JUGADOR);\n    return 0;\n}\n```\n\nEste programa
+        inicializa un jugador con nombre, vidas y velocidad para una partida.\n"
+      Pseudocode: "En este nivel aprenderás a **declarar constantes y variables en
+        pseudocódigo**, entender su diferencia, y cómo usarlas en un programa con
+        temática de videojuegos.\n\n### Constantes\nSe definen en un bloque `const
+        ... end const`, indicando tipo y valor.  \nRepresentan valores que no cambian
+        durante la ejecución del programa.\n\n```pseudocode\nconst\n  MAX_JUGADORES:
+        integer = 4;\n  PUNTOS_VICTORIA: integer = 1000;\n  VELOCIDAD_JUGADOR: real
+        = 5.5;\n  VIDAS_INICIALES: integer = 3;\nend const\n```\n\nAquí `MAX_JUGADORES`
+        define el número máximo de jugadores en una partida y `PUNTOS_VICTORIA` los
+        puntos necesarios para ganar.\n\n---\n\n### Variables\nSe declaran en un bloque
+        `var ... end var` dentro del algoritmo principal.  \nNo se pueden inicializar
+        en la misma línea de la declaración.\n\n```pseudocode\nalgorithm\n  var\n
+        \   puntuacion: integer;\n    energia: real;\n    nivelCompletado: boolean;\n
+        \   inicialJugador: character;\n    nombreJugador: string;\n  end var\nend
+        algorithm\n```\n\n---\n\n### Asignación de valores\nDespués de declararlas,
+        se asigna valor con `:=`.\n\n```pseudocode\nalgorithm\n  var\n    puntuacion:
+        integer;\n    energia: real;\n    nivelCompletado: boolean;\n    inicialJugador:
+        character;\n    nombreJugador: string;\n  end var\n\n  puntuacion := 500;\n
+        \ energia := VELOCIDAD_JUGADOR;\n  nivelCompletado := false;\n  inicialJugador
+        := 'L';\n  nombreJugador := \"Link\";\nend algorithm\n```\n\n---\n\n### Tipos
+        básicos\n- `integer` → enteros  \n- `real` → decimales  \n- `boolean` → `true`
+        o `false`  \n- `character` → un solo carácter, ej. `'A'`  \n- `string` → cadenas
+        de texto  \n\n---\n\n### Ejemplo completo\n```pseudocode\nconst\n  MAX_JUGADORES:
+        integer = 4;\n  PUNTOS_VICTORIA: integer = 1000;\n  VELOCIDAD_JUGADOR: real
+        = 5.5;\n  VIDAS_INICIALES: integer = 3;\nend const\n\nalgorithm partidaVideojuego\n
+        \ var\n    puntuacion: integer;\n    energia: real;\n    nivelCompletado:
+        boolean;\n    inicialJugador: character;\n    nombreJugador: string;\n  end
+        var\n\n  puntuacion := 500;\n  energia := VELOCIDAD_JUGADOR;\n  nivelCompletado
+        := false;\n  inicialJugador := 'L';\n  nombreJugador := \"Link\";\n\n  writeString(\"Jugador
+        \");\n  writeCharacter(inicialJugador);\n  writeString(\" (\");\n  writeString(nombreJugador);\n
+        \ writeString(\") empieza con \");\n  writeInteger(VIDAS_INICIALES);\n  writeString(\"
+        vidas y velocidad \");\n  writeReal(VELOCIDAD_JUGADOR);\nend algorithm\n```\n\nEste
+        algoritmo simula la inicialización de un jugador al comenzar una partida.\n"
+    questions:
+    - id: c-1-judge-suma
+      language: C
+      week: 1
+      mode: judge_c
+      prompt: Escribe un programa completo que lea dos enteros y muestre su suma seguida
+        de un salto de línea.
+      answer: |
+        #include <stdio.h>
+
+        int main(void) {
+          int a, b;
+          scanf("%d %d", &a, &b);
+          printf("%d\n", a + b);
+          return 0;
+        }
+      tests:
+      - input: '2 3
+
+          '
+        output: '5
+
+          '
+      - input: '10 -4
+
+          '
+        output: '6
+
+          '
+      hint: Usa scanf para leer ambos enteros y printf para escribir la suma exacta.
+    - id: c-1-judge-paridad
+      language: C
+      week: 1
+      mode: judge_c
+      prompt: Escribe un programa completo que lea un entero. Si es par imprime PAR\n,
+        en caso contrario imprime IMPAR\n.
+      answer: |
+        #include <stdio.h>
+
+        int main(void) {
+          int n;
+          scanf("%d", &n);
+          if (n % 2 == 0) {
+            printf("PAR\n");
+          } else {
+            printf("IMPAR\n");
+          }
+          return 0;
+        }
+      tests:
+      - input: '8
+
+          '
+        output: 'PAR
+
+          '
+      - input: '7
+
+          '
+        output: 'IMPAR
+
+          '
+      hint: Puedes usar el operador módulo (%).
+    - id: c-1-max_nombre
+      language: C
+      week: 1
+      prompt: Usando la directiva define, declara una constante para el máximo de
+        un nombre "MAX_NOMBRE" con el valor entero 20.
+      answer: "#define MAX_NOMBRE 20"
+      hint:
+      mode: normalize
+    - id: c-1-max_drones
+      language: C
+      week: 1
+      prompt: Declara una constante para el máximo de drones "MAX_DRONES" con el valor
+        entero 5.
+      answer: "#define MAX_DRONES 5"
+      hint:
+      mode: normalize
+    - id: p-1-max_drones
+      language: Pseudocode
+      week: 1
+      prompt: Declara una constante para el máximo de drones "MAX_DRONES" con el valor
+        entero 5.
+      answer: |-
+        const
+            MAX_DRONES: integer = 5;
+        end const
+      hint:
+      mode: normalize
+    - id: c-1-const_decimal
+      language: C
+      week: 1
+      prompt: Declara una constante local de tipo decimal para la distancia mínima
+        "DISTANCIA_MINIMA", asignale el valor 250.0.
+      answer: |
+        int main(){
+          const float DISTANCIA_MINIMA = 250.0;
+          return 0;
+        }
+      hint: Las constantes locales comienzan por const.
+      mode: normalize
+    - id: p-1-const_decimal
+      language: Pseudocode
+      week: 1
+      prompt: Declara una constante de tipo decimal para la distancia mínima "DISTANCIA_MINIMA",
+        asignale el valor 250.0.
+      answer: |-
+        const
+          DISTANCIA_MINIMA: real = 250.0;
+        end const
+      hint: No olvides las palabras reservadas const end const y ;
+      mode: normalize
+    - id: c-1-const_entera
+      language: C
+      week: 1
+      prompt: Declara una constante local de tipo entera para el puntaje inicial INITIAL_SCORE,
+        asignale el valor 0.
+      answer: |
+        int main(){
+            const int INITIAL_SCORE = 0;
+          return 0;
+        }
+      hint: Las constantes locales comienzan por const.
+      mode: normalize
+    - id: p-1-const_entera
+      language: Pseudocode
+      week: 1
+      prompt: Declara una constante local de tipo entera para el puntaje inicial INITIAL_SCORE,
+        asignale el valor 0.
+      answer: |
+        const
+          INITIAL_SCORE: integer = 0;
+        end const
+      hint: No olvides las palabras reservadas const end const y ;
+      mode: normalize
+    - id: c-1-nombredron_20
+      language: C
+      week: 1
+      prompt: Declara una cadena de caracteres llamada nombreDron con tamaño 20.
+      answer: |
+        int main(){
+          char nombreDron[20];
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-nombredron_string
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable de tipo string llamada nombreDron.
+      answer: |-
+        algorithm
+          var
+            nombreDron: string;
+          end var
+        end algorithm
+      hint: Recuerda las palabras reservadas var end var.
+      mode: normalize
+    - id: c-1-nombredron_max_nombre
+      language: C
+      week: 1
+      prompt: Declara una cadena de caracteres llamada nombreDron con tamaño 20, pero
+        esta vez utiliza la constante "MAX_NOMBRE".
+      answer: |
+        int main(){
+          char nombreDron[MAX_NOMBRE];
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: c-1-iddron_entera
+      language: C
+      week: 1
+      prompt: Declara una variable entera para almacenar el identificador del dron,
+        llamala idDron.
+      answer: |
+        int main(){
+          int idDron;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-iddron_entera
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable entera para almacenar el identificador del dron,
+        llamala idDron.
+      answer: "algorithm\n  var \n    idDron: integer; \n  end var\nend algorithm"
+      hint:
+      mode: normalize
+    - id: c-1-bateriainicial_float
+      language: C
+      week: 1
+      prompt: Declara una variable decimal para la batería inicial del dron, llamala
+        bateriaInicial.
+      answer: |
+        int main(){
+          float bateriaInicial;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-bateriainicial_real
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable decimal para la batería inicial del dron, llamala
+        bateriaInicial.
+      answer: "algorithm\n  var \n    bateriaInicial: real; \n  end var\nend algorithm"
+      hint:
+      mode: normalize
+    - id: c-1-iddron_menos1
+      language: C
+      week: 1
+      prompt: Inicializa la variable idDron en -1.
+      answer: |
+        int main(){
+          idDron = -1;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-iddron_menos1
+      language: Pseudocode
+      week: 1
+      prompt: Inicializa la variable idDron en -1.
+      answer: |
+        algorithm
+          idDron := -1;
+        end algorithm
+      hint: El operador de asignación en pseudocódigo es diferente al de C.
+      mode: normalize
+    - id: c-1-distanciaminima_const
+      language: C
+      week: 1
+      prompt: Declara una variable llamada distanciaMinima e inicializala con la constante
+        "DISTANCIA_MINIMA".
+      answer: |-
+        int main(){
+          float distanciaMinima = DISTANCIA_MINIMA;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-distanciaminima_const
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable llamada distanciaMinima e inicializala con la constante
+        "DISTANCIA_MINIMA".
+      answer: |-
+        algorithm
+          var
+            distanciaMinima: real;
+          end var
+
+          distanciaMinima:= DISTANCIA_MINIMA;
+
+        end algorithm
+      hint: Aquí es importante recordar que en pseudocódigo no es posible declarar
+        e inicializar a la vez, primero declara y luego asignale el valor, no olvides
+        las palabras reservadas var end var.
+      mode: normalize
+    - id: c-1-dronactivo_true
+      language: C
+      week: 1
+      prompt: Declara una variable booleana llamada dronActivo e inicialízala a true
+        en la misma linea.
+      answer: |
+        int main(){
+          bool dronActivo = true;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-dronactivo_true
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable booleana llamada dronActivo e inicialízala a true.
+      answer: "algorithm\n  var \n    dronActivo: boolean; \n  end var \n\n  dronActivo
+        := true;\n\nend algorithm"
+      hint: Recuerda, primero declara (var end var) y luego inicializa.
+      mode: normalize
+    - id: c-1-categoriadron_a
+      language: C
+      week: 1
+      prompt: Declara e inicializa una variable char llamada categoriaDron a "A" en
+        la misma linea.
+      answer: |
+        int main(){
+          char categoriaDron = 'A';
+          return 0;
+        }
+      hint: Los caracteres se inicializan entre ''.
+      mode: normalize
+    - id: p-1-categoriadron_a
+      language: Pseudocode
+      week: 1
+      prompt: Declara e inicializa una variable char llamada categoriaDron a "A".
+      answer: |-
+        algorithm
+          var
+            categoriaDron: character;
+          end var
+
+          categoriaDron := 'A'
+        end algorithm
+      hint: Recuerda, primero declara y luego inicializa. Los caracteres se inicializan
+        entre ''.
+      mode: normalize
+  - number: 2
+    explanation:
+      C: "En este nivel aprenderás a leer y escribir datos en C utilizando las funciones
+        `scanf` y `printf`.  \nEstas funciones permiten la interacción entre el programa
+        y el jugador: `scanf` captura lo que escribe el usuario, y `printf` muestra
+        información en pantalla.\n\n### Lectura de datos con `scanf`\nSe usa para
+        leer información introducida por el jugador.  \n- En variables simples (`int`,
+        `float`, `char`) se pasa la **dirección de memoria** con `&`.  \n- En cadenas
+        (`char[]`), no se usa `&` porque los arrays ya son punteros.\n\n```c\n#include
+        <stdio.h>\n\nint main() {\n    char nombreJugador[30];\n    int nivel;\n    float
+        energia;\n    char teclaAccion;\n\n    scanf(\"%s\", nombreJugador); // cadena\n
+        \   scanf(\"%d\", &nivel);        // entero\n    scanf(\"%f\", &energia);
+        \     // decimal\n    scanf(\" %c\", &teclaAccion); // carácter\n    return
+        0;\n}\n```\n\nTambién puedes leer datos sobre un string que ya tenga un valor
+        inicial (se reemplaza el contenido):\n\n```c\n#include <stdio.h>\n\nint main()
+        {\n    char nombreJugador[30] = \"Jugador1\";\n    printf(\"Introduce nuevo
+        nombre: \");\n    scanf(\"%s\", nombreJugador);\n    return 0;\n}\n```\n\n####
+        Formatos comunes en `scanf`\n- `%s` → cadenas  \n- `%d` → enteros  \n- `%f`
+        → decimales  \n- `%c` → caracteres  \n\n---\n\n### Escritura de datos con
+        `printf`\nSe usa para mostrar información de la partida en pantalla.  \nLos
+        valores se muestran en el mismo orden que aparecen en la cadena de formato.\n\n```c\n#include
+        <stdio.h>\n\nint main() {\n    char nombreJugador[30] = \"Mario\";\n    int
+        nivel = 2;\n    float energia = 75.5;\n    char teclaAccion = 'A';\n\n    printf(\"Jugador:
+        %s\\n\", nombreJugador);\n    printf(\"Nivel: %d\\n\", nivel);\n    printf(\"Energía:
+        %.1f%%\\n\", energia);\n    printf(\"Tecla de acción: %c\\n\", teclaAccion);\n\n
+        \   return 0;\n}\n```\n\n#### Formatos comunes en `printf`\n- `%s` → cadenas
+        \ \n- `%d` → enteros  \n- `%f` → decimales  \n- `%.1f` → decimales con 1 cifra
+        \ \n- `%c` → caracteres  \n\n**Notas importantes**\n- En `scanf`, usar `&`
+        para variables simples (int, float, char), pero no para cadenas.  \n- En `printf`,
+        el orden y tipo de las variables deben coincidir con los especificadores.
+        \ \n\n---\n\n### Ejemplo completo\n```c\n#include <stdio.h>\n\nint main()
+        {\n    char nombreJugador[30];\n    int nivel;\n    float energia;\n    char
+        teclaAccion;\n\n    printf(\"Introduce tu nombre: \");\n    scanf(\"%s\",
+        nombreJugador);\n\n    printf(\"Introduce nivel inicial: \");\n    scanf(\"%d\",
+        &nivel);\n\n    printf(\"Introduce energía inicial: \");\n    scanf(\"%f\",
+        &energia);\n\n    printf(\"Introduce la tecla de acción: \");\n    scanf(\"
+        %c\", &teclaAccion);\n\n    printf(\"\\n--- Datos del jugador ---\\n\");\n
+        \   printf(\"Nombre: %s\\n\", nombreJugador);\n    printf(\"Nivel: %d\\n\",
+        nivel);\n    printf(\"Energía: %.1f\\n\", energia);\n    printf(\"Tecla de
+        acción: %c\\n\", teclaAccion);\n\n    return 0;\n}\n```\n\nEste programa solicita
+        al jugador sus datos y luego los muestra por pantalla.\n"
+      Pseudocode: "En este nivel aprenderás a leer y escribir datos en pseudocódigo
+        utilizando las funciones `readTipo()` y `writeTipo()`.  \nEstas funciones
+        permiten la interacción entre el programa y el jugador: `read...` captura
+        lo que escribe el usuario, y `write...` muestra información en pantalla.\n\n###
+        Lectura de datos\nCada tipo de dato tiene su función de lectura `readTipo()`.
+        \ \nEl valor obtenido debe asignarse a una variable con `:=`.\n\n```pseudocode\nalgorithm\n
+        \ var\n    nombreJugador: string;\n    nivel: integer;\n    energia: real;\n
+        \   teclaAccion: character;\n    modoCoop: boolean;\n  end var\n\n  nombreJugador
+        := readString();\n  nivel := readInteger();\n  energia := readReal();\n  teclaAccion
+        := readCharacter();\n  modoCoop := readBoolean();\nend algorithm\n```\n\nTambién
+        puedes leer sobre un string que ya tenga valor inicial (el contenido anterior
+        se reemplaza):\n\n```pseudocode\nalgorithm\n  var\n    nombreJugador: string;\n
+        \ end var\n\n  nombreJugador := \"Jugador1\";\n  nombreJugador := readString();\nend
+        algorithm\n```\n\n#### Funciones más comunes de lectura\n- `readString()`
+        → cadenas  \n- `readInteger()` → enteros  \n- `readReal()` → decimales  \n-
+        `readCharacter()` → caracteres  \n- `readBoolean()` → booleanos (`true` /
+        `false`)  \n\n---\n\n### Escritura de datos\nCada tipo de dato tiene su función
+        `writeTipo(valor)`.  \nSolo puedes imprimir un dato por llamada, por lo que
+        debes hacer varias llamadas para mostrar diferentes valores.\n\n```pseudocode\nwriteString(\"Jugador:
+        \");\nwriteString(nombreJugador);\n\nwriteString(\", Nivel: \");\nwriteInteger(nivel);\n\nwriteString(\",
+        Energía: \");\nwriteReal(energia);\n\nwriteString(\", Tecla de acción: \");\nwriteCharacter(teclaAccion);\n\nwriteString(\",
+        Modo cooperativo: \");\nwriteBoolean(modoCoop);\n```\n\n#### Funciones más
+        comunes de escritura\n- `writeString(valor)` → cadenas  \n- `writeInteger(valor)`
+        → enteros  \n- `writeReal(valor)` → decimales  \n- `writeCharacter(valor)`
+        → caracteres  \n- `writeBoolean(valor)` → booleanos  \n\n**Notas importantes**\n-
+        Cada llamada `write...` imprime un único dato o texto.  \n- Los booleanos
+        se muestran como `true` o `false`.  \n- El orden de las llamadas determina
+        el orden en pantalla.  \n\n---\n\n### Ejemplo completo\n```pseudocode\nalgorithm
+        datosJugador\n  var\n    nombreJugador: string;\n    nivel: integer;\n    energia:
+        real;\n    teclaAccion: character;\n  end var\n\n  writeString(\"Introduce
+        tu nombre: \");\n  nombreJugador := readString();\n\n  writeString(\"Introduce
+        nivel inicial: \");\n  nivel := readInteger();\n\n  writeString(\"Introduce
+        energía inicial: \");\n  energia := readReal();\n\n  writeString(\"Introduce
+        la tecla de acción: \");\n  teclaAccion := readCharacter();\n\n  writeString(\"---
+        Datos del jugador --- \");\n  writeString(\"Nombre: \");\n  writeString(nombreJugador);\n
+        \ writeString(\", Nivel: \");\n  writeInteger(nivel);\n  writeString(\", Energía:
+        \");\n  writeReal(energia);\n  writeString(\", Tecla: \");\n  writeCharacter(teclaAccion);\nend
+        algorithm\n```\n\nEste algoritmo solicita al jugador sus datos y luego los
+        muestra en pantalla.\n"
+    questions:
+    - id: c-1-scanf_nombredron
+      language: C
+      week: 1
+      prompt: Lee el nombre del dron desde teclado usando scanf y guardalo en nombreDron.
+      answer: |
+        int main(){
+          scanf("%s", nombreDron);
+          return 0;
+        }
+      hint: El especificador de formato de string es %s.
+      mode: normalize
+    - id: p-1-readstring_nombredron
+      language: Pseudocode
+      week: 1
+      prompt: Lee el nombre del dron desde teclado y guardalo en nombreDron.
+      answer: |
+        algorithm
+          nombreDron := readString();
+        end algorithm
+      hint: Recuerda que cada tipo tiene una función de lectura que comienza por read.
+        El formato es similar al de una inicialización.
+      mode: normalize
+    - id: c-1-scanf_iddron
+      language: C
+      week: 1
+      prompt: Lee el identificador del dron desde teclado usando scanf y guardalo
+        en idDron.
+      answer: |
+        int main(){
+          scanf("%d", &idDron);
+          return 0;
+        }
+      hint: El especificador de formato de integer es %d.
+      mode: normalize
+    - id: p-1-readinteger_iddron
+      language: Pseudocode
+      week: 1
+      prompt: Lee el identificador del dron desde teclado y guardalo en idDron.
+      answer: |
+        algorithm
+          idDron := readInteger();
+        end algorithm
+      hint: Recuerda que cada tipo tiene una función de lectura que comienza por read.
+        El formato es similar al de una inicialización.
+      mode: normalize
+    - id: c-1-scanf_bateriai
+      language: C
+      week: 1
+      prompt: Lee el valor de la batería inicial desde teclado usando scanf y guárdalo
+        en bateriaInicial.
+      answer: |
+        int main(){
+          scanf("%f", &bateriaInicial);
+          return 0;
+        }
+      hint: El especificador de formato de float es %f.
+      mode: normalize
+    - id: p-1-readreal_bateriai
+      language: Pseudocode
+      week: 1
+      prompt: Lee el valor de la batería inicial desde teclado y guárdalo en bateriaInicial.
+      answer: |
+        algorithm
+          bateriaInicial := readReal();
+        end algorithm
+      hint: Recuerda que cada tipo tiene una función de lectura que comienza por read.
+        El formato es similar al de una inicialización.
+      mode: normalize
+    - id: c-1-scanf_categoriadron
+      language: C
+      week: 1
+      prompt: Lee un carácter del usuario desde teclado usando scanf y guárdalo en
+        categoriaDron.
+      answer: |
+        int main(){
+          scanf(" %c", &categoriaDron);
+          return 0;
+        }
+      hint: El especificador de formato de char es %c.
+      mode: normalize
+    - id: p-1-readcharacter_categoriadron
+      language: Pseudocode
+      week: 1
+      prompt: Lee un character del usuario desde teclado y guárdalo en categoriaDron.
+      answer: |
+        algorithm
+          categoriaDron := readCharacter();
+        end algorithm
+      hint: Recuerda que cada tipo tiene una función de lectura que comienza por read.
+        El formato es similar al de una inicialización.
+      mode: normalize
+    - id: c-1-printf_nombre_id
+      language: C
+      week: 1
+      prompt: 'Imprime el nombre del dron y su identificador. Usa "Dron: x, ID: x"
+        para la impresión, siendo "x" el especificador de formato.'
+      answer: |
+        int main(){
+          printf("Dron: %s, ID: %d", nombreDron, idDron);
+          return 0;
+        }
+      hint: 'Ejemplo de ejecución: "Dron: dron001, ID: 1"'
+      mode: normalize
+    - id: p-1-writestring_nombre_id
+      language: Pseudocode
+      week: 1
+      prompt: 'Imprime el nombre del dron y su identificador. Usa "Dron: x, ID: x"
+        para la impresión, siendo "x" el valor pertinente.'
+      answer: "algorithm\n  writeString(\"Dron: \"); \n  writeString(nombreDron);
+        \n  writeString(\", ID: \"); \n  writeInteger(idDron);'\nend algorithm"
+      hint: 'Ejemplo de ejecución: "Dron: dron001, ID: 1". Recuerda que en pseudocódigo
+        no puedes imprimir mas de un dato por linea.'
+      mode: normalize
+    - id: c-1-printf_bateria
+      language: C
+      week: 1
+      prompt: 'Imprime la batería inicial del dron con un decimal. Usa "Batería: x"
+        para la impresión, siendo "x" el especificador de formato.'
+      answer: |
+        int main(){
+          printf("Batería: %.1f", bateriaInicial);
+          return 0;
+        }
+      hint: Para imprimir cierto numero de decimales utiliza %.xf, siendo x el numero
+        de decimales.
+      mode: normalize
+    - id: p-1-writestring_bateria
+      language: Pseudocode
+      week: 1
+      prompt: 'Imprime la batería inicial del dron. Usa "Batería: x" para la impresión,
+        siendo "x" el valor pertinente.'
+      answer: |-
+        algorithm
+          writeString("Batería: ");
+          writeReal(bateriaInicial);
+        end algorithm
+      hint:
+      mode: normalize
+    - id: c-1-printf_categoria
+      language: C
+      week: 1
+      prompt: 'Imprime la categoría del dron como carácter. Usa "Categoría: x" para
+        la impresión, siendo "x" el especificador de formato.'
+      answer: |
+        int main(){
+          printf("Categoría: %c", categoriaDron);
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-writestring_categoria
+      language: Pseudocode
+      week: 1
+      prompt: 'Imprime la categoría del dron como carácter. Usa "Categoría: x" para
+        la impresión, siendo "x" el valor pertinente.'
+      answer: |-
+        algorithm
+          writeString("Categoría: ");
+          writeCharacter(categoriaDron);
+        end algorithm
+      hint:
+      mode: normalize
+  - number: 3
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **enumerativos, operadores aritméticos,
+        relacionales y lógicos, el operador ternario y conversiones de tipo en C**.
+        \ \nEstos conceptos son muy útiles para representar estados de un videojuego,
+        calcular puntuaciones o decidir acciones en el juego.\n\n### Enumerativos
+        (enum)\nUn `enum` define un conjunto finito de etiquetas con valores enteros
+        subyacentes (normalmente `int` empezando en 0).  \nSon ideales para representar
+        estados del juego con nombres claros en lugar de números.\n\n```c\n#include
+        <stdio.h>\n\ntypedef enum {\n  IDLE, ATACANDO, KO\n} tEstadoJugador;\n\nint
+        main() {\n    tEstadoJugador estado = ATACANDO;   // inicialización\n\n    //
+        Lectura como entero sin signo\n    scanf(\"%u\", &estado);   // %u es el especificador
+        para enumerativos\n\n    // Impresión del valor numérico\n    printf(\"Estado
+        (0=IDLE,1=ATACANDO,2=KO): %u\\n\", estado);\n    return 0;\n}\n```\n\n---\n\n###
+        Operadores aritméticos y compuestos\n- Básicos: `+ - * / %`  \n- Compuestos:
+        `+= -= *= /= %=` (operación + asignación).  \n- `++` y `--` incrementan/decrementan
+        en 1.\n\n```c\n#include <stdio.h>\n\nint main() {\n    int puntuacion = 900;\n
+        \   puntuacion += 50;    // ahora 950\n    int vidas = 3;\n    vidas--;             //
+        ahora 2\n    float energia = 87.5f;\n    energia -= 12.5f;    // ahora 75.0\n
+        \   return 0;\n}\n```\n\n---\n\n### Operadores relacionales y lógicos\n- Comparaciones:
+        `== != < <= > >=` → devuelven `bool`.  \n- Lógicos: `&&` (AND), `||` (OR),
+        `!` (NOT).  \n\n```c\n#include <stdio.h>\n#include <stdbool.h>\n\nint main()
+        {\n    bool activo = true;\n    bool averiado = false;\n    float bateria
+        = 22.0f;\n    int vidas = 3;\n\n    bool suficiente = (bateria >= 20.0f);\n
+        \   bool enServicio = activo && !averiado;\n    bool puedeJugar = suficiente
+        && (vidas > 0);\n\n    return 0;\n}\n```\n\n---\n\n### Operador ternario `?:`\nSelecciona
+        entre dos expresiones según una condición.\n\n```c\n#include <stdio.h>\n#include
+        <stdbool.h>\n\nint main() {\n    int puntuacion = 1050;\n    bool enServicio
+        = true;\n\n    printf(\"%s\\n\", enServicio ? \"En servicio\" : \"Fuera de
+        servicio\");\n    int bonus = (puntuacion >= 1000) ? 100 : 0;\n\n    printf(\"Bonus:
+        %d\\n\", bonus);\n    return 0;\n}\n```\n\n---\n\n### Conversiones (casts)\n```c\n#include
+        <stdio.h>\n\nint main() {\n    float energia = 73.8f;\n    int energiaEntera
+        = (int)energia;    // 73\n    int vidas = 2;\n    float vidasF = (float)vidas;
+        \        // 2.0\n\n    printf(\"Energía entera: %d\\n\", energiaEntera);\n
+        \   printf(\"Vidas como real: %.1f\\n\", vidasF);\n\n    return 0;\n}\n```\n\n---\n\n###
+        Ejemplo completo\n```c\n#include <stdio.h>\n#include <stdbool.h>\n\ntypedef
+        enum {\n  IDLE, ATACANDO, KO\n} tEstadoJugador;\n\nint main() {\n    int puntuacion
+        = 950;\n    int vidas = 3;\n    float energia = 73.8f;\n    bool activo =
+        true;\n    bool averiado = false;\n    tEstadoJugador estado = ATACANDO;\n\n
+        \   // Relacionales y lógicos\n    bool suficiente = (energia >= 50.0f);\n
+        \   bool enServicio = activo && !averiado;\n\n    // Operador ternario\n    int
+        bonus = (puntuacion >= 1000) ? 100 : 0;\n\n    // Conversiones\n    int energiaEntera
+        = (int)energia;\n\n    printf(\"Estado del jugador: %u\\n\", estado);\n    printf(\"Puntuación:
+        %d (+%d bonus)\\n\", puntuacion, bonus);\n    printf(\"Vidas: %d\\n\", vidas);\n
+        \   printf(\"Energía: %.1f (entera: %d)\\n\", energia, energiaEntera);\n    printf(\"En
+        servicio: %s\\n\", enServicio ? \"Sí\" : \"No\");\n    return 0;\n}\n```\n\nEste
+        programa combina enumerativos, operadores y conversiones para simular el estado
+        de un jugador en un videojuego.\n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **enumerativos, operadores
+        aritméticos, relacionales y lógicos, además de conversiones de tipo en pseudocódigo**.
+        \ \nEstos conceptos son muy útiles para representar estados de un videojuego,
+        actualizar puntuaciones o decidir acciones.\n\n### Enumerativos\n```pseudocode\ntype\n
+        \ tEstadoJugador = { IDLE, ATACANDO, KO }\nend type\n\nalgorithm\n  var\n
+        \   estado: tEstadoJugador;\n  end var\n\n  estado := ATACANDO;\n  estado
+        := readEnum();\n  writeString(\"Estado actual: \");\n  writeEnum(estado);\nend
+        algorithm\n```\n\n---\n\n### Operadores aritméticos\n```pseudocode\nalgorithm\n
+        \ var\n    puntuacion: integer;\n    vidas: integer;\n    energia: real;\n
+        \ end var\n\n  puntuacion := 900;\n  puntuacion := puntuacion + 50;   { ahora
+        950 }\n  vidas := 3;\n  vidas := vidas - 1;              { ahora 2 }\n  energia
+        := 87.5;\n  energia := energia - 12.5;       { ahora 75.0 }\nend algorithm\n```\n\n---\n\n###
+        Operadores relacionales y lógicos\n```pseudocode\nalgorithm\n  var\n    bateria:
+        real;\n    vidas: integer;\n    activo: boolean;\n    averiado: boolean;\n
+        \   suficiente: boolean;\n    puedeJugar: boolean;\n  end var\n\n  bateria
+        := 22.0;\n  vidas := 3;\n  activo := true;\n  averiado := false;\n\n  suficiente
+        := bateria ≥ 20.0;\n  puedeJugar := suficiente y (vidas > 0);\n  activo :=
+        no averiado;\nend algorithm\n```\n\n---\n\n### Conversiones de tipo\n```pseudocode\nalgorithm\n
+        \ var\n    energia: real;\n    energiaEntera: integer;\n    vidas: integer;\n
+        \   vidasF: real;\n  end var\n\n  energia := 73.8;\n  energiaEntera := realToInteger(energia);\n
+        \ vidas := 2;\n  vidasF := integerToReal(vidas);\n\n  writeString(\"Energía
+        entera: \");\n  writeInteger(energiaEntera);\n  writeString(\", Vidas como
+        real: \");\n  writeReal(vidasF);\nend algorithm\n```\n\n---\n\n### Ejemplo
+        completo\n```pseudocode\ntype\n  tEstadoJugador = { IDLE, ATACANDO, KO }\nend
+        type\n\nalgorithm estadoJugador\n  var\n    puntuacion: integer;\n    vidas:
+        integer;\n    energia: real;\n    activo: boolean;\n    averiado: boolean;\n
+        \   estado: tEstadoJugador;\n    suficiente: boolean;\n    enServicio: boolean;\n
+        \   energiaEntera: integer;\n    bonus: integer;\n  end var\n\n  puntuacion
+        := 950;\n  vidas := 3;\n  energia := 73.8;\n  activo := true;\n  averiado
+        := false;\n  estado := ATACANDO;\n\n  suficiente := energia ≥ 50.0;\n  enServicio
+        := activo y (no averiado);\n\n  { Operador ternario simulado con asignación
+        condicional }\n  si puntuacion ≥ 1000 entonces\n    bonus := 100;\n  si no\n
+        \   bonus := 0;\n  fin si\n\n  energiaEntera := realToInteger(energia);\n\n
+        \ writeString(\"Estado del jugador: \");\n  writeEnum(estado);\n  writeString(\",
+        Puntuación: \");\n  writeInteger(puntuacion);\n  writeString(\" (+\");\n  writeInteger(bonus);\n
+        \ writeString(\" bonus)\");\n  writeString(\", Vidas: \");\n  writeInteger(vidas);\n
+        \ writeString(\", Energía: \");\n  writeReal(energia);\n  writeString(\" (entera:
+        \");\n  writeInteger(energiaEntera);\n  writeString(\")\");\n  writeString(\",
+        En servicio: \");\n  writeBoolean(enServicio);\nend algorithm\n```\n\nEste
+        algoritmo combina enumerativos, operadores y conversiones para simular el
+        estado de un jugador en un videojuego.\n"
+    questions:
+    - id: c-1-enum_tdrone
+      language: C
+      week: 1
+      prompt: Declara un enumerado tDronEstado con los valores PARADO, EN_VUELO y
+        ESTRELLADO.
+      answer: "typedef enum { \n  PARADO, \n  EN_VUELO, \n  ESTRELLADO \n} tDronEstado;"
+      hint: la palabra reservada es typedef enum, recuerda poner ; a continuación
+        del nombre del enum.
+      mode: normalize
+    - id: p-1-type_tdrone
+      language: Pseudocode
+      week: 1
+      prompt: Declara un enumerado tDronEstado con los valores PARADO, EN_VUELO y
+        ESTRELLADO.
+      answer: |-
+        type
+          tDronEstado = { PARADO, EN_VUELO y ESTRELLADO }
+        end type
+      hint: No olvides las palabras reservadas type end type.
+      mode: normalize
+    - id: c-1-estado_en_vuelo
+      language: C
+      week: 1
+      prompt: Declara una variable tDronEstado llamada estado e inicialízala a EN_VUELO.
+      answer: |
+        int main(){
+          tDronEstado estado = EN_VUELO;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-estado_en_vuelo
+      language: Pseudocode
+      week: 1
+      prompt: Declara una variable tDronEstado llamada estado e inicialízala a EN_VUELO.
+      answer: |-
+        algorithm
+          var
+            estado: tDronEstado;
+          end var
+
+        estado := EN_VUELO;
+
+        end algorithm
+      hint: 'Recuerda: primero declara, luego inicializa.'
+      mode: normalize
+    - id: c-1-lee_estado_enum
+      language: C
+      week: 1
+      prompt: Lee el valor del estado del dron desde teclado usando scanf y guárdalo
+        en estado.
+      answer: |
+        int main(){
+          scanf("%u", &estado);
+          return 0;
+        }
+      hint: El especificador de formato para leer enumerativos es %u
+      mode: normalize
+    - id: p-1-readenum_estado
+      language: Pseudocode
+      week: 1
+      prompt: Lee el valor del estado del dron desde teclado usando scanf y guárdalo
+        en estado.
+      answer: |
+        algorithm
+          estado := readEnum();
+        end algorithm
+      hint: La función que se encarga de leer un enumerativo es readEnum.
+      mode: normalize
+    - id: c-1-printf_estado_num
+      language: C
+      week: 1
+      prompt: 'Imprime el valor numérico del estado del dron con una explicación.
+        Usa "Estado (0=PARADO, 1=EN_VUELO, 2=ESTRELLADO): x" para la impresión, siendo
+        "x" el especificador de formato.'
+      answer: |
+        int main(){
+          printf("Estado (0=PARADO, 1=EN_VUELO, 2=ESTRELLADO): %d", estado);
+          return 0;
+        }
+      hint: 'Ejemplo de ejecución: "Estado (0=PARADO, 1=EN_VUELO, 2=ESTRELLADO): 1"'
+      mode: normalize
+    - id: p-1-writestring_estado_num
+      language: Pseudocode
+      week: 1
+      prompt: 'Imprime el valor del estado del dron con una explicación. Usa "Estado:
+        x" para la impresión, siendo "x" el valor a enseñar.'
+      answer: |-
+        algorithm
+          writeString("Estado: ");
+          writeEnum(estado);
+        end algorithm
+      hint: 'Ejemplo de ejecución: Estado: 1'
+      mode: normalize
+    - id: c-1-incremento_iddron
+      language: C
+      week: 1
+      prompt: Incrementa la variable idDron en 1 usando el operador de incremento
+        al finalizar la carrera.
+      answer: |
+        int main(){
+          idDron++;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-incrementa_iddron
+      language: Pseudocode
+      week: 1
+      prompt: Incrementa la variable idDron en 1 al finalizar la carrera.
+      answer: |
+        algorithm
+          idDron := idDron +1;
+        end algorithm
+      hint: Recuerda que en pseudocódigo no existe el operador ++ o -- .
+      mode: normalize
+    - id: c-1-compuesto_bateria
+      language: C
+      week: 1
+      prompt: Resta 10.5 a la bateríaInicial usando operador compuesto.
+      answer: |
+        int main(){
+          float bateriaInicial = 100.0;
+          bateriaInicial -= 10.5;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-resta_bateria
+      language: Pseudocode
+      week: 1
+      prompt: Resta 10.5 a la bateríaInicial .
+      answer: |
+        algorithm
+          bateriaInicial := bateriaInicial - 10.5;
+        end algorithm
+      hint:
+      mode: normalize
+    - id: c-1-suficiente_bool
+      language: C
+      week: 1
+      prompt: Calcula si la batería es suficiente usando un operador relacional y
+        guarda el resultado en en una variable booleana "suficiente". Diremos que
+        la batería es suficiente si tiene al menos un 20%
+      answer: |
+        int main(){
+          bool suficiente = bateriaInicial >= 20.0;
+          return 0;
+        }
+      hint: batería mayor o igual a 20.0
+      mode: normalize
+    - id: p-1-suficiente_bool
+      language: Pseudocode
+      week: 1
+      prompt: Calcula si la batería es suficiente usando un operador relacional y
+        guarda el resultado en en una variable booleana "suficiente". Diremos que
+        la batería es suficiente si tiene al menos un 20%. Necesitarás este operador
+        "≥".
+      answer: |-
+        algorithm
+          var
+            suficiente: boolean;
+          end var
+
+          suficiente := bateriaInicial ≥ 20.0;
+
+        end algorithm
+      hint: 'Ten en cuenta que una comparación con operadores relacionales, siempre
+        devuelven un resultado booleano de verdadero o falso, por eso podemos guardar
+        el resultado en una variable booleana. Extra: bateria ≥ a 20.0.'
+      mode: normalize
+    - id: c-1-ternario_en_servicio
+      language: C
+      week: 1
+      prompt: Usa el operador ternario para imprimir "En servicio" si dronActivo es
+        verdadero, si no imprime "Fuera de servicio".
+      answer: |
+        int main(){
+          printf("%s", dronActivo ? "En servicio" : "Fuera de servicio");
+          return 0;
+        }
+      hint: 'recuerda que printf acepta como argumento cualquier expresión que devuelva
+        un valor, por eso podemos usar el operador ternario. Ejemplo: printf("%s",
+        variable o condición ? "output1"" : ""output2"");"'
+      mode: normalize
+    - id: c-1-ternario_apto
+      language: C
+      week: 1
+      prompt: Imprime "Apto para siguiente ronda" si suficiente es verdadero, si no
+        imprime "No apto", usando ternario.
+      answer: |
+        int main(){
+          printf("%s", suficiente ? "Apto para siguiente ronda" : "No apto");
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: c-1-cast_bateriaentera
+      language: C
+      week: 1
+      prompt: Convierte bateriaInicial a entero y guárdalo en bateriaEntera.
+      answer: "\nint main(){\n  int bateriaEntera = (int)bateriaInicial;              \n
+        \ return 0;\n}\n"
+      hint: Recuerda que para castear una variable utilizas (tipo)variable.
+      mode: normalize
+    - id: p-1-cast_bateriaentera
+      language: Pseudocode
+      week: 1
+      prompt: Convierte bateriaInicial a entero y guárdalo en bateriaEntera.
+      answer: |-
+        algorithm
+          var
+            bateriaEntera: integer;
+          end var
+
+          bateriaEntera := realToInteger(bateriaInicial);
+        end algorithm
+      hint: Recuerda que para castear una variable decimal a una entera usamos realToInteger().
+        También recuerda que primero debes declarar la variable bateriaEntera.
+      mode: normalize
+    - id: c-1-cast_nuevabateria
+      language: C
+      week: 1
+      prompt: Convierte bateriaEntera otra vez a decimal y guárdalo en nuevaBateria.
+      answer: |
+        int main(){
+          float nuevaBateria = (float)bateriaEntera;
+          return 0;
+        }
+      hint:
+      mode: normalize
+    - id: p-1-cast_nuevabateria
+      language: Pseudocode
+      week: 1
+      prompt: Convierte bateriaEntera otra vez a decimal y guárdalo en nuevaBateria.
+      answer: |-
+        algorithm
+          var
+            nuevaBateria: integer;
+          end var
+
+          nuevaBateria := integerToReal(bateriaInicial);
+        end algorithm
+      hint:
+      mode: normalize
+- number: 2
+  explanation: 'Explicación de semana 2
+
+    '
+  levels:
+  - number: 1
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **arrays en C**, tanto de números
+        como de cadenas.  \nLos arrays son fundamentales en videojuegos para guardar
+        puntuaciones de enemigos, inventarios o niveles.\n\n### Arrays en C\nUn **array**
+        es una colección de elementos del mismo tipo almacenados en posiciones consecutivas
+        de memoria.  \nEl tamaño del array debe ser fijo y conocerse en tiempo de
+        compilación.\n\n---\n\n### Tamaño con número fijo o con constante\n```c\n#define
+        MAX_ENEMIGOS 5\n\nint main() {\n    int puntosEnemigos[5];                 //
+        tamaño fijo\n    int puntosEnemigosConst[MAX_ENEMIGOS]; // con constante\n
+        \   return 0;\n}\n```\n\n---\n\n### Inicialización de arrays de tipos primitivos\nPuedes
+        inicializar al declarar:\n```c\nint main() {\n    int puntosEnemigos[5] =
+        {100, 200, 150, 300, 500};\n    return 0;\n}\n```\n\nO asignar después elemento
+        por elemento:\n```c\nint main() {\n    int puntosEnemigos[5];\n    puntosEnemigos[0]
+        = 100;\n    puntosEnemigos[1] = 200;\n    puntosEnemigos[2] = 150;\n    puntosEnemigos[3]
+        = 300;\n    puntosEnemigos[4] = 500;\n    return 0;\n}\n```\n\n*Recuerda*:
+        en C los índices empiezan en **0**.\n\n---\n\n### Arrays de cadenas\nUna cadena
+        es un array de `char` terminado con `'\\0'`.  \nPara guardar varias cadenas
+        se usan arrays bidimensionales:\n\n```c\n#define MAX_OBJETOS 3\n#define MAX_LONGITUD
+        20\n\nint main() {\n    char inventario[MAX_OBJETOS][MAX_LONGITUD];\n    return
+        0;\n}\n```\n\nInicialización directa:\n```c\nint main() {\n    char inventario[3][20]
+        = {\"Espada\", \"Escudo\", \"Poción\"};\n    return 0;\n}\n```\n\nO asignación
+        posterior:\n```c\n#include <string.h>\n\nint main() {\n    char inventario[3][20];\n
+        \   strcpy(inventario[0], \"Espada\");\n    strcpy(inventario[1], \"Escudo\");\n
+        \   strcpy(inventario[2], \"Poción\");\n    return 0;\n}\n```\n\n---\n\n###
+        Acceso a elementos\n```c\nint main() {\n    int puntosEnemigos[5] = {100,
+        200, 150, 300, 500};\n    int valor = puntosEnemigos[2]; // devuelve 150\n\n
+        \   char inventario[3][20] = {\"Espada\", \"Escudo\", \"Poción\"};\n    //
+        inventario[1] → \"Escudo\"\n\n    return 0;\n}\n```\n\n---\n\n### Ejemplo
+        completo\n```c\n#include <stdio.h>\n#include <string.h>\n#define MAX_ENEMIGOS
+        5\n#define MAX_OBJETOS 3\n#define MAX_LONGITUD 20\n\nint main() {\n    int
+        puntosEnemigos[MAX_ENEMIGOS] = {100, 200, 150, 300, 500};\n    char inventario[MAX_OBJETOS][MAX_LONGITUD]
+        = {\"Espada\", \"Escudo\", \"Poción\"};\n\n    printf(\"Puntos del tercer
+        enemigo: %d\\n\", puntosEnemigos[2]);\n    printf(\"Objeto en la segunda ranura:
+        %s\\n\", inventario[1]);\n\n    // Actualizar inventario\n    strcpy(inventario[2],
+        \"Llave mágica\");\n    printf(\"Nuevo objeto en la tercera ranura: %s\\n\",
+        inventario[2]);\n    return 0;\n}\n```\n\nEste programa muestra cómo inicializar
+        arrays, acceder a sus elementos y modificarlos, simulando un sistema de enemigos
+        y objetos en un videojuego.\n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **arrays en pseudocódigo**,
+        tanto de números como de cadenas.  \nSon muy útiles para representar puntuaciones
+        de enemigos o inventarios en videojuegos.\n\n### Arrays en pseudocódigo\nUn
+        **array** es una colección de elementos del mismo tipo.  \nEl tamaño es fijo
+        y se define al crearlo.\n\n---\n\n### Tamaño con número fijo o constante\n```pseudocode\nalgorithm\n
+        \ var\n    puntosEnemigos: vector[5] of integer;\n  end var\nend algorithm\n```\n\n```pseudocode\nconst\n
+        \ MAX_ENEMIGOS: integer = 5;\nend const\n\nalgorithm\n  var\n    puntosEnemigos:
+        vector[MAX_ENEMIGOS] of integer;\n  end var\nend algorithm\n```\n\n---\n\n###
+        Inicialización de arrays de tipos primitivos\nEn pseudocódigo no se permiten
+        llaves `{}`.  \nSe asigna elemento por elemento:\n\n```pseudocode\nconst\n
+        \ MAX_ENEMIGOS: integer = 5;\nend const\n\nalgorithm\n  var\n    puntosEnemigos:
+        vector[MAX_ENEMIGOS] of integer;\n  end var\n\n  puntosEnemigos[1] := 100;\n
+        \ puntosEnemigos[2] := 200;\n  puntosEnemigos[3] := 150;\n  puntosEnemigos[4]
+        := 300;\n  puntosEnemigos[5] := 500;\nend algorithm\n```\n\n*Recuerda*: en
+        pseudocódigo los índices empiezan en **1**.\n\n---\n\n### Arrays de cadenas\n```pseudocode\nconst\n
+        \ MAX_OBJETOS: integer = 3;\nend const\n\nalgorithm\n  var\n    inventario:
+        vector[MAX_OBJETOS] of string;\n  end var\n\n  inventario[1] := \"Espada\";\n
+        \ inventario[2] := \"Escudo\";\n  inventario[3] := \"Poción\";\nend algorithm\n```\n\n---\n\n###
+        Acceso a elementos\n```pseudocode\nvalor := puntosEnemigos[3];\nobjeto :=
+        inventario[2];\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\nconst\n
+        \ MAX_ENEMIGOS: integer = 5;\n  MAX_OBJETOS: integer = 3;\nend const\n\nalgorithm
+        arraysVideojuego\n  var\n    puntosEnemigos: vector[MAX_ENEMIGOS] of integer;\n
+        \   inventario: vector[MAX_OBJETOS] of string;\n    valor: integer;\n    objeto:
+        string;\n  end var\n\n  puntosEnemigos[1] := 100;\n  puntosEnemigos[2] :=
+        200;\n  puntosEnemigos[3] := 150;\n  puntosEnemigos[4] := 300;\n  puntosEnemigos[5]
+        := 500;\n\n  inventario[1] := \"Espada\";\n  inventario[2] := \"Escudo\";\n
+        \ inventario[3] := \"Poción\";\n\n  valor := puntosEnemigos[3];\n  objeto
+        := inventario[2];\n\n  writeString(\"Puntos del tercer enemigo: \");\n  writeInteger(valor);\n
+        \ writeString(\", Objeto en la segunda ranura: \");\n  writeString(objeto);\nend
+        algorithm\n```\n\nEste algoritmo muestra cómo usar arrays para almacenar y
+        consultar puntuaciones de enemigos y un inventario de objetos en un videojuego.\n"
+    questions:
+    - id: c-2-include_stdio
+      language: C
+      week: 2
+      prompt: Incluye la biblioteca estándar de entrada/salida en C para poder usar
+        printf y scanf.
+      answer: "#include <stdio.h>\n"
+      hint: 'Empieza por #include'
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-include_stdbool
+      language: C
+      week: 2
+      prompt: Incluye la biblioteca necesaria para poder usar variables booleanas
+        en C.
+      answer: "#include <stdbool.h>\n"
+      hint: El nombre contiene "std"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-include_string
+      language: C
+      week: 2
+      prompt: Incluye la biblioteca necesaria para trabajar con cadenas de caracteres
+        (funciones como strcpy, strcat, strcmp, strlen).
+      answer: "#include <string.h>\n"
+      hint: La biblioteca clásica para manipulación de strings, el nombre acaba con
+        .h .
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-max_plants_define
+      language: C
+      week: 2
+      prompt: Declara una constante MAX_PLANTS con valor 5 usando define.
+      answer: "#define MAX_PLANTS 5\n"
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-max_plants_const
+      language: Pseudocode
+      week: 2
+      prompt: Declara una constante MAX_PLANTS con valor 5.
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-max_name_define
+      language: C
+      week: 2
+      prompt: Declara una constante MAX_NAME con valor 25 usando define.
+      answer: "#define MAX_NAME 25\n"
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-const_temp_minima
+      language: C
+      week: 2
+      prompt: Dentro de la función main, declara una constante local de tipo float
+        llamada TEMP_MINIMA con valor 15.0.
+      answer: |
+        int main() {
+            const float TEMP_MINIMA = 15.0;
+            return 0;
+        }
+      hint: |
+        int main(){
+
+          // Código
+
+          return 0;
+        }
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-const_temp_minima
+      language: Pseudocode
+      week: 2
+      prompt: Declara una constante de tipo decimal llamada TEMP_MINIMA con valor
+        15.0.
+      answer: |
+        const
+          TEMP_MINIMA: real = 15.0;
+        end const
+      hint: Los decimales en pseudocódigo son el tipo real.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-array-nombres-solo
+      language: C
+      week: 2
+      prompt: Declara un array de cadenas nombrePlantas para 5 plantas, cada nombre
+        de 20 caracteres.
+      answer: |
+        int main() {
+            char nombrePlantas[5][20];
+            return 0;
+        }
+      hint: Primero va el número de elementos, luego el tamaño de cada string.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-array-nombres-solo
+      language: Pseudocode
+      week: 2
+      prompt: Declara un array de strings nombrePlantas para 5 plantas.
+      answer: |
+        algorithm
+          var
+            nombrePlantas: vector[5] of string;
+          end var
+        end algorithm
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-arr_nombreplanta
+      language: C
+      week: 2
+      prompt: |
+        Declara las constantes MAX_PLANTS = 5 y MAX_NAME = 25.
+
+        Dentro de main, declara un array de cadenas nombrePlanta para los nombres de las plantas usando ambas constantes.
+      answer: |
+        #define MAX_PLANTS 5
+        #define MAX_NAME 25
+
+        int main() {
+            char nombrePlanta[MAX_PLANTS][MAX_NAME];
+            return 0;
+        }
+      hint: Después del nombre del array va primero el maximo de plantas y después
+        el de los nombres
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-arr_nombreplanta
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTS = 5.
+
+        Dentro del algoritmo principal, declara un array de strings nombrePlanta para los nombres de las plantas usando dicha constante.
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+
+        algorithm
+          var
+            nombrePlanta: vector[MAX_PLANTS] of string;
+          end var
+        end algorithm
+      hint: No olvides todas las palabras reservadas como const, algorithm y var.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-arr_sensoresactivos
+      language: C
+      week: 2
+      prompt: |
+        Incluye la biblioteca necesaria para booleanos.
+
+        Declara la constante MAX_PLANTS = 5 y un array booleano sensoresActivos usando MAX_PLANTS dentro de main.
+      answer: |
+        #include <stdbool.h>
+        #define MAX_PLANTS 5
+
+        int main() {
+            bool sensoresActivos[MAX_PLANTS];
+            return 0;
+        }
+      hint: Incluye stdbool y usa bool, no int.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-arr_sensoresactivos
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTS = 5.
+
+        Dentro del algoritmo principal, declara un array de booleanos sensoresActivos usando dicha constante.
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+
+        algorithm
+          var
+             sensoresActivos: vector[MAX_PLANTS] of boolean;
+          end var
+        end algorithm
+      hint: No olvides todas las palabras reservadas como const, algorithm y var.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-array-alturas
+      language: C
+      week: 2
+      prompt: Declara la constante MAX_PLANTAS = 5 y un array float alturas usando
+        la constante.
+      answer: |
+        #define MAX_PLANTAS 5
+
+        int main() {
+            float alturas[MAX_PLANTAS];
+            return 0;
+        }
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-array-alturas
+      language: Pseudocode
+      week: 2
+      prompt: Declara la constante MAX_PLANTAS = 5 y un array real alturas usando
+        la constante.
+      answer: |
+        const
+          MAX_PLANTAS: integer = 5;
+        end const
+
+        algorithm
+          var
+            alturas: vector[MAX_PLANTAS] of real;
+          end var
+        end algorithm
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-array-nombres-alturas
+      language: C
+      week: 2
+      prompt: Declara las constantes MAX_PLANTAS = 5 y MAX_NOMBRE = 20. Declara un
+        array de cadenas nombrePlantas y un array float alturas, ambos usando MAX_PLANTAS.
+      answer: |
+        #define MAX_PLANTAS 5
+        #define MAX_NOMBRE 20
+
+        int main() {
+            char nombrePlantas[MAX_PLANTAS][MAX_NOMBRE];
+            float alturas[MAX_PLANTAS];
+            return 0;
+        }
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-array-nombres-alturas
+      language: Pseudocode
+      week: 2
+      prompt: Declara la constante MAX_PLANTAS = 5. Declara un array de strings nombrePlantas
+        y un array de reales alturas usando la constante.
+      answer: |
+        const
+          MAX_PLANTAS: integer = 5;
+        end const
+
+        algorithm
+          var
+            nombrePlantas: vector[MAX_PLANTAS] of string;
+            alturas: vector[MAX_PLANTAS] of real;
+          end var
+        end algorithm
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-arr_humedad
+      language: C
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTS = 5 y un array de enteros humedad con MAX_PLANTS,
+
+        inicializado con los valores "60, 85, 72, 91, 65" en la misma linea dentro de main.
+      answer: |
+        #define MAX_PLANTS 5
+
+        int main() {
+            int humedad[MAX_PLANTS] = {60, 85, 72, 91, 65};
+            return 0;
+        }
+      hint: Los valores deben estar entre llaves, separados por comas.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-arr_humedad
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTS = 5.
+
+        Dentro del algoritmo principal, declara un array de enteros humedad con MAX_PLANTS.
+
+        Inicializa el array con los valores "60, 85, 72, 91, 65".
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+
+        algorithm
+          var
+             humedad: vector[MAX_PLANTS] of integer;
+          end var
+
+          humedad[1] := 60;
+          humedad[2] := 85;
+          humedad[3] := 72;
+          humedad[4] := 91;
+          humedad[5] := 65;
+        end algorithm
+      hint: Recuerda que en pseudocódigo, primero declaramos las variables y después
+        las inicializamos.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-inicializa-alturas
+      language: C
+      week: 2
+      prompt: Declara la constante MAX_PLANTAS = 5 y un array float alturas, inicializándolo
+        con los valores 11.2, 18.4, 13.0, 17.5, 15.1.
+      answer: |
+        #define MAX_PLANTAS 5
+
+        int main() {
+            float alturas[MAX_PLANTAS] = {11.2, 18.4, 13.0, 17.5, 15.1};
+            return 0;
+        }
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-inicializa-alturas
+      language: Pseudocode
+      week: 2
+      prompt: Declara la constante MAX_PLANTAS = 5 y un array real alturas. Inicializa
+        los 5 valores a 11.2, 18.4, 13.0, 17.5, 15.1.
+      answer: |
+        const
+          MAX_PLANTAS: integer = 5;
+        end const
+
+        algorithm
+          var
+            alturas: vector[MAX_PLANTAS] of real;
+          end var
+
+          alturas[1] := 11.2;
+          alturas[2] := 18.4;
+          alturas[3] := 13.0;
+          alturas[4] := 17.5;
+          alturas[5] := 15.1;
+        end algorithm
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 2
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **matrices (arrays bidimensionales)**
+        en C.  \nLas matrices son muy útiles en videojuegos para representar mapas,
+        tableros o zonas de juego.\n\n### ¿Qué es una matriz?\nUna **matriz** es un
+        array con **filas** y **columnas**.  \nLa forma general es:  \n```c\ntipo
+        nombre[FILAS][COLUMNAS];\n```\n*Primero se escriben las filas y después las
+        columnas*.  \nLos índices en C empiezan en **0**.\n\n---\n\n### Declaración
+        con constantes fuera de `main`\n```c\n#define FILAS 3\n#define COLUMNAS 4\n\nint
+        main() {\n    int tablero[FILAS][COLUMNAS];\n    return 0;\n}\n```\n\n---\n\n###
+        Inicialización con llaves `{}` al declarar\n```c\n#define FILAS 2\n#define
+        COLUMNAS 3\n\nint main() {\n    int mapa[FILAS][COLUMNAS] = {\n        {1,
+        0, 0},\n        {0, 1, 0}\n    };\n    return 0;\n}\n```\n\n---\n\n### Inicialización
+        manual elemento a elemento\n```c\n#define FILAS 2\n#define COLUMNAS 3\n\nint
+        main() {\n    int zonas[FILAS][COLUMNAS];\n    zonas[0][0] = 1;\n    zonas[0][1]
+        = 0;\n    zonas[0][2] = 0;\n\n    zonas[1][0] = 0;\n    zonas[1][1] = 1;\n
+        \   zonas[1][2] = 0;\n    return 0;\n}\n```\n\n---\n\n### Matrices booleanas\n```c\n#include
+        <stdbool.h>\n#define FILAS 2\n#define COLUMNAS 3\n\nint main() {\n    bool
+        zonaActiva[FILAS][COLUMNAS];\n\n    zonaActiva[0][0] = true;\n    zonaActiva[0][1]
+        = false;\n    zonaActiva[0][2] = false;\n\n    zonaActiva[1][0] = false;\n
+        \   zonaActiva[1][1] = true;\n    zonaActiva[1][2] = false;\n    return 0;\n}\n```\n\n---\n\n###
+        Acceso a un elemento concreto\n```c\n#define FILAS 2\n#define COLUMNAS 3\n\nint
+        main() {\n    float valores[FILAS][COLUMNAS] = {\n        {6.1f, 6.3f, 6.0f},\n
+        \       {7.1f, 7.0f, 6.9f}\n    };\n    float x = valores[1][0]; // fila 2,
+        columna 1 → 7.1\n    return 0;\n}\n```\n\n---\n\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n#include <stdbool.h>\n#define FILAS 2\n#define COLUMNAS 3\n\nint
+        main() {\n    // Matriz de enteros para un mapa\n    int mapa[FILAS][COLUMNAS]
+        = {\n        {1, 0, 0},\n        {0, 1, 0}\n    };\n\n    // Matriz booleana
+        para zonas activas\n    bool zonaActiva[FILAS][COLUMNAS];\n    zonaActiva[0][0]
+        = true;\n    zonaActiva[0][1] = false;\n    zonaActiva[0][2] = false;\n    zonaActiva[1][0]
+        = false;\n    zonaActiva[1][1] = true;\n    zonaActiva[1][2] = false;\n\n
+        \   // Acceso a valores\n    int casilla = mapa[0][0]; // 1\n    bool activa
+        = zonaActiva[1][1]; // true\n\n    printf(\"Casilla inicial: %d\\n\", casilla);\n
+        \   printf(\"Zona (2,2) activa: %s\\n\", activa ? \"sí\" : \"no\");\n\n    return
+        0;\n}\n```\n\nEste programa muestra cómo declarar, inicializar y acceder a
+        matrices, simulando un mapa de un videojuego con zonas activas o inactivas.\n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **matrices (vectores bidimensionales)**
+        en pseudocódigo.  \nSirven para representar mapas, tableros o zonas en videojuegos.\n\n###
+        ¿Qué es una matriz?\nUna **matriz** es un vector con dos dimensiones: **filas**
+        y **columnas**.  \nEn pseudocódigo los índices empiezan en **1**.\n\n---\n\n###
+        Declaración con constantes\n```pseudocode\nconst\n  FILAS: integer = 3;\n
+        \ COLUMNAS: integer = 4;\nend const\n\nalgorithm\n  var\n    tablero: vector[FILAS][COLUMNAS]
+        of integer;\n  end var\nend algorithm\n```\n\n---\n\n### Inicialización manual\nEn
+        pseudocódigo no se permiten llaves `{}`, se hace elemento por elemento:\n```pseudocode\nconst\n
+        \ FILAS: integer = 2;\n  COLUMNAS: integer = 3;\nend const\n\nalgorithm\n
+        \ var\n    zonas: vector[FILAS][COLUMNAS] of integer;\n  end var\n\n  zonas[1][1]
+        := 1;\n  zonas[1][2] := 0;\n  zonas[1][3] := 0;\n\n  zonas[2][1] := 0;\n  zonas[2][2]
+        := 1;\n  zonas[2][3] := 0;\nend algorithm\n```\n\n---\n\n### Matrices booleanas\n```pseudocode\nconst\n
+        \ FILAS: integer = 2;\n  COLUMNAS: integer = 3;\nend const\n\nalgorithm\n
+        \ var\n    activo: vector[FILAS][COLUMNAS] of boolean;\n  end var\n\n  activo[1][1]
+        := true;\n  activo[1][2] := false;\n  activo[1][3] := false;\n\n  activo[2][1]
+        := false;\n  activo[2][2] := true;\n  activo[2][3] := false;\nend algorithm\n```\n\n---\n\n###
+        Acceso a un elemento concreto\n```pseudocode\ndato := valores[2][1];  { fila
+        2, columna 1 }\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\nconst\n
+        \ FILAS: integer = 2;\n  COLUMNAS: integer = 3;\nend const\n\nalgorithm matrizVideojuego\n
+        \ var\n    mapa: vector[FILAS][COLUMNAS] of integer;\n    zonaActiva: vector[FILAS][COLUMNAS]
+        of boolean;\n    casilla: integer;\n    activa: boolean;\n  end var\n\n  mapa[1][1]
+        := 1;\n  mapa[1][2] := 0;\n  mapa[1][3] := 0;\n  mapa[2][1] := 0;\n  mapa[2][2]
+        := 1;\n  mapa[2][3] := 0;\n\n  zonaActiva[1][1] := true;\n  zonaActiva[1][2]
+        := false;\n  zonaActiva[1][3] := false;\n  zonaActiva[2][1] := false;\n  zonaActiva[2][2]
+        := true;\n  zonaActiva[2][3] := false;\n\n  casilla := mapa[1][1];\n  activa
+        := zonaActiva[2][2];\n\n  writeString(\"Casilla inicial: \");\n  writeInteger(casilla);\n
+        \ writeString(\", Zona (2,2) activa: \");\n  writeBoolean(activa);\nend algorithm\n```\n\nEste
+        algoritmo muestra cómo declarar, inicializar y acceder a matrices, simulando
+        un mapa de un videojuego con zonas activas o inactivas.\n"
+    questions:
+    - id: c-2-mat_sensorestemp
+      language: C
+      week: 2
+      prompt: |
+        Declara las constantes FILAS = 3 y COLUMNAS = 4.
+
+        Dentro de main, declara una matriz de enteros sensoresTemperatura con FILAS Y COLUMNAS.
+      answer: |
+        #define FILAS 3
+        #define COLUMNAS 4
+
+        int main() {
+            int sensoresTemperatura[FILAS][COLUMNAS];
+            return 0;
+        }
+      hint: En una matriz van siempre primero las filas y luego las columnas
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-mat_sensorestemp
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara las constantes FILAS = 3 y COLUMNAS = 4.
+
+        Dentro del algoritmo principal, declara una matriz de enteros sensoresTemperatura con FILAS Y COLUMNAS.
+      answer: |
+        const
+          FILAS: integer = 3;
+          COLUMNAS: integer = 4;
+        end const
+
+        algorithm
+          var
+             sensoresTemperatura: vector[FILAS][COLUMNAS] of integer;
+          end var
+        end algorithm
+      hint: En una matriz van siempre primero las filas y luego las columnas, no olvides
+        todas las palabras reservadas para declarar los datos.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-mat_zonas_bool
+      language: C
+      week: 2
+      prompt: "Declara las constantes FILAS = 2 y COLUMNAS = 3.\n\nDentro de main,
+        declara una matriz booleana zonas con FILAS Y COLUMNAS.\n\nInicialízala con
+        los valores: \nfila 1: true, false, false \nfila 2: false, true, false.\n"
+      answer: |
+        #include <stdbool.h>
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        int main() {
+            bool zonas[FILAS][COLUMNAS];
+
+            zonas[0][0] = true;
+            zonas[0][1] = false;
+            zonas[0][2] = false;
+
+            zonas[1][0] = false;
+            zonas[1][1] = true;
+            zonas[1][2] = false;
+
+            return 0;
+        }
+      hint: Recuerda la biblioteca para el tipo booleano.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-mat_zonas_bool
+      language: Pseudocode
+      week: 2
+      prompt: "Declara las constantes FILAS = 2 y COLUMNAS = 3.\n\nDentro del algoritmo
+        principal, declara una matriz booleana zonas con FILAS Y COLUMNAS. \n\nInicialízala
+        con los valores: \nfila 1: true, false, false \nfila 2: false, true, false.\n"
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 3;
+        end const
+
+        algorithm
+          var
+             zonas: vector[FILAS][COLUMNAS] of boolean;
+          end var
+
+          zonas[1][1] := true;
+          zonas[1][2] := false;
+          zonas[1][3] := false;
+
+          zonas[2][1] := false;
+          zonas[2][2] := true;
+          zonas[2][3] := false;
+        end algorithm
+      hint: No olvides las palabras reservadas para declarar los datos y el algoritmo
+        principal.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-matriz-inicializa-llaves
+      language: C
+      week: 2
+      prompt: "Declara las constantes FILAS = 2 y COLUMNAS = 3. \n\nDentro de la función
+        main, declara e inicializa una matriz de enteros llamada `zonas` con los siguientes
+        valores usando llaves `{}`:\n- fila 1: 1, 0, 0\n- fila 2: 0, 1, 0\n"
+      answer: |
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        int main() {
+            int zonas[FILAS][COLUMNAS] = {
+                {1, 0, 0},
+                {0, 1, 0}
+            };
+            return 0;
+        }
+      hint: "Ejemplo: \n  tipo matriz[2][3] = { {a, b, c}, {d, e, f} };\n"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-matriz-inicializa-manual
+      language: C
+      week: 2
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Dentro de la función main, declara una matriz de enteros llamada `zonas` y asigna manualmente los siguientes valores:
+        - fila 1: 1, 0, 0
+        - fila 2: 0, 1, 0
+      answer: |
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        int main() {
+            int zonas[FILAS][COLUMNAS];
+            zonas[0][0] = 1;
+            zonas[0][1] = 0;
+            zonas[0][2] = 0;
+
+            zonas[1][0] = 0;
+            zonas[1][1] = 1;
+            zonas[1][2] = 0;
+            return 0;
+        }
+      hint: |
+        Asigna cada elemento individualmente con zonas[fila][columna].
+        Recuerda: en C los índices empiezan en 0.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-matriz-inicializa-const
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Dentro del algoritmo principal, declara una matriz de enteros zonas de tamaño FILAS x COLUMNAS.
+
+        Inicializa la matriz manualmente con los valores siguientes:
+        - fila 1: 1, 0, 0
+        - fila 2: 0, 1, 0
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 3;
+        end const
+
+        algorithm
+          var
+            zonas: vector[FILAS][COLUMNAS] of integer;
+          end var
+
+          zonas[1][1] := 1;
+          zonas[1][2] := 0;
+          zonas[1][3] := 0;
+          zonas[2][1] := 0;
+          zonas[2][2] := 1;
+          zonas[2][3] := 0;
+        end algorithm
+      hint: |
+        En pseudocódigo la inicialización de matrices es siempre manual, elemento a elemento.
+        Los índices comienzan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-matriz-ph
+      language: C
+      week: 2
+      prompt: |
+        Incluye stdio.
+
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Declara una matriz float phSuelo.
+
+        Inicializa utilizando {} con los valores:
+        fila 1: 6.1, 6.3, 6.0
+        fila 2: 7.1, 7.0, 6.9
+
+        Imprime el valor de la posición fila 2, columna 1 con el formato "pH: x".
+      answer: |
+        #include <stdio.h>
+
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        int main() {
+            float phSuelo[FILAS][COLUMNAS] = {
+                {6.1, 6.3, 6.0},
+                {7.1, 7.0, 6.9}
+            };
+            printf("pH: %.1f\n", phSuelo[1][0]);
+            return 0;
+        }
+      hint: "Ejemplo de ejecución: \n  pH: 7.1\n"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-matriz-ph
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Declara una matriz real phSuelo.
+
+        Inicializa los valores:
+        fila 1: 6.1, 6.3, 6.0
+        fila 2: 7.1, 7.0, 6.9
+
+        Imprime el valor de la posición fila 2, columna 1 el formato "pH: x".
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 3;
+        end const
+
+        algorithm
+          var
+            phSuelo: vector[FILAS][COLUMNAS] of real;
+          end var
+
+          phSuelo[1][1] := 6.1;
+          phSuelo[1][2] := 6.3;
+          phSuelo[1][3] := 6.0;
+          phSuelo[2][1] := 7.1;
+          phSuelo[2][2] := 7.0;
+          phSuelo[2][3] := 6.9;
+
+          writeString("pH: ");
+          writeReal(phSuelo[2][1]);
+        end algorithm
+      hint: "Recuerda que en pseudocódigo no puedes imprimir mas de un dato por linea.\n\nEjemplo
+        de ejecución: \npH: 7.1\n"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 3
+    explanation:
+      C: "En este nivel aprenderás a leer y escribir datos en arrays, y también a
+        copiar y comparar cadenas de caracteres en C.  \nEsto es útil en videojuegos
+        para guardar puntuaciones de rondas o nombres de objetos en un inventario.\n\n###
+        Leer datos numéricos en arrays\nPuedes leer enteros o reales uno por uno usando
+        `scanf`:\n\n```c\n#include <stdio.h>\n#define MAX_PUNTOS 3\n\nint main() {\n
+        \   int puntos[MAX_PUNTOS];\n\n    printf(\"Puntos ronda 1: \");\n    scanf(\"%d\",
+        &puntos[0]);\n\n    printf(\"Puntos ronda 2: \");\n    scanf(\"%d\", &puntos[1]);\n\n
+        \   printf(\"Puntos ronda 3: \");\n    scanf(\"%d\", &puntos[2]);\n\n    return
+        0;\n}\n```\n\n---\n\n### Mostrar datos de un array\n```c\nprintf(\"Ronda 1:
+        %d\\n\", puntos[0]);\nprintf(\"Ronda 2: %d\\n\", puntos[1]);\nprintf(\"Ronda
+        3: %d\\n\", puntos[2]);\n```\n\n---\n\n### Arrays de cadenas: copiar con `strncpy`\nLas
+        cadenas se almacenan en arrays bidimensionales.  \nPara copiar texto en cada
+        posición, se usa `strncpy`:\n\n```c\n#include <stdio.h>\n#include <string.h>\n#define
+        MAX_ARMAS 2\n#define MAX_NOMBRE 20\n\nint main() {\n    char armas[MAX_ARMAS][MAX_NOMBRE];\n\n
+        \   strncpy(armas[0], \"Espada de fuego\", MAX_NOMBRE);\n    strncpy(armas[1],
+        \"Arco helado\", MAX_NOMBRE);\n\n    printf(\"Arma 1: %s\\n\", armas[0]);\n
+        \   printf(\"Arma 2: %s\\n\", armas[1]);\n    return 0;\n}\n```\n\n---\n\n###
+        Comparar cadenas con `strcmp`\nPara saber si dos cadenas son iguales, se usa
+        `strcmp`, que devuelve 0 si son iguales:\n\n```c\nint esIgual;\nesIgual =
+        strcmp(armas[0], \"Espada de fuego\") == 0 ? 1 : 0;\n```\n\n*Si `esIgual`
+        vale 1, las cadenas son iguales.*\n\n---\n\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n#include <string.h>\n#define MAX_PUNTOS 3\n#define MAX_ARMAS 2\n#define
+        MAX_NOMBRE 20\n\nint main() {\n    int puntos[MAX_PUNTOS];\n    char armas[MAX_ARMAS][MAX_NOMBRE];\n
+        \   int esIgual;\n\n    // Lectura de puntos\n    printf(\"Introduce los puntos
+        de 3 rondas:\\n\");\n    scanf(\"%d\", &puntos[0]);\n    scanf(\"%d\", &puntos[1]);\n
+        \   scanf(\"%d\", &puntos[2]);\n\n    // Mostrar puntos\n    printf(\"Ronda
+        1: %d\\n\", puntos[0]);\n    printf(\"Ronda 2: %d\\n\", puntos[1]);\n    printf(\"Ronda
+        3: %d\\n\", puntos[2]);\n\n    // Copiar nombres de armas\n    strncpy(armas[0],
+        \"Espada de fuego\", MAX_NOMBRE);\n    strncpy(armas[1], \"Arco helado\",
+        MAX_NOMBRE);\n\n    // Mostrar armas\n    printf(\"Arma 1: %s\\n\", armas[0]);\n
+        \   printf(\"Arma 2: %s\\n\", armas[1]);\n\n    // Comparar cadenas\n    esIgual
+        = strcmp(armas[0], \"Espada de fuego\") == 0 ? 1 : 0;\n    printf(\"¿Arma
+        1 es 'Espada de fuego'? %s\\n\", esIgual ? \"Sí\" : \"No\");\n\n    return
+        0;\n}\n```\n\nEste programa combina lectura y escritura de arrays numéricos
+        con el manejo de cadenas en un inventario de armas.\n"
+      Pseudocode: "En este nivel aprenderás a leer y mostrar datos en arrays, y también
+        a copiar y comparar cadenas en pseudocódigo.  \nEsto es útil en videojuegos
+        para guardar puntuaciones de rondas o nombres de objetos.\n\n### Leer datos
+        numéricos\n```pseudocode\nconst\n  MAX_PUNTOS: integer = 3;\nend const\n\nalgorithm
+        leerPuntos\n  var\n    puntos: vector[MAX_PUNTOS] of integer;\n  end var\n\n
+        \ writeString(\"Puntos ronda 1: \");\n  puntos[1] := readInteger();\n\n  writeString(\"Puntos
+        ronda 2: \");\n  puntos[2] := readInteger();\n\n  writeString(\"Puntos ronda
+        3: \");\n  puntos[3] := readInteger();\nend algorithm\n```\n\n---\n\n### Escribir
+        datos\n```pseudocode\nalgorithm mostrarPuntos\n  var\n    puntos: vector[3]
+        of integer;\n  end var\n\n  writeString(\"Ronda 1: \");\n  writeInteger(puntos[1]);\n\n
+        \ writeString(\"Ronda 2: \");\n  writeInteger(puntos[2]);\n\n  writeString(\"Ronda
+        3: \");\n  writeInteger(puntos[3]);\nend algorithm\n```\n\n---\n\n### Leer
+        cadenas\n```pseudocode\nconst\n  MAX_ARMAS: integer = 2;\nend const\n\nalgorithm
+        leerArmas\n  var\n    armas: vector[MAX_ARMAS] of string;\n  end var\n\n  writeString(\"Nombre
+        del arma 1: \");\n  armas[1] := readString();\n\n  writeString(\"Nombre del
+        arma 2: \");\n  armas[2] := readString();\nend algorithm\n```\n\n---\n\n###
+        Comparar cadenas\nEn pseudocódigo se comparan directamente con `=`:\n\n```pseudocode\nalgorithm
+        compararArma\n  var\n    armas: vector[2] of string;\n    esIgual: boolean;\n
+        \ end var\n\n  armas[1] := \"Espada de fuego\";\n  esIgual := (armas[1] =
+        \"Espada de fuego\");\n  writeBoolean(esIgual);\nend algorithm\n```\n\n---\n\n###
+        Ejemplo completo\n```pseudocode\nconst\n  MAX_PUNTOS: integer = 3;\n  MAX_ARMAS:
+        integer = 2;\nend const\n\nalgorithm arraysVideojuego\n  var\n    puntos:
+        vector[MAX_PUNTOS] of integer;\n    armas: vector[MAX_ARMAS] of string;\n
+        \   esIgual: boolean;\n  end var\n\n  writeString(\"Introduce los puntos de
+        3 rondas:\");\n  puntos[1] := readInteger();\n  puntos[2] := readInteger();\n
+        \ puntos[3] := readInteger();\n\n  writeString(\"Puntos registrados:\");\n
+        \ writeInteger(puntos[1]);\n  writeInteger(puntos[2]);\n  writeInteger(puntos[3]);\n\n
+        \ armas[1] := \"Espada de fuego\";\n  armas[2] := \"Arco helado\";\n\n  writeString(\"Arma
+        1: \");\n  writeString(armas[1]);\n  writeString(\", Arma 2: \");\n  writeString(armas[2]);\n\n
+        \ esIgual := (armas[1] = \"Espada de fuego\");\n  writeString(\"¿Arma 1 es
+        'Espada de fuego'? \");\n  writeBoolean(esIgual);\nend algorithm\n```\n\nEste
+        algoritmo combina lectura y escritura de arrays de enteros y cadenas para
+        simular un marcador de rondas y un inventario de armas.\n"
+    questions:
+    - id: c-2-inicializa-nombreplanta
+      language: C
+      week: 2
+      prompt: "Incluye string\n\nDeclara las constantes MAX_PLANTS = 5 y MAX_NAME
+        = 25.\n\nDentro de main, declara un array de cadenas nombrePlanta para los
+        nombres de las plantas y \nusa strncpy para inicializar el primer elemento
+        a \"Margarita\".\n"
+      answer: |
+        #include <string.h>
+        #define MAX_PLANTS 5
+        #define MAX_NAME 25
+
+        int main() {
+            char nombrePlanta[MAX_PLANTS][MAX_NAME];
+            strncpy(nombrePlanta[0], "Margarita", MAX_NAME);
+            return 0;
+        }
+      hint: Usa strncpy para copiar la cadena al array de strings. No olvides pasar
+        el tamaño máximo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-inicializa-nombreplanta
+      language: Pseudocode
+      week: 2
+      prompt: "Declara la constante MAX_PLANTS = 5. \n\nDentro del algoritmo principal,
+        declara un array de strings nombrePlanta y asigna \"Margarita\" al primer
+        elemento.\n"
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+        algorithm
+          var
+            nombrePlanta: vector[MAX_PLANTS] of string;
+          end var
+
+          nombrePlanta[1] := "Margarita";
+        end algorithm
+      hint: En pseudocódigo los índices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-inicializa-varios-nombres
+      language: C
+      week: 2
+      prompt: "Incluye string.\n\nDeclara las constantes MAX_PLANTS = 5 y MAX_NAME
+        = 25.\n\nDentro de main, declara un array de cadenas nombrePlanta y usa strncpy
+        para inicializar los nombres \n\"Margarita\", \"Rosa\", \"Lirio\", \"Orquídea\",
+        \"Girasol\" en el array.\n"
+      answer: |
+        #include <string.h>
+        #define MAX_PLANTS 5
+        #define MAX_NAME 25
+
+        int main() {
+            char nombrePlanta[MAX_PLANTS][MAX_NAME];
+            strncpy(nombrePlanta[0], "Margarita", MAX_NAME);
+            strncpy(nombrePlanta[1], "Rosa", MAX_NAME);
+            strncpy(nombrePlanta[2], "Lirio", MAX_NAME);
+            strncpy(nombrePlanta[3], "Orquídea", MAX_NAME);
+            strncpy(nombrePlanta[4], "Girasol", MAX_NAME);
+            return 0;
+        }
+      hint: Siempre que copies un string, usa strncpy y el tamaño máximo como tercer
+        argumento.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-inicializa-varios-nombres
+      language: Pseudocode
+      week: 2
+      prompt: "Declara la constante MAX_PLANTS = 5. \nDeclara un array de strings
+        nombrePlanta y asigna los nombres \n\"Margarita\", \"Rosa\", \"Lirio\", \"Orquídea\",
+        \"Girasol\" en el array.\n"
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+        algorithm
+          var
+            nombrePlanta: vector[MAX_PLANTS] of string;
+          end var
+
+          nombrePlanta[1] := "Margarita";
+          nombrePlanta[2] := "Rosa";
+          nombrePlanta[3] := "Lirio";
+          nombrePlanta[4] := "Orquídea";
+          nombrePlanta[5] := "Girasol";
+        end algorithm
+      hint: Recuerda, índices desde 1 en pseudocódigo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-muestra-primer-nombre
+      language: C
+      week: 2
+      prompt: |
+        Incluye stdio y string.
+
+        Declara las constantes MAX_PLANTS = 5 y MAX_NAME = 25.
+
+        Declara un array de cadenas nombrePlanta, inicializa el primer elemento con "Margarita" usando strncpy,
+        y muestra el primer nombre con printf.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_PLANTS 5
+        #define MAX_NAME 25
+
+        int main() {
+            char nombrePlanta[MAX_PLANTS][MAX_NAME];
+            strncpy(nombrePlanta[0], "Margarita", MAX_NAME);
+            printf("%s\n", nombrePlanta[0]);
+            return 0;
+        }
+      hint: Usa printf, recuerda el especificador de string y el salto de linea. También
+        recuerda las bibliotecas necesarias.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-muestra-primer-nombre
+      language: Pseudocode
+      week: 2
+      prompt: "Declara la constante MAX_PLANTS = 5. \n\nDeclara un array de strings
+        nombrePlanta, asigna \"Margarita\" al primer elemento \ny muestra ese nombre
+        con writeString.\n"
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+        algorithm
+          var
+            nombrePlanta: vector[MAX_PLANTS] of string;
+          end var
+
+          nombrePlanta[1] := "Margarita";
+          writeString(nombrePlanta[1]);
+        end algorithm
+      hint: Primero declaramos, después asignamos valor y finalmente imprimimos.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-copia-nombre-a-otro
+      language: C
+      week: 2
+      prompt: |
+        Incluye string.
+
+        Declara las constantes MAX_PLANTS = 5 y MAX_NAME = 25. Declara un array de cadenas nombrePlanta.
+
+        Usa strncpy para copiar el nombre "Margarita" en el primer elemento y después usa strncpy para copiar ese mismo nombre
+        al segundo elemento.
+      answer: |
+        #include <string.h>
+        #define MAX_PLANTS 5
+        #define MAX_NAME 25
+
+        int main() {
+            char nombrePlanta[MAX_PLANTS][MAX_NAME];
+            strncpy(nombrePlanta[0], "Margarita", MAX_NAME);
+            strncpy(nombrePlanta[1], nombrePlanta[0], MAX_NAME);
+            return 0;
+        }
+      hint: strncpy sirve para copiar tanto un literal como de un array a otro.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-copia-nombre-a-otro
+      language: Pseudocode
+      week: 2
+      prompt: "Declara la constante MAX_PLANTS = 5. \n\nDeclara un array de strings
+        nombrePlanta, asigna \"Margarita\" al primer elemento\ny copia ese nombre
+        al segundo elemento.\n"
+      answer: |
+        const
+          MAX_PLANTS: integer = 5;
+        end const
+        algorithm
+          var
+            nombrePlanta: vector[MAX_PLANTS] of string;
+          end var
+
+          nombrePlanta[1] := "Margarita";
+          nombrePlanta[2] := nombrePlanta[1];
+        end algorithm
+      hint: En pseudocódigo puedes asignar directamente un string a otro.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-array-temp
+      language: C
+      week: 2
+      prompt: "Incluye stdio.\n\nDeclara la constante MAX_PLANTAS = 4 y un array float
+        tempPlantas.\n\nInicializa los valores a 19.2, 20.5, 22.1 y 18.9 usando {}.
+        \n\nImprime el tercer valor con el formato \"Temp: x\".\n"
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_PLANTAS 4
+
+        int main() {
+            float tempPlantas[MAX_PLANTAS] = {19.2, 20.5, 22.1, 18.9};
+            printf("Temp: %.1f\n", tempPlantas[2]);
+            return 0;
+        }
+      hint: "Ejemplo de ejecución: \nTemp: 22.1\nFijate que solo hay un decimal.\n"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-array-temp
+      language: Pseudocode
+      week: 2
+      prompt: "Declara la constante MAX_PLANTAS = 4.\n\nDeclara un array real tempPlantas.\n\nInicializa
+        los valores a 19.2, 20.5, 22.1 y 18.9. \n\nImprime el tercer valor.\n"
+      answer: |
+        const
+          MAX_PLANTAS: integer = 4;
+        end const
+
+        algorithm
+          var
+            tempPlantas: vector[MAX_PLANTAS] of real;
+          end var
+
+          tempPlantas[1] := 19.2;
+          tempPlantas[2] := 20.5;
+          tempPlantas[3] := 22.1;
+          tempPlantas[4] := 18.9;
+
+          writeReal(tempPlantas[3]);
+        end algorithm
+      hint: "Ejemplo de ejecución: \n22.1\n"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-acceso-paralelos
+      language: C
+      week: 2
+      prompt: |
+        Incluye stdio y string.
+
+        Declara las constantes MAX_PLANTAS = 3, MAX_NOMBRE = 10.
+
+        Declara nombrePlantas (cadenas) y alturaPlantas (float).
+
+        Inicializa con "Loto", "Boj", "Tejo" y 1.2, 0.4, 4.8.
+
+        Imprime el nombre y altura de la primera planta, cada uno en su línea.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+        #define MAX_PLANTAS 3
+        #define MAX_NOMBRE 10
+
+        int main() {
+            char nombrePlantas[MAX_PLANTAS][MAX_NOMBRE];
+            float alturaPlantas[MAX_PLANTAS];
+            strncpy(nombrePlantas[0], "Loto", MAX_NOMBRE);
+            strncpy(nombrePlantas[1], "Boj", MAX_NOMBRE);
+            strncpy(nombrePlantas[2], "Tejo", MAX_NOMBRE);
+            alturaPlantas[0] = 1.2;
+            alturaPlantas[1] = 0.4;
+            alturaPlantas[2] = 4.8;
+            printf("%s\n", nombrePlantas[0]);
+            printf("%.1f\n", alturaPlantas[0]);
+            return 0;
+        }
+      hint: |
+        Recuerda importar las bibliotecas necesarias. Y no olvides los saltos de linea y fijate que el numero solo tiene
+        un decimal.
+
+        Ejemplo de ejecución:
+          Loto
+          1.2
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-acceso-paralelos
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTAS = 3.
+
+        Declara nombrePlantas (strings) y alturaPlantas (reales).
+
+        Inicializa con "Loto", "Boj", "Tejo" y 1.2, 0.4, 4.8.
+
+        Imprime el nombre y altura de la primera planta, cada uno en su línea.
+      answer: |
+        const
+          MAX_PLANTAS: integer = 3;
+        end const
+
+        algorithm
+          var
+            nombrePlantas: vector[MAX_PLANTAS] of string;
+            alturaPlantas: vector[MAX_PLANTAS] of real;
+          end var
+
+          nombrePlantas[1] := "Loto";
+          nombrePlantas[2] := "Boj";
+          nombrePlantas[3] := "Tejo";
+          alturaPlantas[1] := 1.2;
+          alturaPlantas[2] := 0.4;
+          alturaPlantas[3] := 4.8;
+
+          writeString(nombrePlantas[1]);
+          writeReal(alturaPlantas[1]);
+        end algorithm
+      hint: |
+        Ejemplo de ejecución:
+        Loto
+        1.2
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-leer-string
+      language: C
+      week: 2
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAX_NOMBRE = 15.
+
+        Dentro de main, declara la cadena nombrePlanta y lee su valor por teclado usando scanf. Imprime el nombre en el formato "Nombre: x".
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_NOMBRE 15
+
+        int main() {
+            char nombrePlanta[MAX_NOMBRE];
+            scanf("%s", nombrePlanta);
+            printf("Nombre: %s\n", nombrePlanta);
+            return 0;
+        }
+      hint: "Recuerda la biblioteca y el salto de linea en el print.\n\nEjemplo de
+        ejecución: \n\nNombre: Jacinto\n"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-leer-string
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Dentro del algoritmo principal, declara una variable nombrePlanta de tipo string.
+
+        Lee su valor usando readString y después imprímelo.
+      answer: |
+        algorithm
+          var
+            nombrePlanta: string;
+          end var
+
+          nombrePlanta := readString();
+          writeString(nombrePlanta);
+        end algorithm
+      hint: Recuerda usar readString para leer el dato.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-2-leer-array-int
+      language: C
+      week: 2
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAX_PLANTAS = 3.
+
+        Declara el array edadPlantas.
+
+        Lee 3 valores enteros por teclado y guárdalos en el array. Imprime el segundo valor leído.
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_PLANTAS 3
+
+        int main() {
+            int edadPlantas[MAX_PLANTAS];
+            scanf("%d", &edadPlantas[0]);
+            scanf("%d", &edadPlantas[1]);
+            scanf("%d", &edadPlantas[2]);
+            printf("%d\n", edadPlantas[1]);
+            return 0;
+        }
+      hint: "El usuario debe escribir 3 números. \n\nEjemplo entrada: 7 8 10\n\nEjemplo
+        salida: 8\n"
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-2-leer-array-int
+      language: Pseudocode
+      week: 2
+      prompt: |
+        Declara la constante MAX_PLANTAS = 3.
+
+        Declara el array edadPlantas.
+
+        Lee 3 valores enteros usando readInteger y guárdalos en el array. Imprime el segundo valor.
+      answer: |
+        const
+          MAX_PLANTAS: integer = 3;
+        end const
+
+        algorithm
+          var
+            edadPlantas: vector[MAX_PLANTAS] of integer;
+          end var
+
+          edadPlantas[1] := readInteger();
+          edadPlantas[2] := readInteger();
+          edadPlantas[3] := readInteger();
+
+          writeInteger(edadPlantas[2]);
+        end algorithm
+      hint: Recuerda, cada readInteger debe ir en línea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+- number: 3
+  explanation: 'Explicación de semana 3
+
+    '
+  levels:
+  - number: 1
+    explanation:
+      C: "En este nivel aprenderás a representar información de videojuegos como **tipos
+        de enemigos, nombres de personajes, vidas, estados y mapas**, utilizando enumerados,
+        cadenas, arrays paralelos y matrices en C.  \nEstos conceptos permiten organizar
+        datos del juego de forma clara y estructurada.\n\n### Enumerados (enum)\nSirven
+        para definir categorías con nombres.  \nPor ejemplo, los **tipos de enemigo**:\n\n```c\ntypedef
+        enum {\n    ZOMBIE,\n    ALIEN,\n    ROBOT\n} tTipoEnemigo;\n\nint main()
+        {\n    tTipoEnemigo tipo = ALIEN;  // Inicialización\n    return 0;\n}\n```\n\n---\n\n###
+        Arrays de enumerados\nPuedes crear un array con el tipo de cada enemigo:\n\n```c\n#include
+        <stdio.h>\n\n#define MAX_ENEMIGOS 3\n\ntypedef enum {\n    ZOMBIE,\n    ALIEN,\n
+        \   ROBOT\n} tTipoEnemigo;\n\nint main() {\n    tTipoEnemigo enemigos[MAX_ENEMIGOS]
+        = { ZOMBIE, ALIEN, ROBOT };\n    printf(\"Primer enemigo: %d\\n\", enemigos[0]);
+        // 0 → ZOMBIE\n    return 0;\n}\n```\n\n---\n\n### Cadenas con `strncpy`\nPara
+        guardar nombres de personajes se usa un array de `char`:\n\n```c\n#include
+        <string.h>\n#define MAX_NOMBRE 20\n\nint main() {\n    char nombre1[MAX_NOMBRE];\n
+        \   char nombre2[MAX_NOMBRE];\n\n    strncpy(nombre1, \"Link\", MAX_NOMBRE);\n
+        \   strncpy(nombre2, \"Zelda\", MAX_NOMBRE);\n\n    return 0;\n}\n```\n\n---\n\n###
+        Arrays paralelos\nSon arrays diferentes relacionados por posición.  \nPor
+        ejemplo, un array de nombres y otro de vidas:\n\n```c\n#include <stdio.h>\n#define
+        MAX_JUGADORES 3\n#define MAX_NOMBRE 20\n\nint main() {\n    char personaje[MAX_JUGADORES][MAX_NOMBRE]
+        = { \"Mario\", \"Luigi\", \"Peach\" };\n    int vidas[MAX_JUGADORES] = { 3,
+        2, 5 };\n\n    printf(\"%s tiene %d vidas\\n\", personaje[0], vidas[0]);\n
+        \   return 0;\n}\n```\n\nCada índice representa un jugador:\n- `personaje[0]
+        = \"Mario\"` y `vidas[0] = 3`  \n- `personaje[1] = \"Luigi\"` y `vidas[1]
+        = 2`  \n- `personaje[2] = \"Peach\"` y `vidas[2] = 5`  \n\n---\n\n### Booleanos
+        y ternario\nPuedes guardar si una misión está completada:\n\n```c\n#include
+        <stdio.h>\n#include <stdbool.h>\n\n#define MAX_MISIONES 2\n\nint main() {\n
+        \   bool misionCompletada[MAX_MISIONES] = { true, false };\n\n    printf(\"%s\\n\",
+        misionCompletada[0] ? \"Completada\" : \"Pendiente\");\n    return 0;\n}\n```\n\n---\n\n###
+        Matriz booleana\nLas matrices permiten representar una cuadrícula.  \nPor
+        ejemplo, casillas de un mapa exploradas o no:\n\n```c\n#include <stdio.h>\n#include
+        <stdbool.h>\n\nint main() {\n    bool mapa[2][3] = {\n        { true, false,
+        true },\n        { false, true, false }\n    };\n\n    printf(\"Fila 0, Col
+        1: %d\\n\", mapa[0][1]);\n    return 0;\n}\n```\n\n---\n\n### Entrada con
+        `scanf`\nPuedes pedir al jugador que introduzca la salud de un personaje:\n\n```c\n#include
+        <stdio.h>\n\nint main() {\n    int salud[2];\n    printf(\"Introduce la salud
+        de Link: \");\n    scanf(\"%d\", &salud[0]);\n\n    printf(\"Salud de Link:
+        %d\\n\", salud[0]);\n    return 0;\n}\n```\n\n---\n\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n#include <stdbool.h>\n#include <string.h>\n\n#define MAX_JUGADORES
+        3\n#define MAX_NOMBRE 20\n#define MAX_MISIONES 2\n\ntypedef enum {\n    ZOMBIE,
+        ALIEN, ROBOT\n} tTipoEnemigo;\n\nint main() {\n    // Arrays paralelos\n    char
+        personaje[MAX_JUGADORES][MAX_NOMBRE] = { \"Mario\", \"Luigi\", \"Peach\" };\n
+        \   int vidas[MAX_JUGADORES] = { 3, 2, 5 };\n\n    // Estado de misiones\n
+        \   bool misionCompletada[MAX_MISIONES] = { true, false };\n\n    // Matriz
+        booleana de mapa\n    bool mapa[2][3] = {\n        { true, false, true },\n
+        \       { false, true, false }\n    };\n\n    // Entrada de datos\n    int
+        salud[2];\n    printf(\"Introduce la salud de Link: \");\n    scanf(\"%d\",
+        &salud[0]);\n\n    // Salidas\n    printf(\"%s tiene %d vidas\\n\", personaje[0],
+        vidas[0]);\n    printf(\"Misión 1: %s\\n\", misionCompletada[0] ? \"Completada\"
+        : \"Pendiente\");\n    printf(\"Mapa Fila 0, Col 1: %d\\n\", mapa[0][1]);\n
+        \   printf(\"Salud de Link: %d\\n\", salud[0]);\n\n    return 0;\n}\n```\n\nEste
+        programa combina enumerados, cadenas, arrays paralelos y matrices para representar
+        un estado de videojuego.\n"
+      Pseudocode: "En este nivel aprenderás a representar información de videojuegos
+        como **enemigos, nombres de personajes, vidas y mapas**, utilizando enumerados,
+        cadenas, arrays paralelos y matrices en pseudocódigo.  \nEsto permite organizar
+        datos del juego de manera clara.\n\n### Enumerados\n```pseudocode\ntype\n
+        \ tTipoEnemigo = { ZOMBIE, ALIEN, ROBOT }\nend type\n\nalgorithm\n  var\n
+        \   estado: tTipoEnemigo;\n  end var\n\n  estado := ALIEN;\n  writeEnum(estado);\nend
+        algorithm\n```\n\n---\n\n### Cadenas\n```pseudocode\nalgorithm\n  var\n    personaje:
+        vector[2] of string;\n  end var\n\n  personaje[1] := \"Mario\";\n  personaje[2]
+        := \"Peach\";\n\n  writeString(personaje[1]);\n  writeString(personaje[2]);\nend
+        algorithm\n```\n\n---\n\n### Arrays paralelos\n```pseudocode\nalgorithm\n
+        \ var\n    personaje: vector[2] of string;\n    vidas: vector[2] of integer;\n
+        \ end var\n\n  personaje[1] := \"Mario\";\n  vidas[1] := 3;\n\n  personaje[2]
+        := \"Luigi\";\n  vidas[2] := 2;\n\n  writeString(personaje[1]);\n  writeInteger(vidas[1]);\nend
+        algorithm\n```\n\n---\n\n### Booleanos\n```pseudocode\nalgorithm\n  var\n
+        \   mision: vector[2] of boolean;\n  end var\n\n  mision[1] := true;\n  mision[2]
+        := false;\n\n  writeBoolean(mision[1]);\nend algorithm\n```\n\n---\n\n###
+        Matriz booleana\n```pseudocode\nalgorithm\n  var\n    mapa: vector[2][2] of
+        boolean;\n  end var\n\n  mapa[1][1] := true;\n  mapa[1][2] := false;\n  mapa[2][1]
+        := true;\n  mapa[2][2] := false;\n\n  writeBoolean(mapa[1][2]);\nend algorithm\n```\n\n---\n\n###
+        Lectura de datos\n```pseudocode\nalgorithm\n  var\n    vidas: vector[2] of
+        integer;\n  end var\n\n  writeString(\"Introduce las vidas del jugador 1:
+        \");\n  vidas[1] := readInteger();\n\n  writeString(\"Vidas del jugador 1:
+        \");\n  writeInteger(vidas[1]);\nend algorithm\n```\n\n---\n\n### Ejemplo
+        completo\n```pseudocode\ntype\n  tTipoEnemigo = { ZOMBIE, ALIEN, ROBOT }\nend
+        type\n\nalgorithm estadoJuego\n  var\n    personaje: vector[2] of string;\n
+        \   vidas: vector[2] of integer;\n    mision: vector[2] of boolean;\n    mapa:
+        vector[2][2] of boolean;\n    salud: vector[2] of integer;\n    estado: tTipoEnemigo;\n
+        \ end var\n\n  personaje[1] := \"Mario\";\n  vidas[1] := 3;\n\n  personaje[2]
+        := \"Luigi\";\n  vidas[2] := 2;\n\n  mision[1] := true;\n  mision[2] := false;\n\n
+        \ mapa[1][1] := true;\n  mapa[1][2] := false;\n  mapa[2][1] := true;\n  mapa[2][2]
+        := false;\n\n  writeString(\"Introduce la salud de Mario: \");\n  salud[1]
+        := readInteger();\n\n  estado := ALIEN;\n\n  writeString(personaje[1]);\n
+        \ writeString(\" tiene \");\n  writeInteger(vidas[1]);\n  writeString(\" vidas\");\n\n
+        \ writeString(\", Misión 1: \");\n  writeBoolean(mision[1]);\n\n  writeString(\",
+        Casilla (1,2): \");\n  writeBoolean(mapa[1][2]);\n\n  writeString(\", Salud
+        de Mario: \");\n  writeInteger(salud[1]);\n\n  writeString(\", Estado enemigo:
+        \");\n  writeEnum(estado);\nend algorithm\n```\n\nEste algoritmo combina enumerados,
+        cadenas, arrays paralelos y matrices para representar un estado de videojuego.\n"
+    questions:
+    - id: c-3-enum-declaracion
+      language: C
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 3.
+
+        Declara un enumerado tTipoAnimal con los valores PERRO, GATO y AVE.
+
+        Dentro de main, declara un array tipoAnimal de tipo tTipoAnimal inicializado con PERRO, GATO y AVE usando llaves {}.
+      answer: |
+        #define MAX_ANIMALES 3
+
+        typedef enum {
+            PERRO,
+            GATO,
+            AVE
+        } tTipoAnimal;
+
+        int main() {
+            tTipoAnimal tipoAnimal[MAX_ANIMALES] = { PERRO, GATO, AVE };
+            return 0;
+        }
+      hint: Los enumerativos se inicializan igual que los enteros usando sus etiquetas.
+        No olvides la función main y el return 0.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-enum-declaracion
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 3.
+
+        Declara el tipo enumerado tTipoAnimal con los valores PERRO, GATO y AVE.
+
+        Dentro del algoritmo principal, declara un array tipoAnimal de tTipoAnimal, inicializado con PERRO, GATO y AVE.
+      answer: |
+        const
+          MAX_ANIMALES: integer = 3;
+        end const
+
+        type
+          tTipoAnimal = { PERRO, GATO, AVE }
+        end type
+
+        algorithm
+          var
+            tipoAnimal: vector[MAX_ANIMALES] of tTipoAnimal;
+          end var
+
+          tipoAnimal[1] := PERRO;
+          tipoAnimal[2] := GATO;
+          tipoAnimal[3] := AVE;
+        end algorithm
+      hint: Enum en pseudocódigo siempre van entre { }.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-nombres-strncpy
+      language: C
+      week: 3
+      prompt: |
+        Incluye string y stdio
+
+        Declara las constantes MAX_ANIMALES = 2 y MAX_NOMBRE = 15.
+
+        Dentro de main, declara dos cadenas de caracteres usando MAX_NOMBRE: nombre1 y nombre2.
+
+        Inicializa nombre1 y nombre2 con "Nina" y "Rocky" respectivamente usando strncpy.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_ANIMALES 2
+        #define MAX_NOMBRE 15
+
+        int main() {
+            char nombre1[MAX_NOMBRE];
+            char nombre2[MAX_NOMBRE];
+            strncpy(nombre1, "Nina", MAX_NOMBRE);
+            strncpy(nombre2, "Rocky", MAX_NOMBRE);
+            return 0;
+        }
+      hint: strncpy(destino, origen, tamaño) para inicializar strings.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-nombres-strings
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 2.
+
+        Dentro del algoritmo principal, declara un array nombre de strings para dos animales.
+
+        Inicializa nombre[1] con "Nina" y nombre[2] con "Rocky".
+      answer: |
+        const
+          MAX_ANIMALES: integer = 2;
+        end const
+
+        algorithm
+          var
+            nombre: vector[MAX_ANIMALES] of string;
+          end var
+
+          nombre[1] := "Nina";
+          nombre[2] := "Rocky";
+        end algorithm
+      hint:
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-ternario-vacunado
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio y stdbool.
+
+        Declara la constante MAX_ANIMALES = 2 y un array booleano vacunado inicializado con true y false con {}.
+
+        Imprime usando printf y el operador ternario: "Vacunado" si el primer animal está vacunado, "No vacunado" si no lo está.
+
+        Ejemplo de salida: "Vacunado"
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+
+        #define MAX_ANIMALES 2
+
+        int main() {
+            bool vacunado[MAX_ANIMALES] = { true, false };
+            printf("%s\n", vacunado[0] ? "Vacunado" : "No vacunado");
+            return 0;
+        }
+      hint: 'Recuerda la sintaxis del operador ternario: condicion ? valor_si_true
+        : valor_si_false'
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-arrays-paralelos
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara las constantes MAX_ANIMALES = 3 y MAX_NOMBRE = 15.
+
+        Dentro de main, declara un array de cadenas de caracteres con MAX_ANIMALES y MAX_NOMBRE y un array de enteros edad con (MAX_ANIMALES).
+
+        Inicializa los arrays usando llaves {}, con los nombres "Bobby", "Lili", "Rex" y las edades 2, 5, 3.
+
+        Imprime en diferentes líneas cada nombre seguido de la edad, usando printf, en el formato: "Nombre: Bobby, Edad: 2".
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ANIMALES 3
+        #define MAX_NOMBRE 15
+
+        int main() {
+            char nombre[MAX_ANIMALES][MAX_NOMBRE] = { "Bobby", "Lili", "Rex" };
+            int edad[MAX_ANIMALES] = { 2, 5, 3 };
+            printf("Nombre: %s, Edad: %d\n", nombre[0], edad[0]);
+            printf("Nombre: %s, Edad: %d\n", nombre[1], edad[1]);
+            printf("Nombre: %s, Edad: %d\n", nombre[2], edad[2]);
+            return 0;
+        }
+      hint: Cada printf debe estar en una línea diferente y no olvides el salto de
+        linea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-arrays-paralelos
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 3.
+
+        Dentro del algoritmo principal, declara un array nombre de strings y un array edad de enteros para tres animales.
+
+        Inicializa nombre con "Bobby", "Lili", "Rex" y edad con 2, 5, 3.
+
+        Imprime el nombre y la edad de cada animal, uno por línea, usando writeString y writeInteger.
+
+        Ejemplo de salida:
+          Nombre: Bobby
+          Edad: 2
+          Nombre: Lili
+          Edad: 5
+          Nombre: Rex
+          Edad: 3
+      answer: |
+        const
+          MAX_ANIMALES: integer = 3;
+        end const
+
+        algorithm
+          var
+            nombre: vector[MAX_ANIMALES] of string;
+            edad: vector[MAX_ANIMALES] of integer;
+          end var
+
+          nombre[1] := "Bobby";
+          nombre[2] := "Lili";
+          nombre[3] := "Rex";
+
+          edad[1] := 2;
+          edad[2] := 5;
+          edad[3] := 3;
+
+          writeString("Nombre: ");
+          writeString(nombre[1]);
+          writeString("Edad: ");
+          writeInteger(edad[1]);
+          writeString("Nombre: ");
+          writeString(nombre[2]);
+          writeString("Edad: ");
+          writeInteger(edad[2]);
+          writeString("Nombre: ");
+          writeString(nombre[3]);
+          writeString("Edad: ");
+          writeInteger(edad[3]);
+        end algorithm
+      hint: Cada writeString/writeInteger en su línea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-matriz-booleana
+      language: C
+      week: 3
+      prompt: "Incluye stdio y stdbool.\n\nDeclara las constantes FILAS = 2 y COLUMNAS
+        = 3.\n\nDentro de main, declara una matriz de booleanos estadoVacuna con FILAS
+        x COLUMNAS e inicialízala manualmente con: \n  fila 0: true, false, true\n
+        \ fila 1: false, true, false\n\nImprime el valor de cada casilla en una línea
+        con printf. \n\nEjemplo: \"Fila 0, Col 0: 1\" (donde 1 es true y 0 es false)\n"
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        int main() {
+            bool estadoVacuna[FILAS][COLUMNAS];
+            estadoVacuna[0][0] = true;
+            estadoVacuna[0][1] = false;
+            estadoVacuna[0][2] = true;
+            estadoVacuna[1][0] = false;
+            estadoVacuna[1][1] = true;
+            estadoVacuna[1][2] = false;
+
+            printf("Fila 0, Col 0: %d\n", estadoVacuna[0][0]);
+            printf("Fila 0, Col 1: %d\n", estadoVacuna[0][1]);
+            printf("Fila 0, Col 2: %d\n", estadoVacuna[0][2]);
+            printf("Fila 1, Col 0: %d\n", estadoVacuna[1][0]);
+            printf("Fila 1, Col 1: %d\n", estadoVacuna[1][1]);
+            printf("Fila 1, Col 2: %d\n", estadoVacuna[1][2]);
+            return 0;
+        }
+      hint: Imprime todos los valores de la matriz, un dato por línea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-matriz-booleana
+      language: Pseudocode
+      week: 3
+      prompt: "Declara las constantes FILAS = 2 y COLUMNAS = 3.\n\nDentro del algoritmo
+        principal, declara una matriz booleana estadoVacuna con FILAS x COLUMNAS e
+        inicialízala manualmente con: \n  fila 1: true, false, true\n  fila 2: false,
+        true, false\n\nImprime el valor de cada casilla, uno por línea, usando writeBoolean.\n\nEjemplo
+        de salida:\n  true\n  false\n  true\n  ...\n"
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 3;
+        end const
+
+        algorithm
+          var
+            estadoVacuna: vector[FILAS][COLUMNAS] of boolean;
+          end var
+
+          estadoVacuna[1][1] := true;
+          estadoVacuna[1][2] := false;
+          estadoVacuna[1][3] := true;
+          estadoVacuna[2][1] := false;
+          estadoVacuna[2][2] := true;
+          estadoVacuna[2][3] := false;
+
+          writeBoolean(estadoVacuna[1][1]);
+          writeBoolean(estadoVacuna[1][2]);
+          writeBoolean(estadoVacuna[1][3]);
+          writeBoolean(estadoVacuna[2][1]);
+          writeBoolean(estadoVacuna[2][2]);
+          writeBoolean(estadoVacuna[2][3]);
+        end algorithm
+      hint: Escribe un dato por línea, usando writeBoolean.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-lee-edad
+      language: C
+      week: 3
+      prompt: "Incluye stdio.\n\nDeclara la constante MAX_ANIMALES = 2.\n\nDentro
+        de main, declara un array de enteros edad. \n\nPide al usuario que introduzca
+        las edades usando scanf, guardando los valores en el primer y segundo elemento
+        del array.\n\nUsa el siguiente formato:\n  \"Introduce la edad del animal
+        1: \"\n  \"Introduce la edad del animal 2: \"\n"
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ANIMALES 2
+
+        int main() {
+            int edad[MAX_ANIMALES];
+            printf("Introduce la edad del animal 1: ");
+            scanf("%d", &edad[0]);
+            printf("Introduce la edad del animal 2: ");
+            scanf("%d", &edad[1]);
+            return 0;
+        }
+      hint: recuerda el especificador de formato de los enteros para leer el dato.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-lee-edad
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 2.
+
+        Dentro del algoritmo principal, declara un array edad de enteros.
+
+        Pide al usuario que introduzca las edades con readInteger y guarda los valores en el primer y segundo elemento del array.
+      answer: |
+        const
+          MAX_ANIMALES: integer = 2;
+        end const
+
+        algorithm
+          var
+            edad: vector[MAX_ANIMALES] of integer;
+          end var
+
+          writeString("Introduce la edad del animal 1: ");
+          edad[1] := readInteger();
+          writeString("Introduce la edad del animal 2: ");
+          edad[2] := readInteger();
+        end algorithm
+      hint: Lee y guarda cada valor por separado. Los indices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 2
+    explanation:
+      C: "En este nivel aprenderás a **tomar decisiones en tus programas** usando
+        estructuras condicionales como `if`, `else`, `else if`, `strcmp`, el operador
+        ternario y `switch`.  \nEstas herramientas son fundamentales en los videojuegos
+        para decidir acciones, comparar valores o controlar estados.\n\n### if\nEl
+        `if` permite ejecutar una acción si una condición es verdadera.  \nPor ejemplo,
+        decidir si un Pokémon está en forma para la batalla:\n\n```c\n#include <stdio.h>\n\nint
+        main() {\n    int salud;\n    printf(\"Introduce la salud del Pokémon: \");\n
+        \   scanf(\"%d\", &salud);\n\n    if (salud > 50) {\n        printf(\"Listo
+        para luchar\\n\");\n    }\n    return 0;\n}\n```\n\n---\n\n### if...else\nCon
+        `else` puedes ejecutar una alternativa si la condición no se cumple:\n\n```c\n#include
+        <stdio.h>\n#include <stdbool.h>\n\nint main() {\n    bool tienePocion;\n    printf(\"¿Tienes
+        poción? (1 = sí, 0 = no): \");\n    scanf(\"%d\", &tienePocion);\n\n    if
+        (tienePocion) {\n        printf(\"Usas la poción\\n\");\n    } else {\n        printf(\"No
+        puedes curarte\\n\");\n    }\n    return 0;\n}\n```\n\n---\n\n### if...else
+        if...else\nPara múltiples condiciones, puedes usar `else if`:\n\n```c\n#include
+        <stdio.h>\n\nint main() {\n    int nivel;\n    printf(\"Nivel del jugador:
+        \");\n    scanf(\"%d\", &nivel);\n\n    if (nivel < 5) {\n        printf(\"Novato\\n\");\n
+        \   } else if (nivel <= 10) {\n        printf(\"Intermedio\\n\");\n    } else
+        {\n        printf(\"Experto\\n\");\n    }\n    return 0;\n}\n```\n\n---\n\n###
+        strcmp\n`strcmp(cadena1, cadena2)` compara dos cadenas. Devuelve **0 si son
+        iguales**:\n\n```c\n#include <stdio.h>\n#include <string.h>\n\nint main()
+        {\n    char nombre1[10];\n    char nombre2[10];\n\n    strncpy(nombre1, \"Link\",
+        10);\n    strncpy(nombre2, \"Zelda\", 10);\n\n    printf(\"%s\\n\", strcmp(nombre1,
+        nombre2) == 0 ? \"Mismos personajes\" : \"Distintos personajes\");\n    return
+        0;\n}\n```\n\n---\n\n### Operador ternario anidado para enums\nPuedes convertir
+        un enum a texto usando ternarios:\n\n```c\n#include <stdio.h>\n#include <string.h>\n\ntypedef
+        enum { MAGE, WARRIOR, ROGUE } tClase;\n\nint main() {\n    tClase claseJugador
+        = MAGE;\n    char claseStr[20];\n\n    strncpy(claseStr,\n        (claseJugador
+        == MAGE) ? \"Mago\" :\n        (claseJugador == WARRIOR) ? \"Guerrero\" :
+        \"Pícaro\",\n        20);\n\n    printf(\"Clase: %s\\n\", claseStr);\n    return
+        0;\n}\n```\n\n---\n\n### switch\nCuando tienes varios casos posibles para
+        un mismo valor, puedes usar `switch`:\n\n```c\n#include <stdio.h>\n\nint main()
+        {\n    int opcion;\n    printf(\"Elige tu clase (1-Mago, 2-Guerrero, 3-Arquero):
+        \");\n    scanf(\"%d\", &opcion);\n\n    switch (opcion) {\n        case 1:\n
+        \           printf(\"Has elegido Mago\\n\");\n            break;\n        case
+        2:\n            printf(\"Has elegido Guerrero\\n\");\n            break;\n
+        \       case 3:\n            printf(\"Has elegido Arquero\\n\");\n            break;\n
+        \       default:\n            printf(\"Opción no válida\\n\");\n    }\n    return
+        0;\n}\n```\n\n---\n\n### Ejemplo completo\n```c\n#include <stdio.h>\n#include
+        <stdbool.h>\n#include <string.h>\n\ntypedef enum { MAGE, WARRIOR, ROGUE }
+        tClase;\n\nint main() {\n    int salud = 60;\n    bool tienePocion = true;\n
+        \   char nombre1[10] = \"Link\";\n    char nombre2[10] = \"Zelda\";\n    tClase
+        claseJugador = WARRIOR;\n    int opcion = 2;\n    char claseStr[20];\n\n    //
+        if simple\n    if (salud > 50) {\n        printf(\"Listo para luchar\\n\");\n
+        \   }\n\n    // if...else\n    if (tienePocion) {\n        printf(\"Usas la
+        poción\\n\");\n    } else {\n        printf(\"No puedes curarte\\n\");\n    }\n\n
+        \   // strcmp con ternario\n    printf(\"%s\\n\", strcmp(nombre1, nombre2)
+        == 0 ? \"Mismos personajes\" : \"Distintos personajes\");\n\n    // Enum a
+        string con ternario\n    strncpy(claseStr,\n        (claseJugador == MAGE)
+        ? \"Mago\" :\n        (claseJugador == WARRIOR) ? \"Guerrero\" : \"Pícaro\",\n
+        \       20);\n    printf(\"Clase: %s\\n\", claseStr);\n\n    // switch\n    switch
+        (opcion) {\n        case 1:\n            printf(\"Has elegido Mago\\n\");\n
+        \           break;\n        case 2:\n            printf(\"Has elegido Guerrero\\n\");\n
+        \           break;\n        case 3:\n            printf(\"Has elegido Arquero\\n\");\n
+        \           break;\n        default:\n            printf(\"Opción no válida\\n\");\n
+        \   }\n    return 0;\n}\n```\n\nEste programa combina todas las estructuras
+        condicionales para simular distintas decisiones de un videojuego.\n"
+      Pseudocode: "En este nivel aprenderás a **tomar decisiones en tus algoritmos**
+        usando `if`, `else`, `else if` y `switch`.  \nSon muy útiles en videojuegos
+        para controlar acciones, comparar valores o traducir estados a texto.\n\n###
+        if\nEjecuta una acción si se cumple una condición:\n\n```pseudocode\nalgorithm\n
+        \ var\n    salud: integer;\n  end var\n\n  writeString(\"Introduce la salud
+        del personaje: \");\n  salud := readInteger();\n\n  if salud > 50 then\n    writeString(\"Listo
+        para luchar\");\n  end if\nend algorithm\n```\n\n---\n\n### if...else\nEjecuta
+        una alternativa si no se cumple la condición:\n\n```pseudocode\nalgorithm\n
+        \ var\n    tieneEspada: boolean;\n  end var\n\n  writeString(\"¿Tienes espada?
+        (true/false): \");\n  tieneEspada := readBoolean();\n\n  if tieneEspada then\n
+        \   writeString(\"Puedes atacar\");\n  else\n    writeString(\"Necesitas un
+        arma\");\n  end if\nend algorithm\n```\n\n---\n\n### if...else if...else\nPuedes
+        verificar varias condiciones:\n\n```pseudocode\nalgorithm\n  var\n    nivel:
+        integer;\n  end var\n\n  writeString(\"Introduce el nivel del monstruo: \");\n
+        \ nivel := readInteger();\n\n  if nivel < 5 then\n    writeString(\"Fácil\");\n
+        \ else\n    if nivel <= 10 then\n      writeString(\"Normal\");\n    else\n
+        \     writeString(\"Difícil\");\n    end if\n  end if\nend algorithm\n```\n\n---\n\n###
+        Comparar cadenas\nEn pseudocódigo se comparan directamente con `=`:\n\n```pseudocode\nalgorithm\n
+        \ var\n    nombre1: string;\n    nombre2: string;\n  end var\n\n  nombre1
+        := \"Mario\";\n  nombre2 := \"Luigi\";\n\n  if nombre1 = nombre2 then\n    writeString(\"Iguales\");\n
+        \ else\n    writeString(\"Distintos\");\n  end if\nend algorithm\n```\n\n---\n\n###
+        Convertir enums a texto con if anidado\n```pseudocode\ntype\n  tClase = {
+        MAGO, GUERRERO, ARQUERO }\nend type\n\nalgorithm\n  var\n    claseJugador:
+        tClase;\n    claseStr: string;\n  end var\n\n  claseJugador := MAGO;\n\n  if
+        claseJugador = MAGO then\n    claseStr := \"Mago\";\n  else\n    if claseJugador
+        = GUERRERO then\n      claseStr := \"Guerrero\";\n    else\n      claseStr
+        := \"Arquero\";\n    end if\n  end if\n\n  writeString(claseStr);\nend algorithm\n```\n\n---\n\n###
+        switch\nElige una acción según el número introducido por el usuario:\n\n```pseudocode\nalgorithm\n
+        \ var\n    clase: integer;\n  end var\n\n  writeString(\"Elige una clase (1-Mago,
+        2-Guerrero, 3-Arquero): \");\n  clase := readInteger();\n\n  switch clase\n
+        \   case 1 then\n      writeString(\"Has elegido Mago\");\n    end case\n
+        \   case 2 then\n      writeString(\"Has elegido Guerrero\");\n    end case\n
+        \   case 3 then\n      writeString(\"Has elegido Arquero\");\n    end case\n
+        \   case default then\n      writeString(\"Opción no válida\");\n    end case\n
+        \ end switch\nend algorithm\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\ntype\n
+        \ tClase = { MAGO, GUERRERO, ARQUERO }\nend type\n\nalgorithm decisionesJuego\n
+        \ var\n    salud: integer;\n    tienePocion: boolean;\n    nombre1: string;\n
+        \   nombre2: string;\n    claseJugador: tClase;\n    clase: integer;\n    claseStr:
+        string;\n  end var\n\n  salud := 60;\n  tienePocion := true;\n  nombre1 :=
+        \"Link\";\n  nombre2 := \"Zelda\";\n  claseJugador := GUERRERO;\n  clase :=
+        2;\n\n  if salud > 50 then\n    writeString(\"Listo para luchar\");\n  end
+        if\n\n  if tienePocion then\n    writeString(\", Usas la poción\");\n  else\n
+        \   writeString(\", No puedes curarte\");\n  end if\n\n  if nombre1 = nombre2
+        then\n    writeString(\", Mismos personajes\");\n  else\n    writeString(\",
+        Distintos personajes\");\n  end if\n\n  if claseJugador = MAGO then\n    claseStr
+        := \"Mago\";\n  else\n    if claseJugador = GUERRERO then\n      claseStr
+        := \"Guerrero\";\n    else\n      claseStr := \"Arquero\";\n    end if\n  end
+        if\n\n  writeString(\", Clase: \");\n  writeString(claseStr);\n\n  switch
+        clase\n    case 1 then\n      writeString(\", Has elegido Mago\");\n    end
+        case\n    case 2 then\n      writeString(\", Has elegido Guerrero\");\n    end
+        case\n    case 3 then\n      writeString(\", Has elegido Arquero\");\n    end
+        case\n    case default then\n      writeString(\", Opción no válida\");\n
+        \   end case\n  end switch\nend algorithm\n```\n\nEste algoritmo combina todas
+        las estructuras condicionales para simular distintas decisiones de un videojuego.\n"
+    questions:
+    - id: c-3-if-simple
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Dentro de main, declara una variable edad y pídele al usuario que la introduzca.
+
+        Usa el formato de pregunta: "Introduce la edad del animal: ".
+
+        Usa un if para comprobar si la edad es mayor que 10. Si lo es, imprime "Mayor que 10".
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int edad;
+
+            printf("Introduce la edad del animal: ");
+            scanf("%d", &edad);
+
+            if(edad > 10) {
+                printf("Mayor que 10\n");
+            }
+
+            return 0;
+        }
+      hint: Usa if y no olvides el salto de linea. Recuerda que para leer cualquier
+        dato que no sea un string necesitamos el operador &.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-if-simple
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Dentro del algoritmo principal, declara una variable edad, pide el valor al usuario.
+
+        Usa el formato de pregunta: "Introduce la edad del animal: ".
+
+        Usa un if para comprobar si la edad es mayor que 10. Si lo es, imprime "Mayor que 10".
+      answer: |2
+
+        algorithm
+          var
+            edad: integer;
+          end var
+
+          writeString("Introduce la edad del animal: ");
+          edad := readInteger();
+
+          if edad > 10 then
+            writeString("Mayor que 10");
+          end if
+        end algorithm
+      hint: No hace falta else.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-if-else
+      language: C
+      week: 3
+      prompt: "Incluye stdio.h.\n\nDentro de main, declara una variable vacunado (bool)
+        y pide al usuario un número (0 para no vacunado, 1 para vacunado).\n\nUsa
+        un if else para imprimir \"Vacunado\" o \"No vacunado\". \n\nUsa este formato
+        de pregunta: \"¿El animal está vacunado? (1 = sí, 0 = no): \"\n"
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+
+        int main() {
+            bool vacunado;
+
+            printf("¿El animal está vacunado? (1 = sí, 0 = no): ");
+            scanf("%d", &vacunado);
+
+            if(vacunado) {
+                printf("Vacunado\n");
+            } else {
+                printf("No vacunado\n");
+            }
+            return 0;
+        }
+      hint: El valor 0 es false, 1 es true.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-if-else
+      language: Pseudocode
+      week: 3
+      prompt: "Dentro del algoritmo principal, declara una variable vacunado (boolean).\n\nPide
+        al usuario que introduzca true o false (usa readBoolean). \n\nUsa un if else
+        para imprimir \"Vacunado\" o \"No vacunado\".\n\nUsa este formato de pregunta:
+        \"¿El animal está vacunado? (true/false): \"\n"
+      answer: |
+        algorithm
+          var
+            vacunado: boolean;
+          end var
+
+          writeString("¿El animal está vacunado? (true/false): ");
+          vacunado := readBoolean();
+
+          if vacunado then
+            writeString("Vacunado");
+          else
+            writeString("No vacunado");
+          end if
+        end algorithm
+      hint: Usa readBoolean para leer el dato.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-compara-strcmp
+      language: C
+      week: 3
+      prompt: |
+        Incluye string y stdio.
+
+        Declara la constante MAX_NOMBRE = 10.
+
+        Dentro de main, declara dos cadenas de caracteres nombre1 y nombre2 inicializados con "Kira" y "Max" usando strncpy.
+
+        Usa strcmp para comparar si son iguales. Si lo son, imprime "Nombres iguales", si no, imprime "Nombres diferentes".
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 10
+
+        int main() {
+            char nombre1[MAX_NOMBRE];
+            char nombre2[MAX_NOMBRE];
+
+            strncpy(nombre1, "Kira", MAX_NOMBRE);
+            strncpy(nombre2, "Max", MAX_NOMBRE);
+
+            if(strcmp(nombre1, nombre2) == 0) {
+                printf("Nombres iguales\n");
+            } else {
+                printf("Nombres diferentes\n");
+            }
+            return 0;
+        }
+      hint: strcmp devuelve 0 si las cadenas son iguales. No olvides los saltos de
+        linea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-compara-strings
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 2.
+
+        Dentro del algoritmo principal, declara un array nombre de strings para dos animales.
+
+        Inicializa nombre[1] con "Kira" y nombre[2] con "Max".
+
+        Si los nombres son iguales, imprime "Nombres iguales", si no, imprime "Nombres diferentes".
+      answer: |
+        const
+          MAX_ANIMALES: integer = 2;
+        end const
+
+        algorithm
+          var
+            nombre: vector[MAX_ANIMALES] of string;
+          end var
+
+          nombre[1] := "Kira";
+          nombre[2] := "Max";
+
+          if nombre[1] = nombre[2] then
+            writeString("Nombres iguales");
+          else
+            writeString("Nombres diferentes");
+          end if
+        end algorithm
+      hint: En pseudocódigo puedes comparar strings con = .
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-if-else-encadenado
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Dentro de main, declara una variable edad y pide al usuario una edad y usa if, else if y else para imprimir:
+        - "Joven" si la edad es menor que 5,
+        - "Adulto" si es entre 5 y 10 (ambos inclusive),
+        - "Senior" si es mayor de 10.
+
+        Usa el siguiente formato de pregunta: "Introduce la edad del animal: "
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int edad;
+
+            printf("Introduce la edad del animal: ");
+            scanf("%d", &edad);
+
+            if(edad < 5) {
+                printf("Joven\n");
+            } else if(edad <= 10) {
+                printf("Adulto\n");
+            } else {
+                printf("Senior\n");
+            }
+            return 0;
+        }
+      hint: Usa ifs encadenados. No olvides los saltos de linea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-if-else-encadenado
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Dentro del algoritmo principal, declara una variable edad, pide una edad al usuario y usa if, else, if anidados para imprimir:
+        - "Joven" si la edad es menor que 5,
+        - "Adulto" si es entre 5 y 10 (ambos inclusive),
+        - "Senior" si es mayor de 10.
+
+        Usa el siguiente formato de pregunta: "Introduce la edad del animal: "
+      answer: |
+        algorithm
+          var
+            edad: integer;
+          end var
+
+          writeString("Introduce la edad del animal: ");
+          edad := readInteger();
+
+          if edad < 5 then
+            writeString("Joven");
+          else
+            if edad <= 10 then
+              writeString("Adulto");
+            else
+              writeString("Senior");
+            end if
+          end if
+        end algorithm
+      hint: Usa if anidados.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-enum-to-string-ternario
+      language: C
+      week: 3
+      prompt: |
+        Incluye string y stdio.
+
+        Declara la constante MAX_ANIMALES = 3
+
+        Declara un enumerado tTipoAnimal con PERRO, GATO y AVE.
+
+        Declara un array tipoAnimal de tTipoAnimal inicializado con PERRO, GATO y AVE usando {}.
+
+        Declara una cadena de caracteres tipoStr de longitud 20 (Usa el valor directo).
+
+        Copia en tipoStr el nombre del primer animal usando strncpy y el operador ternario anidado para convertir el enum a string ("Perro", "Gato" o "Ave").
+
+        Resumiendo, debes guardar el tipo de animal en un formato string. Para convertir el enumerativo en string, usaras el operador ternario.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_ANIMALES 3
+
+        typedef enum {
+            PERRO, GATO, AVE
+        } tTipoAnimal;
+
+        int main() {
+            tTipoAnimal tipoAnimal[MAX_ANIMALES] = { PERRO, GATO, AVE };
+            char tipoStr[20];
+            strncpy(tipoStr,
+                (tipoAnimal[0] == PERRO) ? "Perro" :
+                (tipoAnimal[0] == GATO) ? "Gato" : "Ave",
+                20);
+            return 0;
+        }
+      hint: Usa strncpy siempre y pon el tamaño como tercer parámetro. En el segundo
+        parametro debe ir el operador ternario anidado.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-enum-to-string-anidado
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_ANIMALES = 3.
+
+        Declara el tipo enumerado tTipoAnimal con PERRO, GATO y AVE.
+
+        Dentro del algoritmo principal, declara un array tipoAnimal de tTipoAnimal inicializado con PERRO, GATO y AVE.
+
+        Declara una variable tipoStr de tipo string.
+
+        Si tipoAnimal[1] es PERRO, tipoStr debe ser "Perro"; si es GATO, "Gato"; si es AVE, "Ave".
+
+        Para lograrlo deberás usar if else if anidados.
+      answer: |
+        const
+          MAX_ANIMALES: integer = 3;
+        end const
+
+        type
+          tTipoAnimal = { PERRO, GATO, AVE }
+        end type
+
+        algorithm
+          var
+            tipoAnimal: vector[MAX_ANIMALES] of tTipoAnimal;
+            tipoStr: string;
+          end var
+
+          tipoAnimal[1] := PERRO;
+          tipoAnimal[2] := GATO;
+          tipoAnimal[3] := AVE;
+
+          if tipoAnimal[1] = PERRO then
+            tipoStr := "Perro";
+          else
+            if tipoAnimal[1] = GATO then
+              tipoStr := "Gato";
+            else
+              tipoStr := "Ave";
+            end if
+          end if
+        end algorithm
+      hint: Deberas usar if else if... Los anidados son if dentro de else.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-switch
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.h.
+
+        Dentro de main, crea una variable entera opcion y pide al usuario un entero entre 1 y 3.
+
+        Usa el siguiente formato: "Introduce el tipo de animal (1-Perro, 2-Gato, 3-Ave): 1"
+
+        Usa switch para imprimir:
+          1 → "Perro"
+          2 → "Gato"
+          3 → "Ave"
+          cualquier otro → "Opción inválida"
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int opcion;
+
+            printf("Introduce el tipo de animal (1-Perro, 2-Gato, 3-Ave): ");
+            scanf("%d", &opcion);
+
+            switch(opcion) {
+                case 1:
+                    printf("Perro\n");
+                    break;
+                case 2:
+                    printf("Gato\n");
+                    break;
+                case 3:
+                    printf("Ave\n");
+                    break;
+                default:
+                    printf("Opción inválida\n");
+            }
+            return 0;
+        }
+      hint: Usa switch...case...break. Y recuerda los saltos de linea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-switch
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Dentro del algoritmo principal, crea una variable entera opcion y pide al usuario un entero entre 1 y 3.
+
+        Usa el siguiente formato: "Introduce el tipo de animal (1-Perro, 2-Gato, 3-Ave): 1"
+
+        Usa switch para imprimir:
+          1 → "Perro"
+          2 → "Gato"
+          3 → "Ave"
+          cualquier otro → "Opción inválida"
+      answer: |
+        algorithm
+          var
+            opcion: integer;
+          end var
+
+          writeString("Introduce el tipo de animal (1-Perro, 2-Gato, 3-Ave): ");
+          opcion := readInteger();
+
+          switch opcion
+            case 1 then
+              writeString("Perro");
+            end case
+            case 2 then
+              writeString("Gato");
+            end case
+            case 3 then
+              writeString("Ave");
+            end case
+            case default then
+              writeString("Opción inválida");
+            end case
+          end switch
+        end algorithm
+      hint: |-
+        Recuerda la estructura del switch en pseudocódigo. switch case    then end case
+        case default then end case end switch
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 3
+    explanation:
+      C: "En este nivel aprenderás a **repetir instrucciones** usando bucles `for`,
+        `while` y `do while`, para recorrer arrays y matrices relacionados con videojuegos.
+        \ \nEstos bucles permiten procesar listas de datos como niveles, puntos de
+        experiencia o mapas.\n\n### Bucle `for` básico\nEl `for` sirve para repetir
+        una acción un número fijo de veces.  \nEjemplo: mostrar los primeros 10 niveles
+        de un personaje:\n\n```c\n#include <stdio.h>\n#define MAX_NIVELES 10\n\nint
+        main() {\n    int i;\n    for (i = 0; i < MAX_NIVELES; i++) {\n        printf(\"%d\\n\",
+        i + 1);\n    }\n    return 0;\n}\n```\n\n---\n\n### Recorrer un array con
+        `for`\nPuedes recorrer un array de puntos de experiencia ganados en misiones:\n\n```c\n#include
+        <stdio.h>\n#define MAX_MISIONES 4\n\nint main() {\n    int experiencia[MAX_MISIONES]
+        = {150, 300, 200, 400};\n    int i;\n\n    for (i = 0; i < MAX_MISIONES; i++)
+        {\n        printf(\"%d\\n\", experiencia[i]);\n    }\n    return 0;\n}\n```\n\n---\n\n###
+        Leer datos en un array con `for`\nPuedes usar `scanf` en un bucle para leer
+        datos del usuario.  \nPor ejemplo, el tiempo que tardó en cada misión:\n\n```c\n#include
+        <stdio.h>\n\nint main() {\n    float tiempo[3];\n    int i;\n\n    for (i
+        = 0; i < 3; i++) {\n        printf(\"Tiempo en misión %d: \", i + 1);\n        scanf(\"%f\",
+        &tiempo[i]);\n    }\n    return 0;\n}\n```\n\n---\n\n### `while` y `do while`\n-
+        `while` se ejecuta mientras se cumpla una condición.  \n- `do while` se ejecuta
+        al menos una vez.\n\n```c\n#include <stdio.h>\n\nint main() {\n    int i =
+        0;\n\n    while (i < 5) {\n        printf(\"%d\\n\", i);\n        i++;\n    }\n\n
+        \   i = 0;\n    do {\n        printf(\"%d\\n\", i);\n        i++;\n    } while
+        (i < 5);\n\n    return 0;\n}\n```\n\n---\n\n### Suma de elementos en un array\nPuedes
+        sumar los puntos conseguidos en varios niveles:\n\n```c\n#include <stdio.h>\n\nint
+        main() {\n    int puntos[4] = {10, 20, 30, 40};\n    int suma = 0;\n    int
+        i;\n\n    for (i = 0; i < 4; i++) {\n        suma += puntos[i];\n    }\n\n
+        \   printf(\"Total: %d\\n\", suma);\n    return 0;\n}\n```\n\n---\n\n### strncpy
+        en bucle\nPuedes copiar nombres de enemigos usando un bucle y `strncpy`:\n\n```c\n#include
+        <stdio.h>\n#include <string.h>\n#define MAX 3\n#define MAX_NOMBRE 12\n\nint
+        main() {\n    char enemigos[MAX][MAX_NOMBRE];\n    char nombresBase[MAX][MAX_NOMBRE]
+        = {\"Goblin\", \"Orco\", \"Troll\"};\n    int i;\n\n    for (i = 0; i < MAX;
+        i++) {\n        strncpy(enemigos[i], nombresBase[i], MAX_NOMBRE);\n    }\n\n
+        \   for (i = 0; i < MAX; i++) {\n        printf(\"%s\\n\", enemigos[i]);\n
+        \   }\n    return 0;\n}\n```\n\n---\n\n### Recorrer matrices\nPuedes recorrer
+        mapas, inventarios o zonas con bucles anidados:\n\n```c\n#include <stdio.h>\n\nint
+        main() {\n    int mapa[2][3] = {\n        {1, 0, 1},\n        {0, 1, 0}\n
+        \   };\n    int i, j;\n\n    for (i = 0; i < 2; i++) {\n        for (j = 0;
+        j < 3; j++) {\n            printf(\"%d \", mapa[i][j]);\n        }\n        printf(\"\\n\");\n
+        \   }\n    return 0;\n}\n```\n\n---\n\n### Suma de una matriz\nPara sumar
+        el daño de cada ataque en un campo de batalla:\n\n```c\n#include <stdio.h>\n\nint
+        main() {\n    int dano[2][2] = {\n        {5, 3},\n        {7, 1}\n    };\n
+        \   int suma = 0;\n    int i, j;\n\n    for (i = 0; i < 2; i++) {\n        for
+        (j = 0; j < 2; j++) {\n            suma += dano[i][j];\n        }\n    }\n\n
+        \   printf(\"Daño total: %d\\n\", suma);\n    return 0;\n}\n```\n\n---\n\n###
+        Ejemplo completo\n```c\n#include <stdio.h>\n#include <string.h>\n#define MAX
+        3\n#define MAX_NOMBRE 12\n\nint main() {\n    // Recorrer array\n    int experiencia[4]
+        = {150, 300, 200, 400};\n    int i, j;\n    for (i = 0; i < 4; i++) {\n        printf(\"Experiencia
+        misión %d: %d\\n\", i + 1, experiencia[i]);\n    }\n\n    // Sumar array\n
+        \   int puntos[4] = {10, 20, 30, 40};\n    int suma = 0;\n    for (i = 0;
+        i < 4; i++) {\n        suma += puntos[i];\n    }\n    printf(\"Puntos totales:
+        %d\\n\", suma);\n\n    // Copiar nombres\n    char enemigos[MAX][MAX_NOMBRE];\n
+        \   char nombresBase[MAX][MAX_NOMBRE] = {\"Goblin\", \"Orco\", \"Troll\"};\n
+        \   for (i = 0; i < MAX; i++) {\n        strncpy(enemigos[i], nombresBase[i],
+        MAX_NOMBRE);\n    }\n\n    // Recorrer matriz\n    int mapa[2][3] = {\n        {1,
+        0, 1},\n        {0, 1, 0}\n    };\n    for (i = 0; i < 2; i++) {\n        for
+        (j = 0; j < 3; j++) {\n            printf(\"%d \", mapa[i][j]);\n        }\n
+        \       printf(\"\\n\");\n    }\n    return 0;\n}\n```\n\nEste programa muestra
+        cómo usar bucles para recorrer arrays y matrices en un videojuego.\n"
+      Pseudocode: "En este nivel aprenderás a **usar bucles** `for`, `while` y `do
+        while` en pseudocódigo para recorrer arrays y matrices.  \nSon muy útiles
+        en videojuegos para repetir acciones, calcular sumas o recorrer mapas.\n\n###
+        Bucle `for` básico\n```pseudocode\nalgorithm\n  var \n    i: integer;\n  end
+        var\n\n  for i = 1 to 10 do\n    writeInteger(i);\n  end for\nend algorithm\n```\n\n---\n\n###
+        Recorrer un array\n```pseudocode\nalgorithm\n  var\n    experiencia: vector[4]
+        of integer;\n    i: integer;\n  end var\n\n  experiencia[1] := 150;\n  experiencia[2]
+        := 300;\n  experiencia[3] := 200;\n  experiencia[4] := 400;\n\n  for i = 1
+        to 4 do\n    writeInteger(experiencia[i]);\n  end for\nend algorithm\n```\n\n---\n\n###
+        Leer un array con `for`\n```pseudocode\nalgorithm\n  var\n    tiempo: vector[3]
+        of real;\n    i: integer;\n  end var\n\n  for i = 1 to 3 do\n    writeString(\"Tiempo
+        misión \");\n    writeInteger(i);\n    writeString(\": \");\n    tiempo[i]
+        := readReal();\n  end for\nend algorithm\n```\n\n---\n\n### `while` y `do
+        while`\n```pseudocode\nalgorithm\n  var i: integer;\n  end var\n\n  i := 1;\n
+        \ while i <= 5 do\n    writeInteger(i);\n    i := i + 1;\n  end while\n\n
+        \ i := 1;\n  do\n    writeInteger(i);\n    i := i + 1;\n  while i <= 5;\nend
+        algorithm\n```\n\n---\n\n### Sumar los puntos obtenidos\n```pseudocode\nalgorithm\n
+        \ var\n    puntos: vector[4] of integer;\n    suma: integer;\n    i: integer;\n
+        \ end var\n\n  puntos[1] := 10;\n  puntos[2] := 20;\n  puntos[3] := 30;\n
+        \ puntos[4] := 40;\n  suma := 0;\n\n  for i = 1 to 4 do\n    suma := suma
+        + puntos[i];\n  end for\n\n  writeString(\"Total: \");\n  writeInteger(suma);\nend
+        algorithm\n```\n\n---\n\n### Imprimir nombres\n```pseudocode\nalgorithm\n
+        \ var\n    enemigos: vector[3] of string;\n    i: integer;\n  end var\n\n
+        \ enemigos[1] := \"Goblin\";\n  enemigos[2] := \"Orco\";\n  enemigos[3] :=
+        \"Troll\";\n\n  for i = 1 to 3 do\n    writeString(enemigos[i]);\n  end for\nend
+        algorithm\n```\n\n---\n\n### Matrices\n```pseudocode\nalgorithm\n  var\n    mapa:
+        vector[2][3] of integer;\n    i, j: integer;\n  end var\n\n  mapa[1][1] :=
+        1;\n  mapa[1][2] := 0;\n  mapa[1][3] := 1;\n  mapa[2][1] := 0;\n  mapa[2][2]
+        := 1;\n  mapa[2][3] := 0;\n\n  for i = 1 to 2 do\n    for j = 1 to 3 do\n
+        \     writeInteger(mapa[i][j]);\n    end for\n  end for\nend algorithm\n```\n\n---\n\n###
+        Sumar los valores de una matriz\n```pseudocode\nalgorithm\n  var\n    dano:
+        vector[2][2] of integer;\n    suma, i, j: integer;\n  end var\n\n  dano[1][1]
+        := 5;\n  dano[1][2] := 3;\n  dano[2][1] := 7;\n  dano[2][2] := 1;\n  suma
+        := 0;\n\n  for i = 1 to 2 do\n    for j = 1 to 2 do\n      suma := suma +
+        dano[i][j];\n    end for\n  end for\n\n  writeString(\"Daño total: \");\n
+        \ writeInteger(suma);\nend algorithm\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\nalgorithm
+        buclesVideojuego\n  var\n    experiencia: vector[4] of integer;\n    puntos:
+        vector[4] of integer;\n    enemigos: vector[3] of string;\n    mapa: vector[2][3]
+        of integer;\n    suma, i, j: integer;\n  end var\n\n  experiencia[1] := 150;\n
+        \ experiencia[2] := 300;\n  experiencia[3] := 200;\n  experiencia[4] := 400;\n\n
+        \ for i = 1 to 4 do\n    writeString(\"Experiencia misión \");\n    writeInteger(i);\n
+        \   writeString(\": \");\n    writeInteger(experiencia[i]);\n  end for\n\n
+        \ puntos[1] := 10;\n  puntos[2] := 20;\n  puntos[3] := 30;\n  puntos[4] :=
+        40;\n  suma := 0;\n\n  for i = 1 to 4 do\n    suma := suma + puntos[i];\n
+        \ end for\n  writeString(\"Puntos totales: \");\n  writeInteger(suma);\n\n
+        \ enemigos[1] := \"Goblin\";\n  enemigos[2] := \"Orco\";\n  enemigos[3] :=
+        \"Troll\";\n  for i = 1 to 3 do\n    writeString(enemigos[i]);\n  end for\n\n
+        \ mapa[1][1] := 1;\n  mapa[1][2] := 0;\n  mapa[1][3] := 1;\n  mapa[2][1] :=
+        0;\n  mapa[2][2] := 1;\n  mapa[2][3] := 0;\n  for i = 1 to 2 do\n    for j
+        = 1 to 3 do\n      writeInteger(mapa[i][j]);\n    end for\n  end for\nend
+        algorithm\n```\n\nEste algoritmo muestra cómo recorrer arrays y matrices con
+        diferentes bucles en un videojuego.\n"
+    questions:
+    - id: c-3-for-indice-basico
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.h.
+
+        Declara la constante MAXIMO = 10.
+
+        Dentro de main, declara una variable i.
+
+        Utiliza un bucle for para que i tome valores de 0 a 9, ambos incluidos, e imprime el valor de i en cada iteración.
+
+        La salida debe ser una línea por número, ejemplo:
+          0
+          1
+          2
+          ...
+          9
+      answer: |
+        #include <stdio.h>
+        #define MAXIMO 10
+
+        int main() {
+            int i;
+
+            for(i = 0; i < MAXIMO; i++) {
+                printf("%d\n", i);
+            }
+            return 0;
+        }
+      hint: 'El for clásico en C es: for(inicio; condicion; incremento)'
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-indice-basico
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAXIMO = 10.
+
+        Dentro del algoritmo principal, declara una variable i.
+
+        Utiliza un bucle for para que i tome valores de 1 a MAXIMO e imprime el valor de i en cada iteración.
+
+        La salida debe ser una línea por número del 1 al 10. Ejemplo
+        1
+        2
+        3
+        ...
+        10
+      answer: |
+        const
+          MAXIMO: integer = 10;
+        end const
+
+        algorithm
+          var
+            i: integer;
+          end var
+
+          for i := 1 to MAXIMO do
+            writeInteger(i);
+          end for
+        end algorithm
+      hint: En pseudocódigo los arrays y los índices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-array-imprimir
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAX_DATOS = 4.
+
+        Dentro de main, declara un array de enteros datos con MAX_DATOS inicializado con a 7, 2, 5, 8 usando { }.
+
+        Usa un bucle for para imprimir cada dato, uno por línea. Necesitaras una variable i.
+
+        Ejemplo de ejecución:
+          7
+          2
+          5
+          8
+      answer: |
+        #include <stdio.h>
+        #define MAX_DATOS 4
+
+        int main() {
+            int datos[MAX_DATOS] = {7, 2, 5, 8};
+            int i;
+            for(i = 0; i < MAX_DATOS; i++) {
+                printf("%d\n", datos[i]);
+            }
+            return 0;
+        }
+      hint: Recuerda que los arrays en C empiezan en 0.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-array-imprimir
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX_DATOS = 4.
+
+        Dentro del algoritmo principal, declara un array de enteros datos con MAX_DATOS.
+
+        Inicialízalo a mano con los valores 7, 2, 5, 8.
+
+        Usa un bucle for para imprimir cada dato, uno por línea. Necesitarás una variable i.
+
+        Ejemplo de ejecución:
+          7
+          2
+          5
+          8
+      answer: |
+        const
+          MAX_DATOS: integer = 4;
+        end const
+
+        algorithm
+          var
+            datos: vector[MAX_DATOS] of integer;
+            i: integer;
+          end var
+
+          datos[1] := 7;
+          datos[2] := 2;
+          datos[3] := 5;
+          datos[4] := 8;
+
+          for i := 1 to MAX_DATOS do
+            writeInteger(datos[i]);
+          end for
+        end algorithm
+      hint: El índice comienza en 1 en pseudocódigo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-leer-array
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAXIMO = 3.
+
+        Dentro de main, declara un array de decimales valores con MAXIMO.
+
+        Usa un bucle for para pedir al usuario que ingrese 3 decimales y guardarlos en el array.
+
+        Necesitarás una variable i para usar de iterador.
+
+        Luego imprime los valores, uno por línea utilizando otro for.
+
+        Ejemplo de ejecución:
+          Ingresa valor 1: 3.2
+          Ingresa valor 2: 1.0
+          Ingresa valor 3: 4.8
+          3.2
+          1.0
+          4.8
+      answer: |
+        #include <stdio.h>
+        #define MAXIMO 3
+
+        int main() {
+            float valores[MAXIMO];
+            int i;
+            for(i = 0; i < MAXIMO; i++) {
+                printf("Ingresa valor %d: ", i+1);
+                scanf("%f", &valores[i]);
+            }
+            for(i = 0; i < MAXIMO; i++) {
+                printf("%.1f\n", valores[i]);
+            }
+            return 0;
+        }
+      hint: Usa dos bucles for, uno para leer y otro para imprimir. Imprime los valores
+        con 1 solo decimal.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-leer-array
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAXIMO = 3.
+
+        Dentro del algoritmo principal, declara un array de reales valores con MAXIMO.
+
+        Usa un bucle for para leer 3 decimales del usuario y guardarlos en el array.
+
+        Necesitarás una variable i para usar de iterador.
+
+        Luego usa otro bucle for para imprimir los valores, uno por línea.
+
+        Ejemplo de ejecución:
+          Ingresa valor 1: 3.2
+          Ingresa valor 2: 1.0
+          Ingresa valor 3: 4.8
+          3.2
+          1.0
+          4.8
+
+        El numero seguido de valor toma el valor del indice en cada iteración.
+      answer: |
+        const
+          MAXIMO: integer = 3;
+        end const
+
+        algorithm
+          var
+            valores: vector[MAXIMO] of real;
+            i: integer;
+          end var
+
+          for i := 1 to MAXIMO do
+            writeString("Ingresa valor ");
+            writeInteger(i);
+            writeString(": ");
+            valores[i] := readReal();
+          end for
+
+          for i := 1 to MAXIMO do
+            writeReal(valores[i]);
+          end for
+        end algorithm
+      hint: Usa dos bucles for, uno para leer y otro para imprimir. Recuerda que en
+        pseudocodigo debes imprimir los datos en diferentes lineas.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-while-indice-basico
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAXIMO = 10.
+
+        Dentro de main, declara una variable i inicializada a 0.
+
+        Utiliza un bucle while para imprimir el valor de i mientras i sea menor que MAXIMO.
+
+        La salida debe ser una línea por número, del 0 al 9.
+      answer: |
+        #include <stdio.h>
+        #define MAXIMO 10
+
+        int main() {
+            int i = 0;
+            while(i < MAXIMO) {
+                printf("%d\n", i);
+                i++;
+            }
+            return 0;
+        }
+      hint: Recuerda inicializar i antes del while e incrementarla antes de finalizar
+        cada iteración para no crear un bucle infinito.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-while-indice-basico
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAXIMO = 10.
+
+        Dentro del algoritmo principal, declara una variable i inicializada a 1.
+
+        Usa un bucle while para imprimir el valor de i mientras i sea menor o igual que MAXIMO.
+
+        La salida debe ser una línea por número del 1 al 10.
+      answer: |
+        const
+          MAXIMO: integer = 10;
+        end const
+
+        algorithm
+          var
+            i: integer;
+          end var
+
+          i := 1;
+          while i <= MAXIMO do
+            writeInteger(i);
+            i := i + 1;
+          end while
+        end algorithm
+      hint: En pseudocódigo los índices empiezan en 1 y se incrementan manualmente.
+        No olvides incrementar el indice.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-do-while-indice-basico
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAXIMO = 10.
+
+        Dentro de main, declara una variable i inicializada a 0.
+
+        Usa un bucle do while para imprimir el valor de i mientras i sea menor que MAXIMO.
+
+        La salida debe ser una línea por número, del 0 al 9.
+      answer: |
+        #include <stdio.h>
+        #define MAXIMO 10
+
+        int main() {
+            int i = 0;
+            do {
+                printf("%d\n", i);
+                i++;
+            } while(i < MAXIMO);
+            return 0;
+        }
+      hint: El cuerpo de do while siempre se ejecuta al menos una vez. No olvides
+        el salto de linea en el print.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-do-while-indice-basico
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAXIMO = 10.
+
+        Dentro del algoritmo principal, declara una variable e inicializala a 1.
+
+        Usa un bucle do while para imprimir el valor de i mientras i sea menor o igual que MAXIMO.
+
+        La salida debe ser una línea por número del 1 al 10.
+      answer: |
+        const
+          MAXIMO: integer = 10;
+        end const
+
+        algorithm
+          var
+            i: integer;
+          end var
+
+          i := 1;
+          do
+            writeInteger(i);
+            i := i + 1;
+          while i <= MAXIMO;
+        end algorithm
+      hint: En pseudocódigo los índices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-suma-array
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara la constante MAX = 4.
+
+        Dentro de main, declara un array de enteros valores con MAX inicializado a 1, 2, 3, 4 usando { }.
+
+        Declara una variable suma para almacenar la suma de todos los elementos del array e inicializala en 0.
+
+        También necesitarás una variable i para utilizar en el bucle.
+
+        Usa un bucle for para calcular la suma de todos los elementos y al final imprime el resultado así:
+
+        Suma: x
+
+        Para la suma utiliza el operador compuesto.
+
+        Ejemplo de ejecución:
+          Suma: 10
+      answer: |
+        #include <stdio.h>
+        #define MAX 4
+
+        int main() {
+            int valores[MAX] = {1, 2, 3, 4};
+            int suma = 0;
+            int i;
+            for(i = 0; i < MAX; i++) {
+                suma += valores[i];
+            }
+            printf("Suma: %d\n", suma);
+            return 0;
+        }
+      hint: Acumula la suma con suma += . Imprime el resultado fuera del bucle y no
+        olvides el salto de linea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-suma-array
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX = 4.
+
+        Declara un array de enteros valores con MAX.
+
+        Inicialízalo a mano con los valores 1, 2, 3, 4.
+
+        Declara una variable suma para almacenar la suma de todos los elementos del array e inicializala en 0.
+
+        También necesitarás una variable i para utilizar en el bucle.
+
+        Usa un bucle for para calcular la suma de todos los elementos y al final imprime el resultado así:
+
+        Suma: x
+
+        Ejemplo de ejecución:
+          Suma: 10
+      answer: |
+        const
+          MAX: integer = 4;
+        end const
+
+        algorithm
+          var
+            valores: vector[MAX] of integer;
+            suma: integer;
+            i: integer;
+          end var
+
+          valores[1] := 1;
+          valores[2] := 2;
+          valores[3] := 3;
+          valores[4] := 4;
+          suma := 0;
+
+          for i := 1 to MAX do
+            suma := suma + valores[i];
+          end for
+
+          writeString("Suma: ");
+          writeInteger(suma);
+        end algorithm
+      hint: Recuerda inicializar suma a 0. Imprime el resultado fuera del bucle. Los
+        indices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-strncpy-paralelo
+      language: C
+      week: 3
+      prompt: "Incluye stdio y string.\n\nDeclara la constante MAX = 3 y MAX_NOMBRE
+        = 12.\n\nDentro de main, declara un array de cadenas nombres con MAX y MAX_NOMBRE.\n\nDeclara
+        otro array de cadenas ejemplos con MAX y MAX_NOMBRE e inicializalo con los
+        siguientes nombres usando { }: \nAna\", \"Luis\" y \"Eva\"\n\nDeclara una
+        variable i para utilizar en los bucles.\n\nUsa strncpy para inicializar los
+        nombres con \"Ana\", \"Luis\" y \"Eva\" usando un bucle for.\n\nDespués, imprime
+        cada nombre, uno por línea con otro bucle for.\n\nEjemplo de ejecución:\n
+        \ Ana\n  Luis\n  Eva\n"
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+        #define MAX 3
+        #define MAX_NOMBRE 12
+
+        int main() {
+            char nombres[MAX][MAX_NOMBRE];
+            char ejemplos[MAX][MAX_NOMBRE]; = {"Ana", "Luis", "Eva"};
+            int i;
+            for(i = 0; i < MAX; i++) {
+                strncpy(nombres[i], ejemplos[i], MAX_NOMBRE);
+            }
+            for(i = 0; i < MAX; i++) {
+                printf("%s\n", nombres[i]);
+            }
+            return 0;
+        }
+      hint: Usa strncpy(destino, origen, tamaño).
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-array-paralelo
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara la constante MAX = 3.
+
+        Declara un array de strings nombres con MAX.
+
+        Inicialízalos a mano como "Ana", "Luis" y "Eva".
+
+        Usa un bucle for para imprimir cada nombre, uno por línea.
+
+        Ejemplo de ejecución:
+          Ana
+          Luis
+          Eva
+      answer: |
+        const
+          MAX: integer = 3;
+        end const
+
+        algorithm
+          var
+            nombres: vector[MAX] of string;
+            i: integer;
+          end var
+
+          nombres[1] := "Ana";
+          nombres[2] := "Luis";
+          nombres[3] := "Eva";
+
+          for i := 1 to MAX do
+            writeString(nombres[i]);
+          end for
+        end algorithm
+      hint: Los índices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-matriz-manual
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Dentro de main, declara una matriz de enteros tabla con FILAS x COLUMNAS e inicialízala manualmente usando asignaciones.
+
+        Declara dos variables i j para utilizar en los bucles.
+
+        Asigna manualmente los valores siguientes:
+          fila 1: 2, 4, 6
+          fila 2: 1, 3, 5
+
+        Usa dos bucles for anidados para imprimir la matriz como una tabla.
+
+        Después de cada bucle interno, imprime un salto de linea para lograr el output facilitado.
+
+        Ejemplo de ejecución:
+          2 4 6
+          1 3 5
+      answer: "#include <stdio.h>\n#define FILAS 2\n#define COLUMNAS 3\n\nint main()
+        {\n    int tabla[FILAS][COLUMNAS];\n    int i, j;\n\n    tabla[0][0] = 2;
+        \n    tabla[0][1] = 4; \n    tabla[0][2] = 6;\n    tabla[1][0] = 1; \n    tabla[1][1]
+        = 3; \n    tabla[1][2] = 5;\n\n    for(i = 0; i < FILAS; i++) {\n        for(j
+        = 0; j < COLUMNAS; j++) {\n            printf(\"%d \", tabla[i][j]);\n        }\n
+        \       printf(\"\\n\");\n    }\n    return 0;\n}\n"
+      hint: Inicializa cada elemento manualmente.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-matriz-manual
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 3.
+
+        Declara una matriz de enteros tabla con FILAS x COLUMNAS.
+
+        Declara dos variables i j para utilizar en los bucles.
+
+        Asigna manualmente los valores:
+          fila 1: 2, 4, 6
+          fila 2: 1, 3, 5
+
+        Usa dos bucles for anidados para imprimir la matriz como una tabla.
+
+        Ejemplo de ejecución:
+          2 4 6
+          1 3 5
+      answer: "const\n  FILAS: integer = 2;\n  COLUMNAS: integer = 3;\nend const\n\nalgorithm\n
+        \ var\n    tabla: vector[FILAS][COLUMNAS] of integer;\n    i: integer;\n    j:
+        integer;\n  end var\n\n  tabla[1][1] := 2; \n  tabla[1][2] := 4; \n  tabla[1][3]
+        := 6;\n  tabla[2][1] := 1; \n  tabla[2][2] := 3; \n  tabla[2][3] := 5;\n\n
+        \ for i := 1 to FILAS do\n    for j := 1 to COLUMNAS do\n      writeInteger(tabla[i][j]);\n
+        \   end for\n  end for\nend algorithm\n"
+      hint: Los bucles anidados recorren filas y columnas.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-matriz-inicializa-llaves
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara las constantes FILAS = 2 y COLUMNAS = 2.
+
+        Dentro de main, declara una matriz de decimales temp con FILAS x COLUMNAS e inicialízala con { } con los valores:
+          22.1, 18.3 y 19.5, 20.0 (fila1 y fila2)
+
+        Declara dos variables i j para utilizar en los bucles.
+
+        Usa dos bucles for anidados para imprimir cada valor con un decimal, uno por línea.
+
+        Ejemplo de ejecución:
+          22.1
+          18.3
+          19.5
+          20.0
+      answer: |
+        #include <stdio.h>
+        #define FILAS 2
+        #define COLUMNAS 2
+
+        int main() {
+            float temp[FILAS][COLUMNAS] = {
+                {22.1, 18.3},
+                {19.5, 20.0}
+            };
+            int i, j;
+            for(i = 0; i < FILAS; i++) {
+                for(j = 0; j < COLUMNAS; j++) {
+                    printf("%.1f\n", temp[i][j]);
+                }
+            }
+            return 0;
+        }
+      hint: Usa inicialización con llaves y no olvides el salto de linea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-matriz-inicializa-manual
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 2.
+
+        Declara una matriz de reales temp con FILAS x COLUMNAS.
+
+        Asigna manualmente los valores:
+          22.1, 18.3 y 19.5,20.0 (fila1 y fila2)
+
+        Declara dos variables i j para utilizar en los bucles.
+
+        Usa dos bucles for anidados para imprimir cada valor, uno por línea.
+
+        Ejemplo de ejecución:
+          22.1
+          18.3
+          19.5
+          20.0
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 2;
+        end const
+
+        algorithm
+          var
+            temp: vector[FILAS][COLUMNAS] of real;
+            i: integer;
+            j: integer;
+          end var
+
+          temp[1][1] := 22.1;
+          temp[1][2] := 18.3;
+          temp[2][1] := 19.5;
+          temp[2][2] := 20.0;
+
+          for i := 1 to FILAS do
+            for j := 1 to COLUMNAS do
+              writeReal(temp[i][j]);
+            end for
+          end for
+        end algorithm
+      hint: En pseudocódigo la inicialización es manual.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-3-for-suma-matriz
+      language: C
+      week: 3
+      prompt: |
+        Incluye stdio.
+
+        Declara las constantes FILAS = 2 y COLUMNAS = 2.
+
+        Dentro de main, declara una matriz de enteros tabla con FILAS x COLUMNAS inicializada con (3, 1) y (5, 2).
+
+        Declara una variable suma e inicializala en 0.
+
+        Declara dos variables i, j en la misma linea para utilizar en los bucles.
+
+        Usa dos bucles for anidados para calcular la suma de todos los elementos y luego imprime:
+
+        Suma: x
+
+        La suma realizala con operador compuesto.
+
+        Ejemplo de ejecución:
+          Suma: 11
+      answer: |
+        #include <stdio.h>
+        #define FILAS 2
+        #define COLUMNAS 2
+
+        int main() {
+            int tabla[FILAS][COLUMNAS] = {
+                {3, 1},
+                {5, 2}
+            };
+            int suma = 0;
+            int i, j;
+            for(i = 0; i < FILAS; i++) {
+                for(j = 0; j < COLUMNAS; j++) {
+                    suma += tabla[i][j];
+                }
+            }
+            printf("Suma: %d\n", suma);
+            return 0;
+        }
+      hint: Suma con suma += tabla[i][j].
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-3-for-suma-matriz
+      language: Pseudocode
+      week: 3
+      prompt: |
+        Declara las constantes FILAS = 2 y COLUMNAS = 2.
+
+        Dentro del algoritmo principal, declara una matriz de enteros tabla con FILAS x COLUMNAS inicializada con (3, 1) y (5, 2).
+
+        Declara una variable suma e inicializala en 0.
+
+        Declara dos variables i, j para utilizar en los bucles.
+
+        Usa dos bucles for anidados para calcular la suma de todos los elementos y luego imprime:
+
+        Suma: x
+
+        Ejemplo de ejecución:
+          Suma: 11
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 2;
+        end const
+
+        algorithm
+          var
+            tabla: vector[FILAS][COLUMNAS] of integer;
+            suma: integer;
+            i: integer;
+            j: integer;
+          end var
+
+          tabla[1][1] := 3;
+          tabla[1][2] := 1;
+          tabla[2][1] := 5;
+          tabla[2][2] := 2;
+          suma := 0;
+
+          for i := 1 to FILAS do
+            for j := 1 to COLUMNAS do
+              suma := suma + tabla[i][j];
+            end for
+          end for
+
+          writeString("Suma: ");
+          writeInteger(suma);
+        end algorithm
+      hint: Los indices empiezan en 1. Primero declara y luego inicializa
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+- number: 4
+  explanation: 'Explicación de semana 4
+
+    '
+  levels:
+  - number: 1
+    explanation:
+      C: "En este nivel aprenderás a **declarar y utilizar `structs`** para representar
+        datos complejos como una atracción de un parque, además de cómo declarar **arrays
+        de structs** y acceder a sus campos.  \nLos `structs` son muy útiles para
+        modelar entidades en videojuegos o parques temáticos.\n\n### ¿Qué es un `struct`?\nUn
+        `struct` permite agrupar múltiples variables relacionadas bajo un solo nombre.
+        \ \nEs ideal para representar personajes, ítems o atracciones.\n\n```c\ntypedef
+        struct {\n    char nombre[30];\n    int duracionMinutos;\n    float alturaMinima;\n}
+        tAtraccion;\n```\n\nEsto define un nuevo tipo `tAtraccion` con 3 campos.\n\n---\n\n###
+        Declarar una variable de tipo struct\n```c\nint main(){\n  tAtraccion torreCaida;\n
+        \ return 0;\n}\n```\n\n---\n\n### Asignar valores a los campos\nPara campos
+        `char[]`, usamos `strncpy`:\n\n```c\n#include <string.h>\n\nint main() {\n
+        \   tAtraccion torreCaida;\n    strncpy(torreCaida.nombre, \"Torre de Caída\",
+        30);\n    torreCaida.duracionMinutos = 3;\n    torreCaida.alturaMinima = 1.40;\n
+        \   return 0;\n}\n```\n\n---\n\n### Array de structs\nPuedes declarar un array
+        de structs para almacenar varias atracciones:\n\n```c\n#define MAX_ATRACCIONES
+        3\n\nint main(){\n  tAtraccion atracciones[MAX_ATRACCIONES];\n  return 0;\n}\n\n```\n\nPara
+        acceder al nombre de la primera atracción:\n\n```c\nint main(){\n  atracciones[0].nombre;\n
+        \ return 0;\n}\n```\n\n---\n\n### Relación entre arrays paralelos\nSupón que
+        tienes un array de `tAtraccion` y otro array con el número de visitantes.
+        \ \nSi el índice es el mismo, representan datos del mismo objeto:\n\n```c\n#include
+        <string.h>\n#define MAX_ATRACCIONES 3\n\nint main() {\n    tAtraccion atracciones[MAX_ATRACCIONES];\n
+        \   int visitantes[MAX_ATRACCIONES];\n\n    strncpy(atracciones[1].nombre,
+        \"Looping\", 30);\n    visitantes[1] = 1234;\n    return 0;\n}\n```\n\nAquí
+        el índice `1` se refiere a la misma atracción.\n\n---\n\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n#include <string.h>\n\n#define MAX_ATRACCIONES 3\n\ntypedef struct
+        {\n    char nombre[30];\n    int duracionMinutos;\n    float alturaMinima;\n}
+        tAtraccion;\n\nint main() {\n    tAtraccion parque[MAX_ATRACCIONES];\n    int
+        visitantes[MAX_ATRACCIONES];\n\n    // Asignar valores\n    strncpy(parque[0].nombre,
+        \"Torre de Caída\", 30);\n    parque[0].duracionMinutos = 3;\n    parque[0].alturaMinima
+        = 1.40;\n    visitantes[0] = 1200;\n\n    strncpy(parque[1].nombre, \"Looping\",
+        30);\n    parque[1].duracionMinutos = 2;\n    parque[1].alturaMinima = 1.30;\n
+        \   visitantes[1] = 1500;\n\n    strncpy(parque[2].nombre, \"Tazas Locas\",
+        30);\n    parque[2].duracionMinutos = 4;\n    parque[2].alturaMinima = 1.10;\n
+        \   visitantes[2] = 900;\n\n    // Mostrar datos\n    for (int i = 0; i <
+        MAX_ATRACCIONES; i++) {\n        printf(\"Atracción: %s\\n\", parque[i].nombre);\n
+        \       printf(\"Duración: %d minutos\\n\", parque[i].duracionMinutos);\n
+        \       printf(\"Altura mínima: %.2f m\\n\", parque[i].alturaMinima);\n        printf(\"Visitantes:
+        %d\\n\\n\", visitantes[i]);\n    }\n\n    return 0;\n}\n```\n\nEste programa
+        muestra cómo declarar structs, guardarlos en arrays y relacionarlos con otros
+        datos como número de visitantes.\n"
+      Pseudocode: "En este nivel aprenderás a **utilizar `record`** para representar
+        datos compuestos, como atracciones, y cómo trabajar con **arrays de registros**.
+        \ \nLos `record` permiten organizar la información de un parque o videojuego
+        de forma clara.\n\n### ¿Qué es un `record`?\nUn `record` es como una caja
+        que contiene distintos datos relacionados.  \nSirve para representar enemigos,
+        jefes o atracciones de parque.\n\n```pseudocode\ntype\n  tAtraccion = record\n
+        \   nombre: string;\n    duracionMinutos: integer;\n    alturaMinima: real;\n
+        \ end record\nend type\n```\n\n---\n\n### Declarar una variable de tipo record\n```pseudocode\nalgorithm\n
+        \ var\n    torreCaida: tAtraccion;\n  end var\nend algorithm\n```\n\n---\n\n###
+        Asignar valores a los campos\n```pseudocode\nalgorithm\n  var\n    torreCaida:
+        tAtraccion;\n  end var\n\n  torreCaida.nombre := \"Torre de Caída\";\n  torreCaida.duracionMinutos
+        := 3;\n  torreCaida.alturaMinima := 1.40;\nend algorithm\n```\n\n---\n\n###
+        Array de records\n```pseudocode\nconst\n  MAX_ATRACCIONES: integer = 3;\nend
+        const\n\nalgorithm\n  var\n    parque: vector[MAX_ATRACCIONES] of tAtraccion;\n
+        \ end var\nend algorithm\n```\n\nPara acceder al campo de la primera atracción:\n\n```pseudocode\nparque[1].nombre\n```\n\n---\n\n###
+        Relación entre arrays paralelos\nSi tienes un array `parque` y otro array
+        llamado `visitantes`, puedes almacenar información relacionada en la misma
+        posición:\n\n```pseudocode\nalgorithm\n  var\n    parque: vector[3] of tAtraccion;\n
+        \   visitantes: vector[3] of integer;\n  end var\n\n  parque[2].nombre :=
+        \"Tazas locas\";\n  parque[2].duracionMinutos := 4;\n  parque[2].alturaMinima
+        := 1.10;\n\n  visitantes[2] := 300;\nend algorithm\n```\n\nAquí, el índice
+        2 representa los datos de la misma atracción.\n\n---\n\n### Ejemplo completo\n```pseudocode\nconst\n
+        \ MAX_ATRACCIONES: integer = 3;\nend const\n\ntype\n  tAtraccion = record\n
+        \   nombre: string;\n    duracionMinutos: integer;\n    alturaMinima: real;\n
+        \ end record\nend type\n\nalgorithm parqueDiversiones\n  var\n    parque:
+        vector[MAX_ATRACCIONES] of tAtraccion;\n    visitantes: vector[MAX_ATRACCIONES]
+        of integer;\n    i: integer;\n  end var\n\n  parque[1].nombre := \"Torre de
+        Caída\";\n  parque[1].duracionMinutos := 3;\n  parque[1].alturaMinima := 1.40;\n
+        \ visitantes[1] := 1200;\n\n  parque[2].nombre := \"Looping\";\n  parque[2].duracionMinutos
+        := 2;\n  parque[2].alturaMinima := 1.30;\n  visitantes[2] := 1500;\n\n  parque[3].nombre
+        := \"Tazas Locas\";\n  parque[3].duracionMinutos := 4;\n  parque[3].alturaMinima
+        := 1.10;\n  visitantes[3] := 900;\n\n  for i := 1 to MAX_ATRACCIONES do\n
+        \   writeString(\"Atracción: \");\n    writeString(parque[i].nombre);\n    writeString(\",
+        Duración: \");\n    writeInteger(parque[i].duracionMinutos);\n    writeString(\"
+        min, Altura mínima: \");\n    writeReal(parque[i].alturaMinima);\n    writeString(\"
+        m, Visitantes: \");\n    writeInteger(visitantes[i]);\n  end for\nend algorithm\n```\n\nEste
+        algoritmo muestra cómo trabajar con registros y arrays paralelos para representar
+        un parque de atracciones.\n"
+    questions:
+    - id: c-4-atraccion-basica
+      language: C
+      week: 4
+      prompt: |
+        Crea un tipo de dato llamado tAtraccion para una atracción de parque con los siguientes campos exactos:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por la constante MAX_NOMBRE (valor 30).
+        - Un número decimal llamado alturaMinima.
+        - Un valor lógico llamado enMantenimiento.
+
+        Declara una variable llamada atraccion1 de tipo tAtraccion dentro de la función main.
+      answer: |
+        #include <stdbool.h>
+
+        #define MAX_NOMBRE 30
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            float alturaMinima;
+            bool enMantenimiento;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            return 0;
+        }
+      hint: Declara primero la constante, luego el typedef del struct y por último
+        la variable atraccion1 dentro de main. No olvides la biblioteca de booleanos
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-basica
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo de dato llamado tAtraccion para una atracción de parque con los siguientes campos exactos:
+        - Un texto llamado nombre.
+        - Un número real llamado alturaMinima.
+        - Un valor booleano llamado enMantenimiento.
+
+        Declara una variable llamada atraccion1 de tipo tAtraccion dentro del bloque principal.
+      answer: |
+        type
+          tAtraccion = record
+            nombre: string;
+            alturaMinima: real;
+            enMantenimiento: boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+        end algorithm
+      hint: En pseudocódigo no se especifica el tamaño del texto; usa string.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-con-tipo
+      language: C
+      week: 4
+      prompt: |
+        Crea un tipo enumerado llamado tTipoAtraccion con los valores MONTANA_RUSA, CARRUSEL y SIMULADOR.
+        Crea un tipo tAtraccion con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por la constante MAX_NOMBRE (valor 30).
+        - Un campo llamado tipo de tipo tTipoAtraccion.
+
+        Declara una variable llamada atraccion1 de tipo tAtraccion dentro de la función main.
+      answer: |
+        #define MAX_NOMBRE 30
+
+        typedef enum {
+            MONTANA_RUSA,
+            CARRUSEL,
+            SIMULADOR
+        } tTipoAtraccion;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tTipoAtraccion tipo;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            return 0;
+        }
+      hint: Declara primero la constante, luego el typedef del enum y luego el typedef
+        del struct que lo usa.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-con-tipo
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo enumerado llamado tTipoAtraccion con los valores MONTANA_RUSA, CARRUSEL y SIMULADOR.
+        Crea un tipo tAtraccion con:
+        - Un texto llamado nombre.
+        - Un campo llamado tipo de tipo tTipoAtraccion.
+
+        Declara una variable llamada atraccion1 de tipo tAtraccion dentro del bloque principal.
+      answer: |
+        type
+          tTipoAtraccion = { MONTANA_RUSA, CARRUSEL, SIMULADOR }
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            tipo: tTipoAtraccion;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+        end algorithm
+      hint: Declara el tipo enumerado antes del record que lo utiliza utiliza dos
+        bloques type diferentes.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atracciones-lista
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (30) y MAX_ATRACCIONES (5).
+
+        Crea un tipo tAtraccion con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 30).
+        - Un número entero llamado capacidadMaxima.
+
+        Dentro de la función principal, declara un array llamado lista de tipo tAtraccion con MAX_ATRACCIONES elementos.
+      answer: |
+        #define MAX_NOMBRE 30
+        #define MAX_ATRACCIONES 5
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            int capacidadMaxima;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion lista[MAX_ATRACCIONES];
+            return 0;
+        }
+      hint: Las constantes deben definirse antes del typedef del struct.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atracciones-lista
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 5.
+
+        Crea un tipo tAtraccion con:
+        - Un texto llamado nombre.
+        - Un número entero llamado capacidadMaxima.
+
+        En el bloque principal, declara un array llamado lista de tipo tAtraccion con MAX_ATRACCIONES elementos.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 5;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            capacidadMaxima: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            lista: vector[MAX_ATRACCIONES] of tAtraccion;
+          end var
+        end algorithm
+      hint: Usa vector[MAX_ATRACCIONES] of tAtraccion para el array de registros.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-horario
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_HORA (6) y MAX_NOMBRE (30).
+
+        Crea un tipo tHorario con:
+        - Una cadena de caracteres llamada apertura con tamaño máximo definido por MAX_HORA (valor 6).
+        - Una cadena de caracteres llamada cierre con tamaño máximo definido por MAX_HORA (valor 6).
+
+        Crea un tipo tAtraccion con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 30).
+        - Un campo llamado horario de tipo tHorario.
+
+
+        Declara dentro de main una variable llamada atraccion1 de tipo tAtraccion.
+      answer: |
+        #define MAX_HORA 6
+        #define MAX_NOMBRE 30
+
+        typedef struct {
+            char apertura[MAX_HORA];
+            char cierre[MAX_HORA];
+        } tHorario;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tHorario horario;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            return 0;
+        }
+      hint: Los structs anidados se declaran con un typedef para cada tipo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-horario
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo tHorario con:
+        - Un texto llamado apertura.
+        - Un texto llamado cierre.
+
+        Crea un tipo tAtraccion con:
+        - Un texto llamado nombre.
+        - Un campo llamado horario de tipo tHorario.
+
+        Declara una variable llamada atraccion1 de tipo tAtraccion en el bloque principal.
+      answer: |
+        type
+          tHorario = record
+            apertura: string;
+            cierre: string;
+          end record
+
+          tAtraccion = record
+            nombre: string;
+            horario: tHorario;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+        end algorithm
+      hint: Declara primero tHorario y luego úsalo como campo en tAtraccion, usa un
+        solo bloque type.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-ficha-seguridad
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 30.
+
+        Crea un tipo tFichaSeguridad con:
+        - Una cadena de caracteres llamada inspector con tamaño máximo definido por MAX_NOMBRE (valor 30).
+        - Un número decimal llamado puntaje.
+        - Un valor lógico llamado aprobada.
+
+        Declara dentro de main una variable llamada ficha1 de tipo tFichaSeguridad.
+      answer: |
+        #include <stdbool.h>
+
+        #define MAX_NOMBRE 30
+
+        typedef struct {
+            char inspector[MAX_NOMBRE];
+            float puntaje;
+            bool aprobada;
+        } tFichaSeguridad;
+
+        int main() {
+            tFichaSeguridad ficha1;
+            return 0;
+        }
+      hint: Recuerda incluir <stdbool.h> cuando uses bool en C.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-ficha-seguridad
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo tFichaSeguridad con:
+        - Un texto llamado inspector.
+        - Un número real llamado puntaje.
+        - Un valor booleano llamado aprobada.
+
+        Declara dentro del bloque principal una variable llamada ficha1 de tipo tFichaSeguridad.
+      answer: |
+        type
+          tFichaSeguridad = record
+            inspector: string;
+            puntaje: real;
+            aprobada: boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            ficha1: tFichaSeguridad;
+          end var
+        end algorithm
+      hint: El record agrupa campos de distintos tipos en un solo dato.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-restricciones
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 30.
+
+        Crea un tipo enumerado tDificultad con los valores BAJA, MEDIA y ALTA.
+        Crea un tipo tRestriccion con:
+        - Un número decimal llamado alturaMinima.
+        - Un valor lógico llamado embarazadasProhibido.
+
+        Crea un tipo tAtraccion con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 30).
+        - Un campo llamado dificultad de tipo tDificultad.
+        - Un campo llamado restriccion de tipo tRestriccion.
+
+
+        Declara dentro de main una variable llamada atraccion1 de tipo tAtraccion.
+      answer: |
+        #include <stdbool.h>
+
+        #define MAX_NOMBRE 30
+
+        typedef enum {
+            BAJA, MEDIA, ALTA
+        } tDificultad;
+
+        typedef struct {
+            float alturaMinima;
+            bool embarazadasProhibido;
+        } tRestriccion;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tDificultad dificultad;
+            tRestriccion restriccion;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            return 0;
+        }
+      hint: Declara enum y structs con typedef y en ese orden antes de main.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-restricciones
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo enumerado tDificultad con los valores BAJA, MEDIA y ALTA.
+        Crea un tipo tRestriccion con:
+        - Un número real llamado alturaMinima.
+        - Un valor booleano llamado embarazadasProhibido.
+
+        Crea un tipo tAtraccion con:
+        - Un texto llamado nombre.
+        - Un campo llamado dificultad de tipo tDificultad.
+        - Un campo llamado restriccion de tipo tRestriccion.
+
+        Declara dentro del bloque principal una variable llamada atraccion1 de tipo tAtraccion.
+      answer: |
+        type
+          tDificultad = { BAJA, MEDIA, ALTA }
+
+          tRestriccion = record
+            alturaMinima: real;
+            embarazadasProhibido: boolean;
+          end record
+
+          tAtraccion = record
+            nombre: string;
+            dificultad: tDificultad;
+            restriccion: tRestriccion;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+        end algorithm
+      hint: 'Define los tipos en orden: enum, record restricción y luego el record
+        atracción. Utiliza un solo bloque type end type.'
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-cartelera-atracciones
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (20) y MAX_ATRACCIONES (3).
+
+        Crea un tipo tAtraccion con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 20).
+        - Un número entero llamado duracionMinutos.
+
+        Declara dentro de main un array llamado cartelera de tipo tAtraccion con MAX_ATRACCIONES elementos.
+      answer: |
+        #define MAX_NOMBRE 20
+        #define MAX_ATRACCIONES 3
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            int duracionMinutos;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion cartelera[MAX_ATRACCIONES];
+            return 0;
+        }
+      hint: El array de structs se declara como cualquier array, usando el tipo tAtraccion.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-cartelera-atracciones
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (20) y MAX_ATRACCIONES (3).
+
+        Crea un tipo tAtraccion con:
+        - Un texto llamado nombre.
+        - Un número entero llamado duracionMinutos.
+
+        Declara dentro del bloque principal un array llamado cartelera de tipo tAtraccion con MAX_ATRACCIONES elementos.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 3;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            duracionMinutos: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            cartelera: vector[MAX_ATRACCIONES] of tAtraccion;
+          end var
+        end algorithm
+      hint: En pseudocódigo los arrays se declaran con vector[tamaño] of tipo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-mapa-zona
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (25), FILAS (2) y COLUMNAS (3).
+
+        Crea un tipo tMapaZona con:
+        - Una cadena de caracteres llamada nombreZona con tamaño máximo definido por MAX_NOMBRE (valor 25).
+        - Una matriz booleana llamada ocupacion con tamaño FILAS x COLUMNAS.
+
+        Declara dentro de main una variable llamada mapa1 de tipo tMapaZona.
+      answer: |
+        #include <stdbool.h>
+
+        #define MAX_NOMBRE 25
+        #define FILAS 2
+        #define COLUMNAS 3
+
+        typedef struct {
+            char nombreZona[MAX_NOMBRE];
+            bool ocupacion[FILAS][COLUMNAS];
+        } tMapaZona;
+
+        int main() {
+            tMapaZona mapa1;
+            return 0;
+        }
+      hint: Para usar bool en C incluye <stdbool.h>. La matriz va como campo del struct.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-mapa-zona
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara las constantes FILAS con valor 2 y COLUMNAS con valor 3.
+
+        Crea un tipo tMapaZona con:
+        - Un texto llamado nombreZona.
+        - Una matriz booleana llamada ocupacion de tamaño FILAS x COLUMNAS.
+
+        Declara dentro del bloque principal una variable llamada mapa1 de tipo tMapaZona.
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 3;
+        end const
+
+        type
+          tMapaZona = record
+            nombreZona: string;
+            ocupacion: vector[FILAS][COLUMNAS] of boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            mapa1: tMapaZona;
+          end var
+        end algorithm
+      hint: En pseudocódigo, las matrices se representan como vector[FILAS][COLUMNAS]
+        of tipo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-snack-categoria
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 20.
+
+        Crea un tipo tSnack con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 20).
+        - Un carácter llamado categoria (por ejemplo 'A', 'B', 'C').
+
+        Declara dentro de main una variable llamada snack1 de tipo tSnack.
+      answer: |
+        #define MAX_NOMBRE 20
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            char categoria;
+        } tSnack;
+
+        int main() {
+            tSnack snack1;
+            return 0;
+        }
+      hint: Recuerda que un carácter en C es tipo char y ocupa un solo carácter.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-snack-categoria
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un tipo tSnack con:
+        - Un texto llamado nombre.
+        - Un carácter llamado categoria.
+
+        Declara dentro del bloque principal una variable llamada snack1 de tipo tSnack.
+      answer: |
+        type
+          tSnack = record
+            nombre: string;
+            categoria: character;
+          end record
+        end type
+
+        algorithm
+          var
+            snack1: tSnack;
+          end var
+        end algorithm
+      hint: El campo categoria es de tipo character (un único símbolo).
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-puesto-precios
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (25) y NUM_PLATOS (4).
+
+        Crea un tipo tPuestoComida con:
+        - Una cadena de caracteres llamada nombre con tamaño máximo definido por MAX_NOMBRE (valor 25).
+        - Un array de números decimales llamado precios con tamaño NUM_PLATOS.
+
+        Declara dentro de main una variable llamada puesto1 de tipo tPuestoComida.
+      answer: |
+        #define MAX_NOMBRE 25
+        #define NUM_PLATOS 4
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            float precios[NUM_PLATOS];
+        } tPuestoComida;
+
+        int main() {
+            tPuestoComida puesto1;
+            return 0;
+        }
+      hint: Declara las constantes antes del typedef; el array precios es de longitud
+        fija.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-puesto-precios
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante NUM_PLATOS con valor 4.
+
+        Crea un tipo tPuestoComida con:
+        - Un texto llamado nombre.
+        - Un array de números reales llamado precios con tamaño NUM_PLATOS.
+
+        Declara dentro del bloque principal una variable llamada puesto1 de tipo tPuestoComida.
+      answer: |
+        const
+          NUM_PLATOS: integer = 4;
+        end const
+
+        type
+          tPuestoComida = record
+            nombre: string;
+            precios: vector[NUM_PLATOS] of real;
+          end record
+        end type
+
+        algorithm
+          var
+            puesto1: tPuestoComida;
+          end var
+        end algorithm
+      hint: En pseudocódigo usa vector[NUM_PLATOS] of real para el campo precios.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 2
+    explanation:
+      C: "En este nivel aprenderás a **declarar, inicializar y acceder a estructuras
+        (`struct`) en C**, usando ejemplos relacionados con atracciones de parques.
+        \ \nLas estructuras son muy útiles para agrupar información variada bajo un
+        mismo nombre.\n\n### ¿Qué es un `struct`?\nUna estructura (`struct`) te permite
+        agrupar distintos datos bajo un solo tipo.  \nPor ejemplo, para representar
+        una atracción con un nombre, tipo y duración:\n\n```c\ntypedef struct {\n
+        \   char nombre[30];\n    int tipo;\n    int duracion;\n} tAtraccion;\n```\n\nAquí
+        se definen tres campos:  \n- `nombre`: cadena de caracteres.  \n- `tipo`:
+        número entero que representa la categoría.  \n- `duracion`: entero con la
+        duración en minutos.  \n\n---\n\n### Declarar y asignar manualmente\n```c\n#include
+        <string.h>\n\nint main() {\n    tAtraccion a;\n\n    strncpy(a.nombre, \"Montaña
+        Rusa\", 30);\n    a.tipo = 1;\n    a.duracion = 5;\n\n    return 0;\n}\n```\n\n---\n\n###
+        Declarar e inicializar con llaves\n```c\nint main() {\n    tAtraccion a =
+        { \"Torre de Caída\", 2, 3 };\n    return 0;\n}\n```\n\n---\n\n### Acceso
+        a campos\nPara acceder a un campo de una estructura se usa el operador punto
+        (`.`):\n\n```c\n#include <stdio.h>\n#include <string.h>\n\nint main() {\n
+        \   tAtraccion a = { \"Noria\", 3, 4 };\n\n    printf(\"Nombre: %s\\n\", a.nombre);\n
+        \   printf(\"Duración: %d minutos\\n\", a.duracion);\n\n    return 0;\n}\n```\n\n---\n\n###
+        Array de estructuras\nTambién puedes crear un array de `structs`:\n\n```c\n#include
+        <string.h>\n\nint main() {\n    tAtraccion parque[2];\n\n    strncpy(parque[0].nombre,
+        \"Noria\", 30);\n    parque[0].tipo = 3;\n    parque[0].duracion = 4;\n\n
+        \   strncpy(parque[1].nombre, \"Montaña Rusa\", 30);\n    parque[1].tipo =
+        1;\n    parque[1].duracion = 5;\n\n    return 0;\n}\n```\n\nPara acceder a
+        un campo de un elemento concreto:\n```c\nprintf(\"Nombre primera atracción:
+        %s\\n\", parque[0].nombre);\n```\n\n---\n\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n#include <string.h>\n\ntypedef struct {\n    char nombre[30];\n
+        \   int tipo;\n    int duracion;\n} tAtraccion;\n\nint main() {\n    tAtraccion
+        parque[2];\n\n    strncpy(parque[0].nombre, \"Noria\", 30);\n    parque[0].tipo
+        = 3;\n    parque[0].duracion = 4;\n\n    strncpy(parque[1].nombre, \"Montaña
+        Rusa\", 30);\n    parque[1].tipo = 1;\n    parque[1].duracion = 5;\n\n    for
+        (int i = 0; i < 2; i++) {\n        printf(\"Atracción: %s\\n\", parque[i].nombre);\n
+        \       printf(\"Tipo: %d\\n\", parque[i].tipo);\n        printf(\"Duración:
+        %d minutos\\n\\n\", parque[i].duracion);\n    }\n\n    return 0;\n}\n```\n\nEste
+        programa muestra cómo definir, inicializar y recorrer un array de estructuras
+        para representar varias atracciones.\n"
+      Pseudocode: "En pseudocódigo también puedes usar **registros (`record`)** para
+        agrupar datos de una entidad.  \nSon útiles para representar objetos del juego,
+        como atracciones de un parque.\n\n### ¿Qué es un `record`?\nUn `record` es
+        una estructura con diferentes campos:\n\n```pseudocode\ntype\n  tAtraccion
+        = record\n    nombre: string;\n    tipo: integer;\n    duracion: integer;\n
+        \ end record\nend type\n```\n\n---\n\n### Declarar y asignar valores\n```pseudocode\nalgorithm\n
+        \ var\n    a: tAtraccion;\n  end var\n\n  a.nombre := \"Montaña Rusa\";\n
+        \ a.tipo := 1;\n  a.duracion := 5;\nend algorithm\n```\n\n---\n\n### Acceso
+        a campos\nPara acceder a los campos se usa el punto (`.`):\n\n```pseudocode\nalgorithm\n
+        \ var\n    a: tAtraccion;\n  end var\n\n  a.nombre := \"Noria\";\n  a.tipo
+        := 3;\n  a.duracion := 4;\n\n  writeString(a.nombre);\n  writeInteger(a.duracion);\nend
+        algorithm\n```\n\n---\n\n### Array de registros\nTambién puedes crear arrays
+        de registros para almacenar varias atracciones:\n\n```pseudocode\nalgorithm\n
+        \ var\n    parque: vector[2] of tAtraccion;\n  end var\n\n  parque[1].nombre
+        := \"Noria\";\n  parque[1].tipo := 3;\n  parque[1].duracion := 4;\n\n  parque[2].nombre
+        := \"Torre de Caída\";\n  parque[2].tipo := 2;\n  parque[2].duracion := 3;\nend
+        algorithm\n```\n\nPara acceder a un campo de un elemento concreto:\n```pseudocode\nwriteString(parque[1].nombre);\nwriteInteger(parque[1].duracion);\n```\n\n---\n\n###
+        Ejemplo completo\n```pseudocode\ntype\n  tAtraccion = record\n    nombre:
+        string;\n    tipo: integer;\n    duracion: integer;\n  end record\nend type\n\nalgorithm
+        parqueDiversiones\n  var\n    parque: vector[2] of tAtraccion;\n    i: integer;\n
+        \ end var\n\n  parque[1].nombre := \"Noria\";\n  parque[1].tipo := 3;\n  parque[1].duracion
+        := 4;\n\n  parque[2].nombre := \"Montaña Rusa\";\n  parque[2].tipo := 1;\n
+        \ parque[2].duracion := 5;\n\n  for i = 1 to 2 do\n    writeString(\"Atracción:
+        \");\n    writeString(parque[i].nombre);\n    writeString(\", Tipo: \");\n
+        \   writeInteger(parque[i].tipo);\n    writeString(\", Duración: \");\n    writeInteger(parque[i].duracion);\n
+        \   writeString(\" minutos\");\n  end for\nend algorithm\n```\n\nEste algoritmo
+        muestra cómo definir, asignar y recorrer un array de registros que representan
+        varias atracciones del parque.\n"
+    questions:
+    - id: c-4-atraccion-inicializa-imprime
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 30.
+
+        Declara el tipo tAtraccion con los campos exactos:
+        - nombre: cadena de caracteres de tamaño MAX_NOMBRE
+        - alturaMinima: número decimal
+        - enMantenimiento: booleano
+
+        Dentro de main, declara la variable atraccion1 de tipo tAtraccion e inicializa:
+        - nombre = "Cometa"
+        - alturaMinima = 1.20
+        - enMantenimiento = false
+
+        Imprime dos líneas:
+        - "Nombre: x"
+        - "Altura mínima: x" (Con dos decimales)
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 30
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            float alturaMinima;
+            bool enMantenimiento;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            strncpy(atraccion1.nombre, "Cometa", MAX_NOMBRE);
+            atraccion1.alturaMinima = 1.20;
+            atraccion1.enMantenimiento = false;
+
+            printf("Nombre: %s\n", atraccion1.nombre);
+            printf("Altura mínima: %.2f\n", atraccion1.alturaMinima);
+            return 0;
+        }
+      hint: Usa strncpy para copiar al campo nombre y printf en líneas separadas.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-inicializa-imprime
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara el tipo tAtraccion con los campos exactos:
+        - nombre: texto
+        - alturaMinima: real
+        - enMantenimiento: booleano
+
+        En el bloque principal, declara la variable atraccion1 de tipo tAtraccion e inicializa:
+        - nombre := "Cometa"
+        - alturaMinima := 1.20
+        - enMantenimiento := false
+
+        Imprime dos líneas:
+        - "Nombre: x"
+        - "Altura mínima: x"
+      answer: |
+        type
+          tAtraccion = record
+            nombre: string;
+            alturaMinima: real;
+            enMantenimiento: boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+
+          atraccion1.nombre := "Cometa";
+          atraccion1.alturaMinima := 1.20;
+          atraccion1.enMantenimiento := false;
+
+          writeString("Nombre: ");
+          writeString(atraccion1.nombre);
+          writeString("Altura mínima: ");
+          writeReal(atraccion1.alturaMinima);
+        end algorithm
+      hint: Cada operación en su propia línea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-con-enum-imprime
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 25.
+
+        Declara un tipo enumerado tTipoAtraccion con los valores RUEDA, BARCA y SIMULADOR.
+
+        Declara el tipo tAtraccion con:
+        - nombre: cadena de caracteres de tamaño MAX_NOMBRE
+        - tipo: tTipoAtraccion
+
+        Dentro de main, declara la variable atraccion1 de tipo tAtraccion e inicializa:
+        - nombre = "Rueda Panorámica"
+        - tipo = RUEDA
+
+        Imprime una sola línea con el formato "Tipo: x" mostrando Rueda, Barca o Simulador en texto.
+
+        Debes mapear el enum a string utilizando if else if.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 25
+
+        typedef enum { RUEDA, BARCA, SIMULADOR } tTipoAtraccion;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tTipoAtraccion tipo;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            strncpy(atraccion1.nombre, "Rueda Panorámica", MAX_NOMBRE);
+            atraccion1.tipo = RUEDA;
+
+            if (atraccion1.tipo == RUEDA) {
+                printf("Tipo: Rueda\n");
+            } else if (atraccion1.tipo == BARCA) {
+                printf("Tipo: Barca\n");
+            } else {
+                printf("Tipo: Simulador\n");
+            }
+            return 0;
+        }
+      hint: Hay 3 posibles casos en los que deberás imprimir el mensaje usando if
+        else if.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-con-enum
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara el tipo enumerado tTipoAtraccion con los valores RUEDA, BARCA y SIMULADOR.
+        Declara el tipo tAtraccion con:
+        - nombre: texto
+        - tipo: tTipoAtraccion
+
+        En el bloque principal, declara la variable atraccion1 de tipo tAtraccion e inicializa:
+        - nombre := "Rueda Panorámica"
+        - tipo := RUEDA
+
+        Imprime dos líneas:
+        - "Nombre: x"
+        - "Tipo: x" (imprime el valor del enumerado tal cual)
+      answer: |
+        type
+          tTipoAtraccion = { RUEDA, BARCA, SIMULADOR }
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            tipo: tTipoAtraccion;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+
+          atraccion1.nombre := "Rueda Panorámica";
+          atraccion1.tipo := RUEDA;
+
+          writeString("Nombre: ");
+          writeString(atraccion1.nombre);
+          writeString("Tipo: ");
+          writeEnum(atraccion1.tipo);
+        end algorithm
+      hint: Usa writeEnum para mostrar el enumerado.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-horario-inicializa
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (30) y MAX_HORA (6).
+
+        Declara tHorario con:
+        - apertura: cadena de tamaño MAX_HORA
+        - cierre: cadena de tamaño MAX_HORA
+
+        Declara tAtraccion con:
+        - nombre: cadena de tamaño MAX_NOMBRE
+        - horario: tHorario
+
+        Dentro de main, declara atraccion1 e inicializa:
+        - nombre = "Dragón"
+        - horario - apertura = "10:00"
+        - horario - cierre = "19:30"
+
+        Imprime: "Cierra a: x"
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 30
+        #define MAX_HORA 6
+
+        typedef struct {
+            char apertura[MAX_HORA];
+            char cierre[MAX_HORA];
+        } tHorario;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tHorario horario;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            strncpy(atraccion1.nombre, "Dragón", MAX_NOMBRE);
+            strncpy(atraccion1.horario.apertura, "10:00", MAX_HORA);
+            strncpy(atraccion1.horario.cierre, "19:30", MAX_HORA);
+
+            printf("Cierra a: %s\n", atraccion1.horario.cierre);
+            return 0;
+        }
+      hint: Usa strncpy con el tamaño adecuado para cada campo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-horario-inicializa
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara tHorario con:
+        - apertura: texto
+        - cierre: texto
+
+        Declara tAtraccion con:
+        - nombre: texto
+        - horario: tHorario
+
+        En el bloque principal, declara atraccion1 e inicializa:
+        - nombre := "Dragón"
+        - horario - apertura := "10:00"
+        - horario - cierre := "19:30"
+
+        Imprime: "Cierra a: x"
+      answer: |
+        type
+          tHorario = record
+            apertura: string;
+            cierre: string;
+          end record
+
+          tAtraccion = record
+            nombre: string;
+            horario: tHorario;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+          end var
+
+          atraccion1.nombre := "Dragón";
+          atraccion1.horario.apertura := "10:00";
+          atraccion1.horario.cierre := "19:30";
+
+          writeString("Cierra a: ");
+          writeString(atraccion1.horario.cierre);
+        end algorithm
+      hint: Accede a campos anidados con punto.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-array-atracciones-suma-capacidad
+      language: C
+      week: 4
+      prompt: "Declara las constantes MAX_NOMBRE (20) y MAX_ATRACCIONES (2).\n\nDeclara
+        tAtraccion con:\n- nombre: cadena de tamaño MAX_NOMBRE\n- capacidadMaxima:
+        entero\n\nDentro de main, declara lista (array de tAtraccion con MAX_ATRACCIONES)
+        e inicializa:\n- lista 0 - nombre = \"Lanza\" y lista 0 - capacidadMaxima
+        = 12\n- lista 1 - nombre = \"Náutica\" y lista 1 - capacidadMaxima = 8\n\nDeclara
+        totalCapacidad (entero) y guarda la suma de ambas capacidades. \n\nImprime
+        \"Total: x\".\n"
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 20
+        #define MAX_ATRACCIONES 2
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            int capacidadMaxima;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion lista[MAX_ATRACCIONES];
+
+            strncpy(lista[0].nombre, "Lanza", MAX_NOMBRE);
+            lista[0].capacidadMaxima = 12;
+
+            strncpy(lista[1].nombre, "Náutica", MAX_NOMBRE);
+            lista[1].capacidadMaxima = 8;
+
+            int totalCapacidad = lista[0].capacidadMaxima + lista[1].capacidadMaxima;
+            printf("Total: %d\n", totalCapacidad);
+            return 0;
+        }
+      hint: Suma campos enteros y muestra el resultado.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-array-atracciones-suma-capacidad
+      language: Pseudocode
+      week: 4
+      prompt: "Declara la constante MAX_ATRACCIONES con valor 2.\n\nDeclara tAtraccion
+        con:\n- nombre: texto\n- capacidadMaxima: entero\n\nEn el bloque principal,
+        declara lista (vector[MAX_ATRACCIONES] de tAtraccion) e inicializa:\n- lista
+        0 - nombre = \"Lanza\" y lista 0 - capacidadMaxima = 12\n- lista 1 - nombre
+        = \"Náutica\"; lista 1 - capacidadMaxima = 8\n\nDeclara totalCapacidad (entero)
+        como la suma de ambas capacidades. \n\nImprime \"Total: x\".\n"
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 2;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            capacidadMaxima: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            lista: vector[MAX_ATRACCIONES] of tAtraccion;
+            totalCapacidad: integer;
+          end var
+
+          lista[1].nombre := "Lanza";
+          lista[1].capacidadMaxima := 12;
+          lista[2].nombre := "Náutica";
+          lista[2].capacidadMaxima := 8;
+
+          totalCapacidad := lista[1].capacidadMaxima + lista[2].capacidadMaxima;
+
+          writeString("Total: ");
+          writeInteger(totalCapacidad);
+        end algorithm
+      hint: Índices desde 1 en pseudocódigo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-precios-promedio
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (25) y NUM_PRECIOS (3).
+
+        Declara tPuestoComida con:
+        - nombre: cadena de tamaño MAX_NOMBRE
+        - precios: array de decimales de tamaño NUM_PRECIOS
+
+        Dentro de main, declara puesto1 e inicializa:
+        - nombre = "Taco Loco"
+        - precios = (3.5, 4.0, 2.5)
+
+        Calcula el promedio en la variable promedio (decimal) e imprime "Promedio: x" con un decimal.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 25
+        #define NUM_PRECIOS 3
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            float precios[NUM_PRECIOS];
+        } tPuestoComida;
+
+        int main() {
+            tPuestoComida puesto1;
+            strncpy(puesto1.nombre, "Taco Loco", MAX_NOMBRE);
+            puesto1.precios[0] = 3.5;
+            puesto1.precios[1] = 4.0;
+            puesto1.precios[2] = 2.5;
+
+            float promedio = (puesto1.precios[0] + puesto1.precios[1] + puesto1.precios[2]) / 3;
+            printf("Promedio: %.1f\n", promedio);
+            return 0;
+        }
+      hint: El promedio se calcula con la suma de todos los precios dividido entre
+        3. Utiliza paréntesis en la suma.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-precios-promedio
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante NUM_PRECIOS con valor 3.
+
+        Declara tPuestoComida con:
+        - nombre: texto
+        - precios: vector[NUM_PRECIOS] de reales
+
+        En el bloque principal, declara puesto1 e inicializa:
+        - nombre = "Taco Loco"
+        - precios = (3.5, 4.0, 2.5)
+
+        Calcula promedio (real) como la media de los tres precios e imprime "Promedio: x".
+      answer: |
+        const
+          NUM_PRECIOS: integer = 3;
+        end const
+
+        type
+          tPuestoComida = record
+            nombre: string;
+            precios: vector[NUM_PRECIOS] of real;
+          end record
+        end type
+
+        algorithm
+          var
+            puesto1: tPuestoComida;
+            promedio: real;
+          end var
+
+          puesto1.nombre := "Taco Loco";
+          puesto1.precios[1] := 3.5;
+          puesto1.precios[2] := 4.0;
+          puesto1.precios[3] := 2.5;
+
+          promedio := (puesto1.precios[1] + puesto1.precios[2] + puesto1.precios[3]) / 3;
+
+          writeString("Promedio: ");
+          writeReal(promedio);
+        end algorithm
+      hint: Una sentencia por línea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-ficha-booleano-ternario
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 30.
+
+        Declara tFichaSeguridad con:
+        - inspector: cadena de tamaño MAX_NOMBRE
+        - puntaje: decimal
+        - aprobada: booleano
+
+        Dentro de main, declara ficha1 e inicializa:
+        - inspector = "María"
+        - puntaje = 8.7
+        - aprobada = true
+
+        Imprime "Estado: Aprobada" si aprobada es true, o "Estado: Rechazada" si es false usando operador ternario.
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 30
+
+        typedef struct {
+            char inspector[MAX_NOMBRE];
+            float puntaje;
+            bool aprobada;
+        } tFichaSeguridad;
+
+        int main() {
+            tFichaSeguridad ficha1;
+            strncpy(ficha1.inspector, "María", MAX_NOMBRE);
+            ficha1.puntaje = 8.7;
+            ficha1.aprobada = true;
+
+            printf("Estado: %s\n", ficha1.aprobada ? "Aprobada" : "Rechazada");
+            return 0;
+        }
+      hint: Este ejercicio usa ternario.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-ficha-booleano
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara tFichaSeguridad con:
+        - inspector: texto
+        - puntaje: real
+        - aprobada: booleano
+
+        En el bloque principal, declara ficha1 e inicializa:
+        - inspector := "María"
+        - puntaje := 8.7
+        - aprobada := true
+
+        Imprime:
+        - "Inspector: x"
+        - "Aprobada: x" (true o false)
+      answer: |
+        type
+          tFichaSeguridad = record
+            inspector: string;
+            puntaje: real;
+            aprobada: boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            ficha1: tFichaSeguridad;
+          end var
+
+          ficha1.inspector := "María";
+          ficha1.puntaje := 8.7;
+          ficha1.aprobada := true;
+
+          writeString("Inspector: ");
+          writeString(ficha1.inspector);
+          writeString("Aprobada: ");
+          writeBoolean(ficha1.aprobada);
+        end algorithm
+      hint: No hay operador ternario en pseudocódigo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-mapa-ocupacion-contar
+      language: C
+      week: 4
+      prompt: "Declara las constantes MAX_NOMBRE (20), FILAS (2) y COLUMNAS (2).\n\nDeclara
+        tMapaZona con:\n- nombreZona: cadena de tamaño MAX_NOMBRE\n- ocupacion: matriz
+        booleana de tamaño FILAS x COLUMNAS\n\nEn main, declara mapa1 e inicializa:\n-
+        nombreZona = \"Zona A\"\n- ocupacion 0-0 = true\n- ocupacion 0-1 = false\n-
+        ocupacion 1-0 = true\n- ocupacion 1-1 = true\n\nDeclara ocupadas (entero),
+        inicializa en 0 y cuenta cuántas casillas true hay con if y sumas ++ (sin
+        bucles ni operador ternario). \n\nImprime \"Ocupadas: x\".\n"
+      answer: "#include <stdio.h>\n#include <stdbool.h>\n#include <string.h>\n\n#define
+        MAX_NOMBRE 20\n#define FILAS 2\n#define COLUMNAS 2\n\ntypedef struct {\n    char
+        nombreZona[MAX_NOMBRE];\n    bool ocupacion[FILAS][COLUMNAS];\n} tMapaZona;\n\nint
+        main() {\n    tMapaZona mapa1;\n    strncpy(mapa1.nombreZona, \"Zona A\",
+        MAX_NOMBRE);\n    mapa1.ocupacion[0][0] = true;\n    mapa1.ocupacion[0][1]
+        = false;\n    mapa1.ocupacion[1][0] = true;\n    mapa1.ocupacion[1][1] = true;\n\n
+        \   int ocupadas = 0;\n    if (mapa1.ocupacion[0][0]) { \n      ocupadas++;
+        \n    }\n    if (mapa1.ocupacion[0][1]) { \n      ocupadas++; \n    }\n    if
+        (mapa1.ocupacion[1][0]) { \n      ocupadas++; \n    }\n    if (mapa1.ocupacion[1][1])
+        { \n      ocupadas++; \n    }\n\n    printf(\"Ocupadas: %d\\n\", ocupadas);\n
+        \   return 0;\n}\n"
+      hint: Usa if y acumulación con ++; no uses operador ternario.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-mapa-ocupacion-contar
+      language: Pseudocode
+      week: 4
+      prompt: "Declara las constantes FILAS (2) y COLUMNAS (2).\n\nDeclara tMapaZona
+        con:\n- nombreZona: texto\n- ocupacion: matriz booleana FILAS x COLUMNAS\n\nEn
+        el bloque principal, declara mapa1 e inicializa:\n- nombreZona = \"Zona A\"\n-
+        ocupacion 0-0 = true\n- ocupacion 0-1 = false\n- ocupacion 1-0 = true\n- ocupacion
+        1-1 = true\n\nDeclara ocupadas (entero), inicializa en 0 y cuenta cuántas
+        casillas true hay con if (sin bucles). \n\nImprime \"Ocupadas: x\".\n"
+      answer: |
+        const
+          FILAS: integer = 2;
+          COLUMNAS: integer = 2;
+        end const
+
+        type
+          tMapaZona = record
+            nombreZona: string;
+            ocupacion: vector[FILAS][COLUMNAS] of boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            mapa1: tMapaZona;
+            ocupadas: integer;
+          end var
+
+          mapa1.nombreZona := "Zona A";
+          mapa1.ocupacion[1][1] := true;
+          mapa1.ocupacion[1][2] := false;
+          mapa1.ocupacion[2][1] := true;
+          mapa1.ocupacion[2][2] := true;
+
+          ocupadas := 0;
+          if mapa1.ocupacion[1][1] = true then
+            ocupadas := ocupadas + 1;
+          end if
+          if mapa1.ocupacion[1][2] = true then
+            ocupadas := ocupadas + 1;
+          end if
+          if mapa1.ocupacion[2][1] = true then
+            ocupadas := ocupadas + 1;
+          end if
+          if mapa1.ocupacion[2][2] = true then
+            ocupadas := ocupadas + 1;
+          end if
+
+          writeString("Ocupadas: ");
+          writeInteger(ocupadas);
+        end algorithm
+      hint: 'Forma correcta del if en pseudocódigo: if … then / end if.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-atraccion-dificultad-a-texto
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 20.
+
+        Declara tDificultad con valores BAJA, MEDIA y ALTA.
+
+        Declara tAtraccion con:
+        - nombre: cadena de tamaño MAX_NOMBRE
+        - dificultad: tDificultad
+
+        Dentro de main, declara atraccion1 e inicializa:
+        - nombre = "Vértigo"
+        - dificultad = ALTA
+
+        Declara tipoStr (cadena de tamaño 10) y copia "Baja", "Media" o "Alta" según la dificultad de la atracción usando if/else. Imprime "Dif: x".
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 20
+
+        typedef enum { BAJA, MEDIA, ALTA } tDificultad;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tDificultad dificultad;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atraccion1;
+            strncpy(atraccion1.nombre, "Vértigo", MAX_NOMBRE);
+            atraccion1.dificultad = ALTA;
+
+            char tipoStr[10];
+            if (atraccion1.dificultad == BAJA) {
+                strncpy(tipoStr, "Baja", 10);
+            } else if (atraccion1.dificultad == MEDIA) {
+                strncpy(tipoStr, "Media", 10);
+            } else {
+                strncpy(tipoStr, "Alta", 10);
+            }
+
+            printf("Dif: %s\n", tipoStr);
+            return 0;
+        }
+      hint: Usa if/else para seleccionar la cadena y strncpy para copiarla.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-atraccion-dificultad-texto
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara tDificultad con valores BAJA, MEDIA y ALTA.
+        Declara tAtraccion con:
+        - nombre: texto
+        - dificultad: tDificultad
+
+        En el bloque principal, declara atraccion1 e inicializa:
+        - nombre := "Vértigo"
+        - dificultad := ALTA
+
+        Declara tipoStr (texto) y asígnale:
+        - "Baja" si la dificultad es BAJA, "Media" si es MEDIA, o "Alta" si es ALTA.
+        Imprime "Dif: x".
+      answer: |
+        type
+          tDificultad = { BAJA, MEDIA, ALTA }
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            dificultad: tDificultad;
+          end record
+        end type
+
+        algorithm
+          var
+            atraccion1: tAtraccion;
+            tipoStr: string;
+          end var
+
+          atraccion1.nombre := "Vértigo";
+          atraccion1.dificultad := ALTA;
+
+          if atraccion1.dificultad = BAJA then
+            tipoStr := "Baja";
+          else
+            if atraccion1.dificultad = MEDIA then
+              tipoStr := "Media";
+            else
+                tipoStr := "Alta";
+            end if
+          end if
+
+          writeString("Dif: ");
+          writeString(tipoStr);
+        end algorithm
+      hint: Un if por caso también es válido en pseudocódigo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-precio-mayor
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (20) y NUM_PRECIOS (3).
+
+        Declara tPuestoComida con:
+        - nombre: cadena de tamaño MAX_NOMBRE
+        - precios: array de decimales de tamaño NUM_PRECIOS
+
+        En main, declara puesto1 e inicializa:
+        - nombre = "Papas Xpress"
+        - precios = (2.5, 3.0, 1.8)
+
+        Declara mayor (decimal) y calcula el mayor de los tres precios usando comparaciones e if (sin bucles ni operador ternario). Imprime "Mayor: x" con un decimal.
+      answer: "#include <stdio.h>\n#include <string.h>\n\n#define MAX_NOMBRE 20\n#define
+        NUM_PRECIOS 3\n\ntypedef struct {\n    char nombre[MAX_NOMBRE];\n    float
+        precios[NUM_PRECIOS];\n} tPuestoComida;\n\nint main() {\n    tPuestoComida
+        puesto1;\n    strncpy(puesto1.nombre, \"Papas Xpress\", MAX_NOMBRE);\n    puesto1.precios[0]
+        = 2.5;\n    puesto1.precios[1] = 3.0;\n    puesto1.precios[2] = 1.8;\n\n    float
+        mayor = puesto1.precios[0];\n    if (puesto1.precios[1] > mayor) { \n      mayor
+        = puesto1.precios[1]; \n    }\n    if (puesto1.precios[2] > mayor) { \n      mayor
+        = puesto1.precios[2]; \n    }\n\n    printf(\"Mayor: %.1f\\n\", mayor);\n
+        \   return 0;\n}\n"
+      hint: Actualiza mayor si encuentras un valor superior.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-precio-mayor
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante NUM_PRECIOS (3).
+
+        Declara tPuestoComida con:
+        - nombre: texto
+        - precios: vector[NUM_PRECIOS] de reales
+
+        En el bloque principal, declara puesto1 e inicializa:
+        - puesto1.nombre := "Papas Xpress"
+        - puesto1.precios[1] := 2.5
+        - puesto1.precios[2] := 3.0
+        - puesto1.precios[3] := 1.8
+
+        Declara mayor (real) y calcula el mayor de los tres precios con comparaciones (sin bucles). Imprime "Mayor: x".
+      answer: |
+        const
+          NUM_PRECIOS: integer = 3;
+        end const
+
+        type
+          tPuestoComida = record
+            nombre: string;
+            precios: vector[NUM_PRECIOS] of real;
+          end record
+        end type
+
+        algorithm
+          var
+            puesto1: tPuestoComida;
+            mayor: real;
+          end var
+
+          puesto1.nombre := "Papas Xpress";
+          puesto1.precios[1] := 2.5;
+          puesto1.precios[2] := 3.0;
+          puesto1.precios[3] := 1.8;
+
+          mayor := puesto1.precios[1];
+          if puesto1.precios[2] > mayor then
+            mayor := puesto1.precios[2];
+          end if
+          if puesto1.precios[3] > mayor then
+            mayor := puesto1.precios[3];
+          end if
+
+          writeString("Mayor: ");
+          writeReal(mayor);
+        end algorithm
+      hint: Una sentencia por línea; if con then / end if.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-cartelera-inicializa-imprime-primera
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_NOMBRE (20) y MAX_ATRACCIONES (2).
+
+        Declara tAtraccion con:
+        - nombre: cadena de tamaño MAX_NOMBRE
+        - duracionMinutos: entero
+
+        En main, declara cartelera (array de tAtraccion con MAX_ATRACCIONES) e inicializa:
+        - cartelera 0 - nombre = "Fantasmagoría" y cartelera 0 - duracionMinutos = 7
+        - cartelera 1 - nombre = "Aqua Rush" y cartelera 1 - duracionMinutos = 12
+
+        Imprime una línea con el formato: "Primera: x (y min)" mostrando el nombre y la duración de la primera atracción.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 20
+        #define MAX_ATRACCIONES 2
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            int duracionMinutos;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion cartelera[MAX_ATRACCIONES];
+
+            strncpy(cartelera[0].nombre, "Fantasmagoría", MAX_NOMBRE);
+            cartelera[0].duracionMinutos = 7;
+
+            strncpy(cartelera[1].nombre, "Aqua Rush", MAX_NOMBRE);
+            cartelera[1].duracionMinutos = 12;
+
+            printf("Primera: %s (%d min)\n", cartelera[0].nombre, cartelera[0].duracionMinutos);
+            return 0;
+        }
+      hint: Recuerda usar strncpy para los nombres.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-cartelera-inicializa-imprime-primera
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 2.
+
+        Declara tAtraccion con:
+        - nombre: texto
+        - duracionMinutos: entero
+
+        En el bloque principal, declara cartelera (vector de MAX_ATRACCIONES) e inicializa:
+        - cartelera 0 - nombre = "Fantasmagoría" y cartelera 0 - duracionMinutos = 7
+        - cartelera 1 - nombre = "Aqua Rush" y cartelera 1 - duracionMinutos = 12
+
+        Imprime una línea con el formato: "Primera: x (y min)" mostrando el nombre y duración de la primera atracción.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 2;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            duracionMinutos: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            cartelera: vector[MAX_ATRACCIONES] of tAtraccion;
+          end var
+
+          cartelera[1].nombre := "Fantasmagoría";
+          cartelera[1].duracionMinutos := 7;
+          cartelera[2].nombre := "Aqua Rush";
+          cartelera[2].duracionMinutos := 12;
+
+          writeString("Primera: ");
+          writeString(cartelera[1].nombre);
+          writeString(" (");
+          writeInteger(cartelera[1].duracionMinutos);
+          writeString(" min)");
+        end algorithm
+      hint: En pseudocódigo imprimimos por partes, cada llamada en su línea.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 3
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **estructuras (`struct`) más avanzadas
+        en C**, incluyendo:\n- **enumerados (`enum`)** para representar categorías
+        de atracciones,  \n- **arrays de estructuras** para almacenar varias entidades,
+        \ \n- **estructuras anidadas** (structs dentro de structs),  \n- y su uso
+        con **bucles** y **estructuras de control** (`if`, `while`, `for`, `switch`)
+        para realizar operaciones.\n\nEstos conceptos son esenciales para modelar
+        un parque de atracciones en un programa.\n\n---\n\n### Enumerados\nUn `enum`
+        define un conjunto de valores con nombres más claros que los números.  \nPor
+        ejemplo, los tipos de atracciones:\n\n```c\ntypedef enum {\n    MONTANA_RUSA,\n
+        \   CARRUSEL,\n    SIMULADOR\n} tTipoAtraccion;\n```\n\n---\n\n### Estructuras
+        básicas\nUn `struct` agrupa datos relacionados.  \nUna atracción puede tener
+        nombre, tipo y duración:\n\n```c\n#define MAX_NOMBRE 20\n\ntypedef struct
+        {\n    char nombre[MAX_NOMBRE];\n    tTipoAtraccion tipo;\n    int duracionMinutos;\n}
+        tAtraccion;\n```\n\n---\n\n### Arrays de estructuras\nPara manejar varias
+        atracciones a la vez, usamos un array:\n\n```c\n#define MAX_ATRACCIONES 3\n\nint
+        main() {\n    tAtraccion atracciones[MAX_ATRACCIONES];\n    return 0;\n}\n```\n\n---\n\n###
+        Estructuras anidadas\nUna estructura puede contener otra.  \nPor ejemplo,
+        cada atracción puede tener un horario con apertura y cierre:\n\n```c\n#define
+        MAX_HORA 6\n\ntypedef struct {\n    char apertura[MAX_HORA];\n    char cierre[MAX_HORA];\n}
+        tHorario;\n\ntypedef struct {\n    char nombre[MAX_NOMBRE];\n    tTipoAtraccion
+        tipo;\n    int duracionMinutos;\n    tHorario horario;\n} tAtraccion;\n```\n\n---\n\n###
+        Bucles con estructuras\nPodemos recorrer arrays de `structs` con `for` o `while`
+        para pedir datos y realizar cálculos:\n\n```c\nint main() {\n    tAtraccion
+        atracciones[MAX_ATRACCIONES];\n    int i, totalDuracion = 0;\n\n    for(i
+        = 0; i < MAX_ATRACCIONES; i++) {\n        printf(\"Duración (min): \");\n
+        \       scanf(\"%d\", &atracciones[i].duracionMinutos);\n        totalDuracion
+        += atracciones[i].duracionMinutos;\n    }\n\n    printf(\"Total: %d\\n\",
+        totalDuracion);\n    return 0;\n}\n```\n\n---\n\n### Condicionales y switch\nPodemos
+        tomar decisiones con `if` y `switch`.  \nEjemplo de menú con `do while`:\n\n```c\nint
+        main() {\n    int opcion;\n    do {\n        printf(\"Opción (1=MONTANA_RUSA,2=CARRUSEL,3=SIMULADOR,0=Salir):
+        \");\n        scanf(\"%d\", &opcion);\n\n        switch(opcion) {\n            case
+        1: printf(\"Montaña rusa\\n\"); break;\n            case 2: printf(\"Carrusel\\n\");
+        break;\n            case 3: printf(\"Simulador\\n\"); break;\n            case
+        0: printf(\"Saliendo...\\n\"); break;\n            default: printf(\"Inválida\\n\");\n
+        \       }\n    } while(opcion != 0);\n    return 0;\n}\n```\n\n---\n\n###
+        Comparación de cadenas\nPara comparar nombres de atracciones usamos `strcmp`:\n\n```c\nint
+        main() {\n    tAtraccion a1, a2;\n    printf(\"Nombre 1: \");\n    scanf(\"%s\",
+        a1.nombre);\n    printf(\"Nombre 2: \");\n    scanf(\"%s\", a2.nombre);\n\n
+        \   if(strcmp(a1.nombre, a2.nombre) == 0) {\n        printf(\"Iguales\\n\");\n
+        \   } else {\n        printf(\"Diferentes\\n\");\n    }\n    return 0;\n}\n```\n\n---\n\n###
+        Promedios y ternario\nSe puede calcular un promedio y decidir con `?:`:\n\n```c\nint
+        main() {\n    tAtraccion atracciones[MAX_ATRACCIONES];\n    int i, suma =
+        0;\n    float promedio;\n\n    for(i = 0; i < MAX_ATRACCIONES; i++) {\n        printf(\"Duración
+        (min): \");\n        scanf(\"%d\", &atracciones[i].duracionMinutos);\n        suma
+        += atracciones[i].duracionMinutos;\n    }\n\n    promedio = suma / (float)MAX_ATRACCIONES;\n
+        \   printf(\"Promedio: %.1f\\n\", promedio);\n    printf(\"%s\\n\", (promedio
+        >= 120.0) ? \"Larga\" : \"Corta\");\n\n    return 0;\n}\n```\n\n---\n\n###
+        Ejemplo completo\n```c\n#include <stdio.h>\n#include <string.h>\n#include
+        <stdbool.h>\n\n#define MAX_ATRACCIONES 3\n#define MAX_NOMBRE 20\n#define MAX_HORA
+        6\n\ntypedef enum {\n    MONTANA_RUSA,\n    CARRUSEL,\n    SIMULADOR\n} tTipoAtraccion;\n\ntypedef
+        struct {\n    char apertura[MAX_HORA];\n    char cierre[MAX_HORA];\n} tHorario;\n\ntypedef
+        struct {\n    char nombre[MAX_NOMBRE];\n    tTipoAtraccion tipo;\n    int
+        duracionMinutos;\n    bool enMantenimiento;\n    tHorario horario;\n} tAtraccion;\n\nint
+        main() {\n    tAtraccion atracciones[MAX_ATRACCIONES];\n    int i, totalDuracion
+        = 0, contador = 0;\n\n    for(i = 0; i < MAX_ATRACCIONES; i++) {\n        printf(\"Nombre:
+        \");\n        scanf(\"%s\", atracciones[i].nombre);\n        printf(\"Tipo
+        (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): \");\n        scanf(\"%u\", &atracciones[i].tipo);\n
+        \       printf(\"Duración (min): \");\n        scanf(\"%d\", &atracciones[i].duracionMinutos);\n
+        \       printf(\"¿En mantenimiento? (1 sí / 0 no): \");\n        int temp;
+        scanf(\"%d\", &temp);\n        atracciones[i].enMantenimiento = (temp != 0);\n
+        \       printf(\"Apertura: \");\n        scanf(\"%s\", atracciones[i].horario.apertura);\n
+        \       printf(\"Cierre: \");\n        scanf(\"%s\", atracciones[i].horario.cierre);\n\n
+        \       totalDuracion += atracciones[i].duracionMinutos;\n        if(atracciones[i].enMantenimiento)
+        contador++;\n    }\n\n    float promedio = totalDuracion / (float)MAX_ATRACCIONES;\n
+        \   printf(\"Duración total: %d\\n\", totalDuracion);\n    printf(\"Promedio:
+        %.1f\\n\", promedio);\n    printf(\"%s\\n\", (promedio >= 120.0) ? \"Larga\"
+        : \"Corta\");\n    printf(\"En mantenimiento: %d\\n\", contador);\n\n    for(i
+        = 0; i < MAX_ATRACCIONES; i++) {\n        switch(atracciones[i].tipo) {\n
+        \           case MONTANA_RUSA: printf(\"Montaña rusa\\n\"); break;\n            case
+        CARRUSEL:     printf(\"Carrusel\\n\");     break;\n            case SIMULADOR:
+        \   printf(\"Simulador\\n\");    break;\n        }\n    }\n\n    return 0;\n}\n```\n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **registros (`record`)
+        más avanzados en pseudocódigo**, incluyendo:\n- **enumerados** para tipos
+        de atracción,  \n- **arrays de registros** para manejar varias atracciones,
+        \ \n- **registros anidados**,  \n- y el uso de **bucles y estructuras de control**
+        (`for`, `while`, `switch`, `if`) para operaciones.\n\n---\n\n### Enumerados\n```pseudocode\ntype\n
+        \ tTipoAtraccion = { MONTANA_RUSA, CARRUSEL, SIMULADOR }\nend type\n```\n\n---\n\n###
+        Registros\n```pseudocode\ntype\n  tAtraccion = record\n    nombre: string;\n
+        \   tipo: tTipoAtraccion;\n    duracionMinutos: integer;\n  end record\nend
+        type\n```\n\n---\n\n### Registros anidados\n```pseudocode\ntype\n  tHorario
+        = record\n    apertura: string;\n    cierre: string;\n  end record\nend type\n\ntype\n
+        \ tAtraccion = record\n    nombre: string;\n    tipo: tTipoAtraccion;\n    duracionMinutos:
+        integer;\n    enMantenimiento: boolean;\n    horario: tHorario;\n  end record\nend
+        type\n```\n\n---\n\n### Arrays de registros\n```pseudocode\nconst\n  MAX_ATRACCIONES:
+        integer = 3;\nend const\n\nalgorithm\n  var\n    parque: vector[MAX_ATRACCIONES]
+        of tAtraccion;\n  end var\nend algorithm\n```\n\n---\n\n### Bucles y operaciones\n```pseudocode\nalgorithm\n
+        \ var\n    parque: vector[MAX_ATRACCIONES] of tAtraccion;\n    i, totalDuracion:
+        integer;\n  end var\n\n  totalDuracion := 0;\n  for i := 1 to MAX_ATRACCIONES
+        do\n    writeString(\"Duración (min): \");\n    parque[i].duracionMinutos
+        := readInteger();\n    totalDuracion := totalDuracion + parque[i].duracionMinutos;\n
+        \ end for\n\n  writeString(\"Total: \");\n  writeInteger(totalDuracion);\nend
+        algorithm\n```\n\n---\n\n### Condicionales y switch\n```pseudocode\nalgorithm\n
+        \ var\n    atraccion: tAtraccion;\n  end var\n\n  atraccion.tipo := MONTANA_RUSA;\n\n
+        \ switch atraccion.tipo\n    case MONTANA_RUSA then\n      writeString(\"Montaña
+        rusa\");\n    end case\n    case CARRUSEL then\n      writeString(\"Carrusel\");\n
+        \   end case\n    case SIMULADOR then\n      writeString(\"Simulador\");\n
+        \   end case\n  end switch\nend algorithm\n```\n\n---\n\n### Comparación de
+        cadenas\n```pseudocode\nalgorithm\n  var\n    a1, a2: tAtraccion;\n  end var\n\n
+        \ writeString(\"Nombre 1: \");\n  a1.nombre := readString();\n  writeString(\"Nombre
+        2: \");\n  a2.nombre := readString();\n\n  if a1.nombre = a2.nombre then\n
+        \   writeString(\"Iguales\");\n  else\n    writeString(\"Diferentes\");\n
+        \ end if\nend algorithm\n```\n\n---\n\n### Promedios\n```pseudocode\nalgorithm\n
+        \ var\n    parque: vector[MAX_ATRACCIONES] of tAtraccion;\n    i, suma: integer;\n
+        \   promedio: real;\n  end var\n\n  suma := 0;\n  for i := 1 to MAX_ATRACCIONES
+        do\n    writeString(\"Duración (min): \");\n    parque[i].duracionMinutos
+        := readInteger();\n    suma := suma + parque[i].duracionMinutos;\n  end for\n\n
+        \ promedio := suma / integerToReal(MAX_ATRACCIONES);\n  writeString(\"Promedio:
+        \");\n  writeReal(promedio);\nend algorithm\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\nconst\n
+        \ MAX_ATRACCIONES: integer = 3;\nend const\n\ntype\n  tTipoAtraccion = { MONTANA_RUSA,
+        CARRUSEL, SIMULADOR };\nend type\n\ntype\n  tHorario = record\n    apertura:
+        string;\n    cierre: string;\n  end record\nend type\n\ntype\n  tAtraccion
+        = record\n    nombre: string;\n    tipo: tTipoAtraccion;\n    duracionMinutos:
+        integer;\n    enMantenimiento: boolean;\n    horario: tHorario;\n  end record\nend
+        type\n\nalgorithm parqueDiversiones\n  var\n    parque: vector[MAX_ATRACCIONES]
+        of tAtraccion;\n    i, contador, suma: integer;\n    promedio: real;\n  end
+        var\n\n  suma := 0;\n  contador := 0;\n\n  for i := 1 to MAX_ATRACCIONES do\n
+        \   writeString(\"Nombre: \");\n    parque[i].nombre := readString();\n\n
+        \   writeString(\"Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): \");\n    parque[i].tipo
+        := readEnum();\n\n    writeString(\"Duración (min): \");\n    parque[i].duracionMinutos
+        := readInteger();\n    suma := suma + parque[i].duracionMinutos;\n\n    writeString(\"¿En
+        mantenimiento? (true/false): \");\n    parque[i].enMantenimiento := readBoolean();\n
+        \   if parque[i].enMantenimiento then\n      contador := contador + 1;\n    end
+        if\n\n    writeString(\"Apertura: \");\n    parque[i].horario.apertura :=
+        readString();\n    writeString(\"Cierre: \");\n    parque[i].horario.cierre
+        := readString();\n  end for\n\n  promedio := suma / integerToReal(MAX_ATRACCIONES);\n\n
+        \ writeString(\"Duración total: \");\n  writeInteger(suma);\n  writeString(\"Promedio:
+        \");\n  writeReal(promedio);\n  writeString(\"En mantenimiento: \");\n  writeInteger(contador);\n\n
+        \ for i := 1 to MAX_ATRACCIONES do\n    switch parque[i].tipo\n      case
+        MONTANA_RUSA then\n        writeString(\"Montaña rusa\");\n      end case\n
+        \     case CARRUSEL then\n        writeString(\"Carrusel\");\n      end case\n
+        \     case SIMULADOR then\n        writeString(\"Simulador\");\n      end
+        case\n    end switch\n  end for\nend algorithm\n```\n"
+    questions:
+    - id: c-4-l3-registro-basico-for
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 3 y MAX_NOMBRE con valor 20.
+
+        Crea un tipo enumerado llamado tTipoAtraccion con los valores MONTANA_RUSA, CARRUSEL y SIMULADOR.
+
+        Crea un tipo tAtraccion con los campos exactos:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+        - tipo: de tipo tTipoAtraccion.
+        - duracionMinutos: número entero.
+
+        Dentro de la función principal, declara un array llamado atracciones de tipo tAtraccion con MAX_ATRACCIONES elementos y una variable entera llamada i.
+
+        Recorre el array con un bucle for y, en cada iteración, pide al usuario:
+        - el nombre (muestra "Nombre: ") y guarda el texto en el campo de nombre de la atracción actual,
+        - el tipo (muestra "Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): ") y guarda el valor en el campo de tipo,
+        - la duración en minutos (muestra "Duración (min): ") y guarda el número en el campo correspondiente.
+
+        Al final, muestra por pantalla el nombre de la primera atracción en su propia línea.
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ATRACCIONES 3
+        #define MAX_NOMBRE 20
+
+        typedef enum {
+            MONTANA_RUSA,
+            CARRUSEL,
+            SIMULADOR
+        } tTipoAtraccion;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tTipoAtraccion tipo;
+            int duracionMinutos;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            int i;
+
+            for(i = 0; i < MAX_ATRACCIONES; i++) {
+                printf("Nombre: ");
+                scanf("%s", atracciones[i].nombre);
+                printf("Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): ");
+                scanf("%u", &atracciones[i].tipo);
+                printf("Duración (min): ");
+                scanf("%d", &atracciones[i].duracionMinutos);
+            }
+
+            printf("%s\n", atracciones[0].nombre);
+            return 0;
+        }
+      hint: 'Limita la lectura del nombre con %19s (si MAX_NOMBRE es 20).
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-registro-basico-for
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Tema Parque de Atracciones.
+
+        Declara la constante MAX_ATRACCIONES con valor 3.
+
+        Crea un tipo enumerado llamado tTipoAtraccion con los valores MONTANA_RUSA, CARRUSEL y SIMULADOR.
+
+        Crea un tipo tAtraccion con los campos exactos:
+        - nombre: texto.
+        - tipo: de tipo tTipoAtraccion.
+        - duracionMinutos: número entero.
+
+        En el bloque principal, declara un array llamado atracciones de tipo tAtraccion con MAX_ATRACCIONES elementos y una variable entera i.
+
+        Recorre el array con un bucle for (de 1 a MAX_ATRACCIONES) y, en cada iteración, pide al usuario:
+        - el nombre (muestra "Nombre: ") y guarda el texto en el campo de nombre de la atracción actual,
+        - el tipo (muestra "Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): "); lee un número auxiliar y asígnalo al campo de tipo mediante un switch,
+        - la duración en minutos (muestra "Duración (min): ") y guarda el número en el campo correspondiente.
+
+        Al final, muestra el nombre de la primera atracción en su propia línea.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 3;
+        end const
+
+        type
+          tTipoAtraccion = { MONTANA_RUSA, CARRUSEL, SIMULADOR };
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            tipo: tTipoAtraccion;
+            duracionMinutos: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+            auxTipo: integer;
+          end var
+
+          for i := 1 to MAX_ATRACCIONES do
+            writeString("Nombre: ");
+            atracciones[i].nombre := readString();
+
+            writeString("Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): ");
+            atracciones[i].tipo := readEnum();
+
+            writeString("Duración (min): ");
+            atracciones[i].duracionMinutos := readInteger();
+          end for
+
+          writeString(atracciones[1].nombre);
+        end algorithm
+      hint: 'En pseudocodigo contamos con la funcion readEnum();
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-suma-duraciones-while
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 3 y MAX_NOMBRE con valor 15.
+
+        Define el tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+        - duracionMinutos: número entero.
+
+        En la función principal, declara un array atracciones de tipo tAtraccion. Asigna manualmente las duraciones 10, 15 y 20 a sus tres elementos.
+        Declara una variable entera i y otra llamada totalDuracion inicializada a 0. Usando un bucle while, recorre el array y acumula en totalDuracion
+        la suma de las duraciones. Al terminar, imprime en una línea: "Total: x".
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ATRACCIONES 3
+        #define MAX_NOMBRE 15
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            int duracionMinutos;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            int i = 0;
+            int totalDuracion = 0;
+
+            atracciones[0].duracionMinutos = 10;
+            atracciones[1].duracionMinutos = 15;
+            atracciones[2].duracionMinutos = 20;
+
+            while(i < MAX_ATRACCIONES) {
+                totalDuracion += atracciones[i].duracionMinutos;
+                i++;
+            }
+
+            printf("Total: %d\n", totalDuracion);
+            return 0;
+        }
+      hint: 'Inicializa i en 0 antes del while.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-suma-duraciones-while
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 3.
+
+        Define el tipo tAtraccion con:
+        - nombre: texto.
+        - duracionMinutos: número entero.
+
+        En el bloque principal, declara un array atracciones de tipo tAtraccion. Asigna manualmente a sus tres elementos las duraciones 10, 15 y 20.
+        Declara una variable i e inicialízala a 1, y otra llamada totalDuracion con valor 0. Recorre el array con un bucle while sumando las duraciones
+        en totalDuracion. Al final, escribe "Total: " y en la línea siguiente el valor acumulado.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 3;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            duracionMinutos: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+            totalDuracion: integer;
+          end var
+
+          atracciones[1].duracionMinutos := 10;
+          atracciones[2].duracionMinutos := 15;
+          atracciones[3].duracionMinutos := 20;
+
+          i := 1;
+          totalDuracion := 0;
+          while i <= MAX_ATRACCIONES do
+            totalDuracion := totalDuracion + atracciones[i].duracionMinutos;
+            i := i + 1;
+          end while
+
+          writeString("Total: ");
+          writeInteger(totalDuracion);
+        end algorithm
+      hint: 'En pseudocódigo los índices de arrays empiezan en 1.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-menu-switch-do-while
+      language: C
+      week: 4
+      prompt: |
+        Declara un tipo enumerado tTipoAtraccion con los valores MONTANA_RUSA, CARRUSEL y SIMULADOR.
+
+        En la función principal, crea un menú dentro de un bucle do-while:
+        - Pide una opción entera mostrando "Opción (1=MONTANA_RUSA,2=CARRUSEL,3=SIMULADOR,0=Salir): ".
+        - Con un switch, muestra exactamente una de estas líneas según la opción:
+          "Montaña rusa", "Carrusel", "Simulador", "Saliendo..." o "Inválida".
+
+        El bucle termina cuando la opción sea 0.
+      answer: "#include <stdio.h>\n\ntypedef enum {\n    MONTANA_RUSA,\n    CARRUSEL,\n
+        \   SIMULADOR\n} tTipoAtraccion;\n\nint main() {\n    int opcion;\n    do
+        {\n        printf(\"Opción (1=MONTANA_RUSA,2=CARRUSEL,3=SIMULADOR,0=Salir):
+        \");\n        scanf(\"%d\", &opcion);\n\n        switch(opcion) {\n            case
+        1: \n              printf(\"Montaña rusa\\n\"); \n              break;\n            case
+        2: \n              printf(\"Carrusel\\n\"); \n              break;\n            case
+        3: \n              printf(\"Simulador\\n\"); \n              break;\n            case
+        0: \n              printf(\"Saliendo...\\n\"); \n              break;\n            default:
+        \n              printf(\"Inválida\\n\");\n        }\n    } while(opcion !=
+        0);\n    return 0;\n}\n"
+      hint: 'do-while ejecuta el cuerpo al menos una vez.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-menu-switch-do-while
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Crea un menú en un bucle do-while:
+        - Pide una opción entera mostrando "Opción (1=Montaña rusa,2=Carrusel,3=Simulador,0=Salir): ".
+        - Con un switch, muestra exactamente una de estas líneas:
+          "Montaña rusa", "Carrusel", "Simulador", "Saliendo..." o "Inválida".
+
+        El bucle termina cuando la opción sea 0.
+      answer: |
+        algorithm
+          var
+            opcion: integer;
+          end var
+
+          do
+            writeString("Opción (1=Montaña rusa,2=Carrusel,3=Simulador,0=Salir): ");
+            opcion := readInteger();
+
+            switch opcion
+              case 1 then
+                writeString("Montaña rusa");
+              end case
+              case 2 then
+                writeString("Carrusel");
+              end case
+              case 3 then
+                writeString("Simulador");
+              end case
+              case 0 then
+                writeString("Saliendo...");
+              end case
+              case default then
+                writeString("Inválida");
+              end case
+            end switch
+          while opcion <> 0;
+        end algorithm
+      hint: 'La condición del do-while va después del bloque.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-strcmp-dos-atracciones
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_NOMBRE con valor 25.
+
+        Define el tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+
+        En la función main, declara dos variables a1 y a2 de tipo tAtraccion. Pide al usuario dos nombres:
+        - muestra "Nombre 1: " y guarda el texto en el nombre de a1,
+        - muestra "Nombre 2: " y guarda el texto en el nombre de a2.
+
+        Compara ambos nombres y muestra "Iguales" si son exactamente iguales, o "Diferentes" en caso contrario.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_NOMBRE 25
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+        } tAtraccion;
+
+        int main() {
+            tAtraccion a1, a2;
+
+            printf("Nombre 1: ");
+            scanf("%s", a1.nombre);
+            printf("Nombre 2: ");
+            scanf("%s", a2.nombre);
+
+            if(strcmp(a1.nombre, a2.nombre) == 0) {
+                printf("Iguales\n");
+            } else {
+                printf("Diferentes\n");
+            }
+
+            return 0;
+        }
+      hint: 'strcmp devuelve 0 si las cadenas son iguales.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-compara-nombres-simple
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Define el tipo tAtraccion con:
+        - nombre: texto.
+
+        En el bloque principal, declara a1 y a2 de tipo tAtraccion. Pide al usuario dos nombres:
+        - muestra "Nombre 1: " y guarda el texto en el nombre de a1,
+        - muestra "Nombre 2: " y guarda el texto en el nombre de a2.
+
+        Si ambos nombres son iguales, muestra "Iguales"; en caso contrario, muestra "Diferentes".
+      answer: |
+        type
+          tAtraccion = record
+            nombre: string;
+          end record
+        end type
+
+        algorithm
+          var
+            a1: tAtraccion;
+            a2: tAtraccion;
+          end var
+
+          writeString("Nombre 1: ");
+          a1.nombre := readString();
+          writeString("Nombre 2: ");
+          a2.nombre := readString();
+
+          if a1.nombre = a2.nombre then
+            writeString("Iguales");
+          else
+            writeString("Diferentes");
+          end if
+        end algorithm
+      hint: 'La comparación de textos se realiza con = y <>.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-horarios-for
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 2, MAX_NOMBRE con valor 20 y MAX_HORA con valor 6.
+
+        Crea un tipo tHorario con:
+        - apertura: texto con tamaño máximo MAX_HORA.
+        - cierre: texto con tamaño máximo MAX_HORA.
+
+        Crea un tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+        - horario: de tipo tHorario.
+
+        En la función principal, declara un array atracciones de tipo tAtraccion y una variable entera i.
+        Recorre el array con un bucle for y para cada elemento pide al usuario:
+        - el nombre (muestra "Nombre: "),
+        - la hora de apertura (muestra "Apertura: "),
+        - la hora de cierre (muestra "Cierre: ").
+
+        Al finalizar, muestra en una línea la hora de cierre de la segunda atracción.
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ATRACCIONES 2
+        #define MAX_NOMBRE 20
+        #define MAX_HORA 6
+
+        typedef struct {
+            char apertura[MAX_HORA];
+            char cierre[MAX_HORA];
+        } tHorario;
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            tHorario horario;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            int i;
+            for(i = 0; i < MAX_ATRACCIONES; i++) {
+                printf("Nombre: ");
+                scanf("%s", atracciones[i].nombre);
+                printf("Apertura: ");
+                scanf("%s", atracciones[i].horario.apertura);
+                printf("Cierre: ");
+                scanf("%s", atracciones[i].horario.cierre);
+            }
+            printf("%s\n", atracciones[1].horario.cierre);
+            return 0;
+        }
+      hint: 'Respeta el orden del enunciado para declarar los datos
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-horarios-for
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 2.
+
+        Crea un tipo tHorario con:
+        - apertura: texto.
+        - cierre: texto.
+
+        Crea un tipo tAtraccion con:
+        - nombre: texto.
+        - horario: de tipo tHorario.
+
+        En el bloque principal, declara un array atracciones de tipo tAtraccion y una variable entera i.
+        Recorre el array con un bucle for (de 1 a MAX_ATRACCIONES) y para cada elemento pide al usuario:
+        - el nombre (muestra "Nombre: "),
+        - la hora de apertura (muestra "Apertura: "),
+        - la hora de cierre (muestra "Cierre: ").
+
+        Al finalizar, muestra en una línea la hora de cierre de la segunda atracción.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 2;
+        end const
+
+        type
+          tHorario = record
+            apertura: string;
+            cierre: string;
+          end record
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            horario: tHorario;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+          end var
+
+          for i := 1 to MAX_ATRACCIONES do
+            writeString("Nombre: ");
+            atracciones[i].nombre := readString();
+            writeString("Apertura: ");
+            atracciones[i].horario.apertura := readString();
+            writeString("Cierre: ");
+            atracciones[i].horario.cierre := readString();
+          end for
+
+          writeString(atracciones[2].horario.cierre);
+        end algorithm
+      hint: 'Un campo puede ser otro record anidado.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-contar-mantenimiento-for
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 4 y MAX_NOMBRE con valor 20.
+
+        Crea un tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+        - enMantenimiento: valor lógico.
+
+        En la función principal, declara un array atracciones de tipo tAtraccion, una variable entera i y otra entera contador inicializada a 0.
+        Recorre el array con un bucle for. Para cada posición, pide al usuario:
+        - el nombre (muestra "Nombre: ") y guárdalo en el campo de nombre,
+        - si está en mantenimiento (muestra "¿En mantenimiento? (1 sí / 0 no): "); lee un número y conviértelo a valor lógico para el campo enMantenimiento.
+
+        Luego, con otro bucle for, cuenta cuántas atracciones tienen enMantenimiento verdadero y muestra en una línea: "En mantenimiento: x".
+      answer: |
+        #include <stdio.h>
+        #include <stdbool.h>
+
+        #define MAX_ATRACCIONES 4
+        #define MAX_NOMBRE 20
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+            bool enMantenimiento;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            int i, contador = 0;
+            int temp;
+
+            for(i = 0; i < MAX_ATRACCIONES; i++) {
+                printf("Nombre: ");
+                scanf("%s", atracciones[i].nombre);
+                printf("¿En mantenimiento? (1 sí / 0 no): ");
+                scanf("%d", &temp);
+                atracciones[i].enMantenimiento = (temp != 0);
+            }
+
+            for(i = 0; i < MAX_ATRACCIONES; i++) {
+                if(atracciones[i].enMantenimiento) {
+                    contador++;
+                }
+            }
+
+            printf("En mantenimiento: %d\n", contador);
+            return 0;
+        }
+      hint: 'Lee 0/1 y asigna al bool con una comparación.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-contar-mantenimiento-for
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 4.
+
+        Crea un tipo tAtraccion con:
+        - nombre: texto.
+        - enMantenimiento: valor booleano.
+
+        En el bloque principal, declara un array atracciones de tipo tAtraccion, una variable entera i, una entera contador (inicial 0) y una booleana temp.
+        Recorre el array con un bucle for y, para cada posición, pide:
+        - el nombre (muestra "Nombre: ") y guárdalo en el campo de nombre,
+        - si está en mantenimiento (muestra "¿En mantenimiento? (true/false): "); lee el valor en temp y asígnalo al campo enMantenimiento.
+
+        Después, con otro for, cuenta cuántas atracciones tienen enMantenimiento verdadero y escribe:
+        "En mantenimiento: " y, en la línea siguiente, el número contado.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 4;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+            enMantenimiento: boolean;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+            contador: integer;
+            temp: boolean;
+          end var
+
+          for i := 1 to MAX_ATRACCIONES do
+            writeString("Nombre: ");
+            atracciones[i].nombre := readString();
+            writeString("¿En mantenimiento? (true/false): ");
+            atracciones[i].enMantenimiento := readBoolean();
+          end for
+
+          contador := 0;
+          for i := 1 to MAX_ATRACCIONES do
+            if atracciones[i].enMantenimiento then
+              contador := contador + 1;
+            end if
+          end for
+
+          writeString("En mantenimiento: ");
+          writeInteger(contador);
+        end algorithm
+      hint: 'Una sentencia por línea en pseudocódigo.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-switch-por-tipo
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 3 y MAX_NOMBRE con valor 18.
+
+        Declara el tipo enumerado tTipoAtraccion con MONTANA_RUSA, CARRUSEL y SIMULADOR.
+        Declara el tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+        - tipo: de tipo tTipoAtraccion.
+
+        En la función principal, lee los datos de tres atracciones usando un bucle for (nombre y tipo numérico 0..2).
+        Después recorre el array con un bucle for y, para cada atracción, muestra exactamente una línea con el texto del tipo:
+        "Montaña rusa", "Carrusel" o "Simulador". Usa un switch para decidir el texto.
+      answer: "#include <stdio.h>\n\n#define MAX_ATRACCIONES 3\n#define MAX_NOMBRE
+        18\n\ntypedef enum {\n    MONTANA_RUSA,\n    CARRUSEL,\n    SIMULADOR\n} tTipoAtraccion;\n\ntypedef
+        struct {\n    char nombre[MAX_NOMBRE];\n    tTipoAtraccion tipo;\n} tAtraccion;\n\nint
+        main() {\n    tAtraccion atracciones[MAX_ATRACCIONES];\n    int i;\n\n    for(i
+        = 0; i < MAX_ATRACCIONES; i++) {\n        printf(\"Nombre: \");\n        scanf(\"%s\",
+        atracciones[i].nombre);\n        printf(\"Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR):
+        \");\n        scanf(\"%u\", &atracciones[i].tipo;\n        \n    }\n\n    for(i
+        = 0; i < MAX_ATRACCIONES; i++) {\n        switch(atracciones[i].tipo) {\n
+        \           case MONTANA_RUSA: \n                printf(\"Montaña rusa\\n\");
+        \n                break;\n            case CARRUSEL:     \n                printf(\"Carrusel\\n\");
+        \    \n                break;\n            case SIMULADOR:    \n                printf(\"Simulador\\n\");
+        \   \n                break;\n            default:           \n                printf(\"Desconocido\\n\");\n
+        \       }\n    }\n    return 0;\n}\n"
+      hint: 'Un switch por cada elemento del array.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-switch-por-tipo
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 3.
+
+        Declara el tipo enumerado tTipoAtraccion con MONTANA_RUSA, CARRUSEL y SIMULADOR.
+        Declara el tipo tAtraccion con:
+        - nombre: texto.
+        - tipo: de tipo tTipoAtraccion.
+
+        En el bloque principal, pide al usuario los datos de tres atracciones con un bucle (nombre y un número 0..2 para el tipo; usa un switch para asignarlo).
+        Recorre el array con un bucle for y, para cada atracción, muestra exactamente una línea con el texto del tipo:
+        "Montaña rusa", "Carrusel" o "Simulador".
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 3;
+        end const
+
+        type
+          tTipoAtraccion = { MONTANA_RUSA, CARRUSEL, SIMULADOR };
+        end type
+
+        type
+          tAtraccion = record
+            nombre: string;
+            tipo: tTipoAtraccion;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+          end var
+
+          for i := 1 to MAX_ATRACCIONES do
+            writeString("Nombre: ");
+            atracciones[i].nombre := readString();
+            writeString("Tipo (0=MONTANA_RUSA,1=CARRUSEL,2=SIMULADOR): ");
+            atracciones[i].tipo := readEnum();
+          end for
+
+          for i := 1 to MAX_ATRACCIONES do
+            switch atracciones[i].tipo
+              case MONTANA_RUSA then
+                writeString("Montaña rusa");
+              end case
+              case CARRUSEL then
+                writeString("Carrusel");
+              end case
+              case SIMULADOR then
+                writeString("Simulador");
+              end case
+              case default then
+                writeString("Desconocido");
+              end case
+            end switch
+          end for
+        end algorithm
+      hint: 'Mantén una sola salida por línea.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-entrada-hasta-fin-strcmp
+      language: C
+      week: 4
+      prompt: |
+        Declara las constantes MAX_ATRACCIONES con valor 4 y MAX_NOMBRE con valor 20.
+
+        Define el tipo tAtraccion con:
+        - nombre: texto con tamaño máximo MAX_NOMBRE.
+
+        En la función principal, declara un array atracciones de tipo tAtraccion, un búfer temporal llamado tempNombre (texto de tamaño MAX_NOMBRE) y una variable entera i inicializada a 0.
+
+        Usa un bucle while y repite mientras haya espacio disponible ( i menor que MAX_ATRACCIONES):
+        - pide un nombre mostrando "Nombre (FIN para terminar): " y guárdalo en el búfer temporal,
+        - si el usuario escribe la palabra FIN, detén la repetición (Usando break para detener el bucle),
+        - en caso contrario (No uses else), copia el contenido del búfer temporal al campo de nombre del siguiente elemento y avanza al siguiente índice.
+
+        Al terminar, muestra en una línea "Guardados: x" con la cantidad de elementos almacenados.
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_ATRACCIONES 4
+        #define MAX_NOMBRE 20
+
+        typedef struct {
+            char nombre[MAX_NOMBRE];
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            char tempNombre[MAX_NOMBRE];
+            int i = 0;
+
+            while(i < MAX_ATRACCIONES) {
+                printf("Nombre (FIN para terminar): ");
+                scanf("%s", tempNombre);
+                if(strcmp(tempNombre, "FIN") == 0) {
+                    break;
+                }
+                strncpy(atracciones[i].nombre, tempNombre, MAX_NOMBRE);
+                i++;
+            }
+
+            printf("Guardados: %d\n", i);
+            return 0;
+        }
+      hint: 'Usa strcmp para comparar con "FIN" y strncpy para copiar.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-entrada-hasta-vacio
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 4.
+
+        Define el tipo tAtraccion con:
+        - nombre: texto.
+
+        En el bloque principal, declara un array atracciones de tipo tAtraccion, una variable de texto tempNombre y una entera i inicializada a 1.
+
+        Mientras no se supere el límite y el usuario no escriba "FIN":
+        - pide un nombre mostrando "Nombre (FIN para terminar): " y guárdalo en tempNombre,
+        - si no es "FIN", guarda el texto en el nombre del siguiente elemento del array y avanza al siguiente índice.
+
+        Al terminar, muestra "Guardados: " y, en la línea siguiente, la cantidad de elementos realmente guardados.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 4;
+        end const
+
+        type
+          tAtraccion = record
+            nombre: string;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            tempNombre: string;
+            i: integer;
+          end var
+
+          i := 1;
+          tempNombre := "";
+          while (i <= MAX_ATRACCIONES and tempNombre <> "FIN") do
+            writeString("Nombre (FIN para terminar): ");
+            tempNombre := readString();
+            if tempNombre <> "FIN" then
+              atracciones[i].nombre := tempNombre;
+              i := i + 1;
+            end if
+          end while
+
+          writeString("Guardados: ");
+          writeInteger(i - 1);
+        end algorithm
+      hint: 'Controla fin por palabra y por límite.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-4-l3-promedio-y-ternario
+      language: C
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 3.
+
+        Define el tipo tAtraccion con:
+        - duracionMinutos: número entero.
+
+        En la función principal, declara un array atracciones de tipo tAtraccion, una variable entera i , otra llamada suma con valor inicial 0 y un float promedio.
+        Con un bucle for, pide al usuario tres duraciones mostrando "Duración (min): " y guarda cada valor en el campo de duración del elemento actual, acumulándolo en suma.
+
+        Calcula el promedio como un número decimal dividiendo la suma entre 3 (Castea a float) y muestra:
+        - en una línea: "Promedio: x.x" (con un decimal),
+        - en la siguiente línea, usa un operador ternario para imprimir "Larga" si el promedio es mayor o igual que 120, o "Corta" en caso contrario.
+      answer: |
+        #include <stdio.h>
+
+        #define MAX_ATRACCIONES 3
+
+        typedef struct {
+            int duracionMinutos;
+        } tAtraccion;
+
+        int main() {
+            tAtraccion atracciones[MAX_ATRACCIONES];
+            int i;
+            suma = 0;
+            float promedio;
+
+            for(i = 0; i < MAX_ATRACCIONES; i++) {
+                printf("Duración (min): ");
+                scanf("%d", &atracciones[i].duracionMinutos);
+                suma += atracciones[i].duracionMinutos;
+            }
+
+            promedio = suma / (float)3;
+            printf("Promedio: %.1f\n", promedio);
+            printf("%s\n", (promedio >= 120.0) ? "Larga" : "Corta");
+            return 0;
+        }
+      hint: 'Recuerda castear a (float) el numero 3 en la division
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-4-l3-promedio-simple
+      language: Pseudocode
+      week: 4
+      prompt: |
+        Declara la constante MAX_ATRACCIONES con valor 3.
+
+        Define el tipo tAtraccion con:
+        - duracionMinutos: número entero.
+
+        En el bloque principal, declara un array atracciones de tipo tAtraccion, una variable entera i, otra entera suma y otra real promedio.
+        Con un bucle for, pide al usuario tres duraciones mostrando "Duración (min): " y guarda cada valor en el campo de duración del elemento actual, acumulándolo en suma.
+
+        Calcula el promedio como número real dividiendo suma entre 3 (Casteando a real) y muestra:
+        - en una línea: "Promedio: "
+        - en la línea siguiente, el valor del promedio.
+      answer: |
+        const
+          MAX_ATRACCIONES: integer = 3;
+        end const
+
+        type
+          tAtraccion = record
+            duracionMinutos: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            atracciones: vector[MAX_ATRACCIONES] of tAtraccion;
+            i: integer;
+            suma: integer;
+            promedio: real;
+          end var
+
+          suma := 0;
+          for i := 1 to MAX_ATRACCIONES do
+            writeString("Duración (min): ");
+            atracciones[i].duracionMinutos := readInteger();
+            suma := suma + atracciones[i].duracionMinutos;
+          end for
+
+          promedio := suma / integerToReal(3);
+          writeString("Promedio: ");
+          writeReal(promedio);
+        end algorithm
+      hint: 'Una sentencia por línea; no hay operador ternario en pseudocódigo.
+
+        '
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+- number: 5
+  explanation: 'Explicacion semana 5
+
+    '
+  levels:
+  - number: 1
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **funciones** en C.  \nLas funciones
+        permiten dividir un programa en partes más pequeñas y reutilizables.  \nEn
+        videojuegos, por ejemplo, puedes tener una función que calcule la vida restante
+        de un personaje o la puntuación obtenida tras derrotar a un enemigo.\n\n###
+        ¿Qué es una función?\nUna **función** es un bloque de código independiente
+        que:\n- Tiene un **nombre** que la identifica.\n- Puede recibir **parámetros
+        de entrada** (valores con los que trabaja).  \n  ⚠️ Los parámetros de entrada
+        son **solo de lectura**: la función puede usarlos internamente, pero no modifica
+        la variable original del programa que la llamó.\n- Devuelve un **valor de
+        salida** (resultado).\n- Puede llamarse tantas veces como quieras.\n\n---\n\n###
+        Prototipos de funciones (encabezados)\nAntes de `main`, se declaran los **prototipos**.
+        \ \nUn prototipo indica el nombre, parámetros y tipo de retorno, pero no contiene
+        el cuerpo.\n\n```c\nint calcularPuntos(int enemigos, int bonus);\nint factorial(int
+        number);\n```\n\n---\n\n### Sintaxis general de una función\n```c\ntipo nombreFuncion(tipo
+        param1, tipo param2, ...) {\n    // instrucciones\n    return valor;\n}\n```\n\n*El
+        `return` devuelve el resultado al punto del programa donde se llamó a la función.*\n\n---\n\n###
+        Ejemplo completo\n```c\n#include <stdio.h>\n\n// Prototipos\nint calcularPuntos(int
+        enemigos, int bonus);\nint factorial(int number);\n\n// main primero\nint
+        main() {\n    int puntos, combinaciones;\n\n    // Uso de función para puntos\n
+        \   puntos = calcularPuntos(5, 20);\n    printf(\"Puntos obtenidos: %d\\n\",
+        puntos);\n\n    // Uso de función factorial para combinaciones de ítems\n
+        \   int totalItems = 6;\n    int itemsElegidos = 2;\n    combinaciones = factorial(totalItems)
+        / \n                    (factorial(itemsElegidos) * factorial(totalItems -
+        itemsElegidos));\n\n    printf(\"Posibles combinaciones: %d\\n\", combinaciones);\n\n
+        \   return 0;\n}\n\n// Implementaciones al final\nint calcularPuntos(int enemigos,
+        int bonus) {\n    int total = enemigos * 10 + bonus;\n    return total;\n}\n\nint
+        factorial(int number) {\n    int fact = 1;\n    int i = 1;\n    while (i <=
+        number) {\n        fact = fact * i;\n        i = i + 1;\n    }\n    return
+        fact;\n}\n```\n\nEste programa sigue la estructura usada en la universidad:
+        \ \nprimero los **prototipos**, luego el `main`, y finalmente las **implementaciones**.
+        \ \n\n**Qué hace el programa:**  \n- Calcula la **puntuación** del jugador
+        con la función `calcularPuntos`, multiplicando enemigos derrotados por 10
+        y sumando un bonus.  \n- Calcula las **combinaciones posibles de ítems** en
+        un inventario usando la función `factorial`.  \n- Muestra por pantalla tanto
+        los puntos obtenidos como el número de combinaciones.  \n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **funciones** en pseudocódigo.
+        \ \nLas funciones permiten dividir un algoritmo en partes más pequeñas y reutilizables.
+        \ \nEn videojuegos, puedes usarlas para calcular la vida restante de un personaje
+        o la puntuación obtenida tras derrotar a enemigos.\n\n### ¿Qué es una función?\nUna
+        **función**:\n- Tiene un **nombre** que la identifica.\n- Puede recibir **parámetros
+        de entrada**.  \n  ⚠️ Los parámetros de entrada son **solo de lectura**: el
+        algoritmo puede usarlos internamente, pero no cambia el valor de la variable
+        que se pasó desde fuera.\n- Devuelve un **valor** como resultado.\n- Puede
+        llamarse tantas veces como quieras.\n\n---\n\n### Prototipos de funciones\nEn
+        pseudocódigo no existen prototipos reales, pero podemos simularlos indicando
+        solo la firma.  \nEsto ayuda a organizar el código cuando usamos varias funciones.\n\n```pseudocode\nfunction
+        calcularPuntos(enemigos: integer, bonus: integer): integer end function\nfunction
+        factorial(number: integer): integer end function\n```\n\n---\n\n### Sintaxis
+        general de una función\n```pseudocode\nfunction nombreFuncion(param1: tipo,
+        param2: tipo): tipo\n  ...\n  return valor\nend function\n```\n\n---\n\n###
+        Ejemplo completo\n```pseudocode\n{ Implementaciones }\nfunction calcularPuntos(enemigos:
+        integer, bonus: integer): integer\n  var\n    total: integer;\n  end var\n
+        \ total := enemigos * 10 + bonus;\n  return total;\nend function\n\nfunction
+        factorial(number: integer): integer\n  var\n    fact: integer;\n    i: integer;\n
+        \ end var\n  fact := 1;\n  i := 1;\n  while i <= number do\n    fact := fact
+        * i;\n    i := i + 1;\n  end while\n  return fact;\nend function\n\nalgorithm
+        funcionesVideojuego\n  var\n    puntos: integer;\n    combinaciones: integer;\n
+        \   totalItems: integer;\n    itemsElegidos: integer;\n  end var\n\n  puntos
+        := calcularPuntos(5, 20);\n  writeString(\"Puntos obtenidos: \");\n  writeInteger(puntos);\n\n
+        \ totalItems := 6;\n  itemsElegidos := 2;\n  combinaciones := factorial(totalItems)
+        div \n                   (factorial(itemsElegidos) * factorial(totalItems
+        - itemsElegidos));\n\n  writeString(\"Posibles combinaciones: \");\n  writeInteger(combinaciones);\nend
+        algorithm\n```\n\n**Qué hace el programa:**  \n- Usa `calcularPuntos` para
+        obtener la **puntuación** del jugador (enemigos derrotados × 10 + bonus).
+        \ \n- Usa `factorial` para calcular las **combinaciones posibles de ítems**
+        en el inventario.  \n- Finalmente escribe en pantalla tanto los puntos obtenidos
+        como el número de combinaciones.  \n"
+    questions:
+    - id: c-5-l1-prototipo-xp
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo de una función llamada addXP que reciba dos enteros xp1 y xp2
+        y devuelva un entero con la experiencia total del jugador.
+        No implementes la función, solo el prototipo.
+      answer: 'int addXP(int xp1, int xp2);
+
+        '
+      hint: Un prototipo siempre incluye tipo de retorno, nombre, parámetros y termina
+        con ;
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-prototipo-xp
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe únicamente el encabezado de una función llamada addXP que reciba dos enteros xp1 y xp2
+        y devuelva un entero con la experiencia total.
+      answer: |
+        function addXP(xp1: integer, xp2: integer): integer
+        end function
+      hint: En pseudocódigo se escribe function ... end function.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-prototipo-bonus
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo de una función llamada applyBonus que reciba un número decimal base
+        y devuelva un número decimal aumentado en 10%.
+        No implementes la función, solo el prototipo.
+      answer: 'float applyBonus(float base);
+
+        '
+      hint: Usa float como tipo de retorno y de parámetro.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-prototipo-bonus
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe solo el encabezado de una función llamada applyBonus que reciba un real base
+        y devuelva un real aumentado en 10%.
+      answer: |
+        function applyBonus(base: real): real
+        end function
+      hint: Aquí solo se pide encabezado, no implementación.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-prototipo-enum-level
+      language: C
+      week: 5
+      prompt: |
+        Declara un tipo enumerado tLevel con los valores NOVATO, GUERRERO y MAESTRO.
+        Luego declara el prototipo de una función llamada levelToValue que reciba un tLevel
+        y devuelva un entero con el valor del nivel (ejemplo: NOVATO=1, GUERRERO=2, MAESTRO=3).
+      answer: |
+        typedef enum { NOVATO, GUERRERO, MAESTRO } tLevel;
+        int levelToValue(tLevel l);
+      hint: Aquí devolvemos un entero en lugar de un string.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-prototipo-enum-level
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo enumerado tLevel con los valores NOVATO, GUERRERO y MAESTRO.
+        Luego escribe solo el encabezado de una función llamada levelToValue que reciba un tLevel
+        y devuelva un entero con el valor del nivel (ejemplo: NOVATO=1, GUERRERO=2, MAESTRO=3).
+      answer: |
+        type
+          tLevel = { NOVATO, GUERRERO, MAESTRO }
+        end type
+
+        function levelToValue(l: tLevel): integer
+        end function
+      hint: El tipo enumerado se define antes de usarlo en la función.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-prototipo-struct-item
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_ITEM = 15.
+        Declara una estructura tItem con los campos:
+        - nombre: array de chars
+        - valor: entero
+        Declara además el prototipo de una función getValor que reciba un tItem
+        y devuelva un entero con su valor.
+      answer: |
+        #define MAX_ITEM 15
+
+        typedef struct {
+            char nombre[MAX_ITEM];
+            int valor;
+        } tItem;
+
+        int getValor(tItem i);
+      hint: Los textos se representan con arrays de char.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-prototipo-struct-item
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo tItem con los campos:
+        - nombre: string
+        - valor: integer
+        Luego escribe el encabezado de una función llamada getValor que reciba un tItem
+        y devuelva un entero con su valor.
+      answer: |
+        type
+          tItem = record
+            nombre: string;
+            valor: integer;
+          end record
+        end type
+
+        function getValor(i: tItem): integer
+        end function
+      hint: El encabezado solo indica parámetros y tipo de retorno.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-main-powerup
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo de una función llamada calcPowerUp que reciba un entero base
+        y devuelva un entero con el doble de poder.
+        En main declara base=40, llama a calcPowerUp y guarda el resultado en power.
+        No implementes la función, solo el prototipo y la llamada.
+      answer: |
+        #include <stdio.h>
+
+        int calcPowerUp(int base);
+
+        int main() {
+            int base = 40;
+            int power = calcPowerUp(base);
+            return 0;
+        }
+      hint: Solo se pide prototipo y llamada, no la implementación.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-main-powerup
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe el encabezado de una función llamada calcPowerUp que reciba un entero base
+        y devuelva un entero con el doble de poder.
+        En el bloque principal declara base=40, llama a calcPowerUp y guarda el resultado en power.
+        No implementes la función.
+      answer: |
+        function calcPowerUp(base: integer): integer
+        end function
+
+        algorithm
+          var
+            base: integer;
+            power: integer;
+          end var
+
+          base := 40;
+          power := calcPowerUp(base);
+        end algorithm
+      hint: Aquí solo se pide encabezado y llamada, no implementación.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-funcion-critical
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo de una función llamada criticalHit que reciba un número decimal dmg
+        y devuelva un número decimal.
+        Implementa la función devolviendo dmg * 1.5 (aumenta el daño en 50%).
+      answer: |
+        float criticalHit(float dmg);
+
+        float criticalHit(float dmg) {
+            return dmg * 1.5;
+        }
+      hint: Incluye prototipo antes de la implementación.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-funcion-critical
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe el encabezado de una función llamada criticalHit que reciba un real dmg
+        y devuelva un real.
+        Implementa la función devolviendo dmg * 1.5.
+      answer: |
+        function criticalHit(dmg: real): real
+          return dmg * 1.5;
+        end function
+      hint: Aquí sí se incluye return dentro de la función.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-funcion-checkmana
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tMage con el campo mana (entero).
+        Declara el prototipo de una función hasMana que reciba un tMage
+        y devuelva un entero (1 si mana > 0, 0 si no).
+        En main declara un mago con mana=20 usando {}, llama a hasMana y guarda el resultado en estado.
+        Implementa la función.
+      answer: |
+        #include <stdio.h>
+
+        typedef struct {
+            int mana;
+        } tMage;
+
+        int hasMana(tMage m);
+
+        int main() {
+            tMage mago = {20};
+            int estado = hasMana(mago);
+            return 0;
+        }
+
+        int hasMana(tMage m) {
+            if(m.mana > 0) return 1;
+            else return 0;
+        }
+      hint: Devuelve 1 si tiene maná, 0 si no.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-funcion-checkmana
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo tMage con el campo mana (entero).
+        Escribe el encabezado de una función hasMana que reciba un tMage
+        y devuelva un entero (1 si mana > 0, 0 si no).
+        En el bloque principal declara un mago con mana=20, llama a hasMana y guarda el resultado en estado.
+        Implementa la función devolviendo 1 o 0 según corresponda.
+      answer: |
+        type
+          tMage = record
+            mana: integer;
+          end record
+        end type
+
+        function hasMana(m: tMage): integer
+          if m.mana > 0 then
+            return 1;
+          else
+            return 0;
+          end if
+        end function
+
+        algorithm
+          var
+            mago: tMage;
+            estado: integer;
+          end var
+
+          mago.mana := 20;
+          estado := hasMana(mago);
+        end algorithm
+      hint: Usa un if para devolver 1 o 0 según el maná.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-funcion-sum-hp
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tPlayer con los campos:
+        - vida: real
+        - nivel: entero
+        Declara el prototipo e implementa una función totalLife que reciba dos tPlayer
+        y devuelva un real con la suma de sus vidas.
+      answer: |
+        typedef struct {
+            float vida;
+            int nivel;
+        } tPlayer;
+
+        float totalLife(tPlayer p1, tPlayer p2);
+
+        float totalLife(tPlayer p1, tPlayer p2) {
+            return p1.vida + p2.vida;
+        }
+      hint: Los structs pueden pasarse como parámetros en las funciones.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-funcion-sum-hp
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo tPlayer con los campos:
+        - vida: real
+        - nivel: integer
+        Escribe e implementa una función totalLife que reciba dos tPlayer
+        y devuelva un real con la suma de sus vidas.
+      answer: |
+        type
+          tPlayer = record
+            vida: real;
+            nivel: integer;
+          end record
+        end type
+
+        function totalLife(p1: tPlayer, p2: tPlayer): real
+          return p1.vida + p2.vida;
+        end function
+      hint: Usa return para devolver la suma de las vidas.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-main-attack
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo de una función llamada attack que reciba dos enteros atk y def
+        y devuelva un entero con el daño (atk - def).
+        En main declara atk=50 y def=20, llama a attack y guarda el resultado en dmg.
+        Implementa la función.
+      answer: |
+        #include <stdio.h>
+
+        int attack(int atk, int def);
+
+        int main() {
+            int atk = 50;
+            int def = 20;
+            int dmg = attack(atk, def);
+            return 0;
+        }
+
+        int attack(int atk, int def) {
+            return atk - def;
+        }
+      hint: El daño se calcula como ataque menos defensa.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-main-attack
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe el encabezado de una función attack que reciba dos enteros atk y def
+        y devuelva un entero con el daño (atk - def).
+        En el bloque principal declara atk=50 y def=20, llama a attack y guarda el resultado en dmg.
+        Implementa la función.
+      answer: |
+        function attack(atk: integer, def: integer): integer
+          return atk - def;
+        end function
+
+        algorithm
+          var
+            atk: integer;
+            def: integer;
+            dmg: integer;
+          end var
+
+          atk := 50;
+          def := 20;
+          dmg := attack(atk, def);
+        end algorithm
+      hint: Usa return para devolver atk - def.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 2
+    explanation:
+      C: "En este nivel aprenderás a usar **punteros en C**. Los punteros permiten
+        guardar la **dirección de memoria** de una variable, acceder a su contenido,
+        modificarlo, y trabajar con arrays y estructuras de forma más flexible.  \nSon
+        muy útiles en videojuegos para gestionar objetos, personajes y recursos.\n\n---\n###
+        ¿Qué es un puntero?\nUn puntero es una variable que almacena la dirección
+        de otra variable.  \nPara declarar un puntero se usa `*` y para obtener la
+        dirección de una variable se usa `&`.\n\n```c\nint score = 500;        //
+        variable normal\nint *pScore = &score;   // puntero que apunta a score\n```\n\n---\n###
+        Acceso al valor con el operador `*`\nUsando `*` podemos **leer** o **modificar**
+        el valor al que apunta el puntero.\n\n```c\nint health = 100;\nint *pHealth
+        = &health;\n\n*pHealth = 80;  // cambia health a 80\n```\n\n---\n### Imprimir
+        valores y direcciones\nCon `printf` podemos imprimir el contenido (`%d`) o
+        la dirección (`%p`).\n\n```c\nint coins = 250;\nint *pCoins = &coins;\n\nprintf(\"%d\",
+        *pCoins); // imprime 250\nprintf(\"%p\", pCoins);  // imprime la dirección
+        de coins\n```\n\n---\n### Punteros y estructuras\nUn puntero a una estructura
+        permite acceder a sus campos con `->`.\n\n```c\ntypedef struct {\n    int
+        valor;\n} tItem;\n\ntItem espada = {100};\ntItem *pEspada = &espada;\n\nprintf(\"%d\",
+        pEspada->valor); // imprime 100\n```\n\nTambién se pueden modificar los campos:\n\n```c\ntypedef
+        struct {\n    int hp;\n} tPlayer;\n\ntPlayer heroe = {120};\ntPlayer *pHeroe
+        = &heroe;\n\npHeroe->hp = 200; // cambia hp del héroe a 200\n```\n\n---\n###
+        Punteros y arrays\nEl nombre de un array es equivalente a un puntero a su
+        primer elemento.  \nPodemos recorrerlo o modificarlo usando aritmética de
+        punteros.\n\n```c\nint scores[3] = {10, 20, 30};\nint *pScores = scores;\n\nprintf(\"%d\",
+        *(pScores + 1)); // imprime 20\n```\n\nY también modificar elementos:\n\n```c\nint
+        inventory[3] = {5, 10, 15};\nint *pInv = inventory;\n\n*(pInv + 2) = 50; //
+        cambia el tercer valor a 50\n```\n\n---\n### Ejemplo completo\n```c\n#include
+        <stdio.h>\n\ntypedef struct {\n    int valor;\n} tItem;\n\ntypedef struct
+        {\n    int hp;\n} tPlayer;\n\nint main() {\n    // Variable y puntero\n    int
+        score = 500;\n    int *pScore = &score;\n\n    // Modificación con puntero\n
+        \   int health = 100;\n    int *pHealth = &health;\n    *pHealth = 80;\n\n
+        \   // Impresión con puntero\n    int coins = 250;\n    int *pCoins = &coins;\n
+        \   printf(\"Coins: %d\\n\", *pCoins);\n    printf(\"Coins address: %p\\n\",
+        pCoins);\n\n    // Puntero a struct y acceso\n    tItem espada = {100};\n
+        \   tItem *pEspada = &espada;\n    printf(\"Espada valor: %d\\n\", pEspada->valor);\n\n
+        \   // Modificación de struct\n    tPlayer heroe = {120};\n    tPlayer *pHeroe
+        = &heroe;\n    pHeroe->hp = 200;\n    printf(\"Heroe HP: %d\\n\", heroe.hp);\n\n
+        \   // Array y punteros\n    int scores[3] = {10, 20, 30};\n    int *pScores
+        = scores;\n    printf(\"Segundo score: %d\\n\", *(pScores + 1));\n\n    int
+        inventory[3] = {5, 10, 15};\n    int *pInv = inventory;\n    *(pInv + 2) =
+        50;\n    printf(\"Tercer valor inventory: %d\\n\", inventory[2]);\n\n    return
+        0;\n}\n```\n\nEste programa muestra cómo usar punteros para acceder y modificar
+        variables, estructuras y arrays, simulando elementos de un videojuego como
+        vida, inventario o armas.\n"
+    questions:
+    - id: c-5-l2-pointer-basic
+      language: C
+      week: 5
+      prompt: |
+        Declara un entero score con valor 500.
+        Declara un puntero pScore que apunte a score.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int score = 500;
+            int *pScore = &score;
+            return 0;
+        }
+      hint: Usa * para declarar punteros y & para obtener la dirección.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-pointer-dereference
+      language: C
+      week: 5
+      prompt: |
+        Declara un entero health con valor 100.
+        Declara un puntero pHealth que apunte a health.
+        Usando el puntero, asigna el valor 80 a health.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int health = 100;
+            int *pHealth = &health;
+            *pHealth = 80;
+            return 0;
+        }
+      hint: El operador * permite acceder al valor apuntado.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-pointer-print
+      language: C
+      week: 5
+      prompt: |
+        Declara un entero coins con valor 250.
+        Declara un puntero pCoins que apunte a coins.
+        Imprime con printf el valor de coins usando el puntero.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int coins = 250;
+            int *pCoins = &coins;
+            printf("%d", *pCoins);
+            return 0;
+        }
+      hint: printf muestra el contenido con %d.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-pointer-address
+      language: C
+      week: 5
+      prompt: |
+        Declara un entero stamina con valor 40.
+        Declara un puntero pStamina que apunte a stamina.
+        Imprime con printf la dirección almacenada en pStamina.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int stamina = 40;
+            int *pStamina = &stamina;
+            printf("%p", pStamina);
+            return 0;
+        }
+      hint: Usa %p para imprimir direcciones.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-pointer-change
+      language: C
+      week: 5
+      prompt: |
+        Declara un entero level con valor 3.
+        Declara un puntero pLevel que apunte a level.
+        Cambia el valor de level a 4 usando el puntero.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int level = 3;
+            int *pLevel = &level;
+            *pLevel = 4;
+            return 0;
+        }
+      hint: Con *pLevel accedes al contenido de level.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-struct-pointer
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tItem con un campo valor (entero).
+        En main declara un objeto pocion con valor=50.
+        Declara un puntero pItem que apunte a pocion.
+      answer: |
+        #include <stdio.h>
+
+        typedef struct {
+            int valor;
+        } tItem;
+
+        int main() {
+            tItem pocion = {50};
+            tItem *pItem = &pocion;
+            return 0;
+        }
+      hint: Para punteros a struct, usa el nombre del tipo seguido de *.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-struct-pointer-access
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tItem con un campo valor (entero).
+        En main declara un objeto espada con valor=100.
+        Declara un puntero pEspada que apunte a espada.
+        Imprime el valor usando pEspada con el operador ->.
+      answer: |
+        #include <stdio.h>
+
+        typedef struct {
+            int valor;
+        } tItem;
+
+        int main() {
+            tItem espada = {100};
+            tItem *pEspada = &espada;
+            printf("%d", pEspada->valor);
+            return 0;
+        }
+      hint: Usa -> para acceder a campos desde un puntero a struct.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-struct-modify
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tPlayer con un campo hp (entero).
+        En main declara un objeto heroe con hp=120.
+        Declara un puntero pHeroe que apunte a heroe.
+        Usa el puntero para cambiar hp a 200.
+      answer: |
+        #include <stdio.h>
+
+        typedef struct {
+            int hp;
+        } tPlayer;
+
+        int main() {
+            tPlayer heroe = {120};
+            tPlayer *pHeroe = &heroe;
+            pHeroe->hp = 200;
+            return 0;
+        }
+      hint: Con -> puedes modificar campos del struct.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-array-pointer
+      language: C
+      week: 5
+      prompt: |
+        Declara un array de enteros scores con valores {10, 20, 30}.
+        Declara un puntero pScores que apunte al primer elemento del array.
+        Imprime con printf el segundo valor usando el puntero.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int scores[3] = {10, 20, 30};
+            int *pScores = scores;
+            printf("%d", *(pScores + 1));
+            return 0;
+        }
+      hint: Los arrays se comportan como punteros al primer elemento.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-array-pointer-change
+      language: C
+      week: 5
+      prompt: |
+        Declara un array de enteros inventory con valores {5, 10, 15}.
+        Declara un puntero pInv que apunte al primer elemento.
+        Cambia el tercer valor del array a 50 usando el puntero.
+      answer: |
+        #include <stdio.h>
+
+        int main() {
+            int inventory[3] = {5, 10, 15};
+            int *pInv = inventory;
+            *(pInv + 2) = 50;
+            return 0;
+        }
+      hint: " *(p + i) accede al elemento i del array. "
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 3
+    explanation:
+      C: "En este nivel aprenderás a trabajar con **acciones (procedimientos)** en
+        C.  \nUna acción es similar a una función, pero **no devuelve un valor**.
+        \ \nEn videojuegos, las acciones son útiles para mostrar información en pantalla,
+        actualizar la vida de un jugador o aplicar un efecto, sin necesidad de devolver
+        un resultado directo.\n\n### ¿Qué es una acción?\nUna **acción** (también
+        llamada procedimiento) es un bloque de código independiente que:\n- Tiene
+        un **nombre** que la identifica.  \n- Puede recibir **parámetros**:  \n  -
+        `in` (entrada → solo lectura).  \n  - `out` (salida → el valor se escribe
+        dentro del parámetro y afecta a la variable original).  \n  - `inout` (entrada/salida
+        → se lee y se modifica, actualizando la variable original).  \n- No devuelve
+        un valor con `return`.  \n\n---\n\n### Prototipos de acciones (encabezados)\nIgual
+        que en las funciones, se declara el encabezado antes de `main`.  \nEjemplo:\n```c\nvoid
+        mostrarPuntos(int puntos);\nvoid aplicarBonus(int enemigos, int bonus, int
+        *resultado);       // salida\nvoid acumularPuntos(int enemigos, int bonus,
+        int *resultado);    // entrada/salida\n```\n\n---\n\n### Sintaxis general
+        de una acción\n```c\nvoid nombreAccion(tipo parametros) {\n    // instrucciones\n}\n```\n\n*Se
+        utiliza `void` porque no devuelve ningún valor.*\n\n---\n\n### Ejemplo en
+        código\nAcción que recibe un parámetro de entrada y lo muestra:\n```c\nvoid
+        mostrarPuntos(int puntos) {\n    printf(\"Puntos actuales: %d\\n\", puntos);\n}\n```\n\n---\n\n###
+        Ejemplo completo\n```c\n#include <stdio.h>\n\n// Prototipos\nvoid mostrarPuntos(int
+        puntos);                       // entrada\nvoid aplicarBonus(int enemigos,
+        int bonus, int *res); // salida\nvoid acumularPuntos(int enemigos, int bonus,
+        int *res); // entrada/salida\n\n// main primero\nint main() {\n    int puntos;\n
+        \   int total = 100; // puntos iniciales del jugador\n\n    // Acción de salida:
+        calcula puntos a partir de enemigos y bonus\n    aplicarBonus(5, 20, &puntos);\n
+        \   mostrarPuntos(puntos);\n\n    // Acción de entrada/salida: acumula puntos
+        en el total del jugador\n    acumularPuntos(3, 10, &total);\n    mostrarPuntos(total);\n\n
+        \   return 0;\n}\n\n// Implementaciones al final\n// Acción de entrada\nvoid
+        mostrarPuntos(int puntos) {\n    printf(\"Puntos actuales: %d\\n\", puntos);\n}\n\n//
+        Acción con parámetro de salida\nvoid aplicarBonus(int enemigos, int bonus,
+        int *res) {\n    int calculo = enemigos * 10 + bonus;\n    *res = calculo;
+        // modifica la variable original\n}\n\n// Acción con parámetro entrada/salida\nvoid
+        acumularPuntos(int enemigos, int bonus, int *res) {\n    int calculo = enemigos
+        * 5 + bonus;\n    *res = *res + calculo; // suma al valor original\n}\n```\n\n**Qué
+        hace el programa:**  \n- `aplicarBonus` (salida) calcula puntos en base a
+        enemigos derrotados y bonus, guardándolos en una variable.  \n- `mostrarPuntos`
+        (entrada) imprime los puntos actuales del jugador.  \n- `acumularPuntos` (entrada/salida)
+        suma más puntos al total existente.  \n- Se simula cómo un jugador gana puntos
+        por enemigos derrotados y acumula un total.  \n"
+      Pseudocode: "En este nivel aprenderás a trabajar con **acciones** en pseudocódigo.
+        \ \nUna acción es similar a una función, pero **no devuelve un valor**.  \nEn
+        videojuegos, las acciones sirven para mostrar mensajes, actualizar variables
+        de juego o aplicar efectos sobre los personajes.\n\n### ¿Qué es una acción?\nUna
+        **acción**:\n- Tiene un **nombre** que la identifica.  \n- Puede recibir **parámetros**:
+        \ \n  - `in` (entrada → solo lectura).  \n  - `out` (salida → el valor se
+        escribe dentro del parámetro y afecta a la variable original).  \n  - `inout`
+        (entrada/salida → se lee y se modifica, actualizando la variable original).
+        \ \n- No devuelve un valor.  \n\n---\n\n### Sintaxis general de una acción\n```pseudocode\naction
+        nombreAccion(parametros)\n  ...\nend action\n```\n\n---\n\n### Ejemplo en
+        pseudocódigo\nAcción de entrada para mostrar puntos:\n```pseudocode\naction
+        mostrarPuntos(in puntos: integer)\n  writeString(\"Puntos actuales: \");\n
+        \ writeInteger(puntos);\nend action\n```\n\n---\n\n### Ejemplo completo\n```pseudocode\n{
+        Implementaciones }\n\naction mostrarPuntos(in puntos: integer)\n  writeString(\"Puntos
+        actuales: \");\n  writeInteger(puntos);\nend action\n\naction aplicarBonus(in
+        enemigos: integer, in bonus: integer, out res: integer)\n  var\n    calculo:
+        integer;\n  end var\n  calculo := enemigos * 10 + bonus;\n  res := calculo;
+        \  { modifica la variable original }\nend action\n\naction acumularPuntos(in
+        enemigos: integer, in bonus: integer, inout res: integer)\n  var\n    calculo:
+        integer;\n  end var\n  calculo := enemigos * 5 + bonus;\n  res := res + calculo;
+        \  { suma al valor original }\nend action\n\nalgorithm accionesVideojuego\n
+        \ var\n    puntos: integer;\n    total: integer;\n  end var\n\n  total :=
+        100;  { puntos iniciales }\n\n  aplicarBonus(5, 20, puntos);    { calcula
+        puntos con salida }\n  mostrarPuntos(puntos);\n\n  acumularPuntos(3, 10, total);
+        \  { acumula puntos en total }\n  mostrarPuntos(total);\nend algorithm\n```\n\n**Qué
+        hace el programa:**  \n- `aplicarBonus` (salida) calcula los puntos por enemigos
+        derrotados y bonus, y los asigna a una variable.  \n- `mostrarPuntos` (entrada)
+        escribe en pantalla los puntos actuales.  \n- `acumularPuntos` (entrada/salida)
+        suma más puntos al total acumulado del jugador.  \n- Se simula un sistema
+        de puntuación en un videojuego, donde el jugador gana y acumula puntos progresivamente.
+        \ \n"
+    questions:
+    - id: c-5-l2-action-welcome
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción en C llamada showWelcome que no reciba parámetros.
+        Dentro de la acción imprime con printf el mensaje "Bienvenido al RPG".
+        En main llama a showWelcome.
+      answer: |
+        #include <stdio.h>
+
+        void showWelcome();
+
+        int main() {
+            showWelcome();
+            return 0;
+        }
+
+        void showWelcome() {
+            printf("Bienvenido al RPG\n");
+        }
+      hint: Una acción en C se define con void, no devuelve valores.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-welcome
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción llamada showWelcome que no reciba parámetros.
+        Dentro de la acción escribe el mensaje "Bienvenido al RPG".
+        En el bloque principal llama a showWelcome.
+      answer: |
+        action showWelcome()
+          writeString("Bienvenido al RPG");
+        end action
+
+        algorithm
+          showWelcome();
+        end algorithm
+      hint: Una acción no devuelve valores, solo ejecuta instrucciones.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-in-score
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción printScore que reciba como entrada un entero score.
+        Dentro de la acción muestra con printf "Puntuacion: <score>".
+        En main declara un entero score=300 y llama a printScore con esa variable.
+      answer: |
+        #include <stdio.h>
+
+        void printScore(int score);
+
+        int main() {
+            int score = 300;
+            printScore(score);
+            return 0;
+        }
+
+        void printScore(int score) {
+            printf("Puntuacion: %d\n", score);
+        }
+      hint: Los parámetros de entrada en C se pasan como variables normales.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-in-score
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción printScore que reciba como entrada un entero score.
+        Dentro de la acción escribe el mensaje "Puntuacion: " seguido del valor.
+        En el bloque principal declara un entero score=300 y llama a printScore.
+      answer: |
+        action printScore(in score: integer)
+          writeString("Puntuacion: ");
+          writeInteger(score);
+        end action
+
+        algorithm
+          var
+            score: integer;
+          end var
+
+          score := 300;
+          printScore(score);
+        end algorithm
+      hint: Usa "in" para los parámetros de entrada.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-out-health
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción initHealth que reciba como salida un entero *health.
+        Dentro de la acción asigna a *health el valor 100.
+        En main declara un entero hp sin inicializar, llama a initHealth con &hp
+        y luego muestra hp con printf.
+      answer: |
+        #include <stdio.h>
+
+        void initHealth(int *health);
+
+        int main() {
+            int hp;
+            initHealth(&hp);
+            printf("%d\n", hp);
+            return 0;
+        }
+
+        void initHealth(int *health) {
+            *health = 100;
+        }
+      hint: Los parámetros de salida en C se pasan como punteros.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-out-health
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción initHealth que reciba como salida un entero health.
+        Dentro de la acción asigna a health el valor 100.
+        En el bloque principal declara un entero hp sin inicializar, llama a initHealth con hp
+        y luego muestra hp.
+      answer: |
+        action initHealth(out health: integer)
+          health := 100;
+        end action
+
+        algorithm
+          var
+            hp: integer;
+          end var
+
+          initHealth(hp);
+          writeInteger(hp);
+        end algorithm
+      hint: Usa "out" cuando la acción debe inicializar un valor.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-inout-heal
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción heal que reciba como entrada/salida un entero *hp.
+        Dentro de la acción suma 50 al valor apuntado por hp usando operador compuesto.
+        En main declara un entero hp=120, llama a heal con &hp
+        y luego imprime el nuevo valor.
+      answer: |
+        #include <stdio.h>
+
+        void heal(int *hp);
+
+        int main() {
+            int hp = 120;
+            heal(&hp);
+            printf("%d\n", hp);
+            return 0;
+        }
+
+        void heal(int *hp) {
+            *hp += 50;
+        }
+      hint: Usa inout cuando el valor inicial se modifica.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-inout-heal
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción heal que reciba como entrada/salida un entero hp.
+        Dentro de la acción suma 50 al valor de hp.
+        En el bloque principal declara hp=120, llama a heal con hp
+        y muestra el nuevo valor.
+      answer: |
+        action heal(inout hp: integer)
+          hp := hp + 50;
+        end action
+
+        algorithm
+          var
+            hp: integer;
+          end var
+
+          hp := 120;
+          heal(hp);
+          writeInteger(hp);
+        end algorithm
+      hint: Usa "inout" cuando el parámetro se actualiza.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-struct-revive
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tPlayer con los campos:
+        - nombre: texto de 20 chars
+        - hp: entero
+        Declara una acción revive que reciba como salida un puntero a tPlayer
+        y lo inicialice con hp=100 y nombre="Heroe".
+        En main declara un jugador sin inicializar y llama a revive.
+        Imprime los valores "Nombre: x Hp: x".
+      answer: |
+        #include <stdio.h>
+        #include <string.h>
+
+        typedef struct {
+            char nombre[20];
+            int hp;
+        } tPlayer;
+
+        void revive(tPlayer *p);
+
+        int main() {
+            tPlayer jugador;
+            revive(&jugador);
+            printf("Nombre: %s Hp: %d\n", jugador.nombre, jugador.hp);
+            return 0;
+        }
+
+        void revive(tPlayer *p) {
+            strcpy(p->nombre, "Heroe");
+            p->hp = 100;
+        }
+      hint: Con punteros a structs se usa -> para asignar.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-struct-revive
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo tPlayer con los campos:
+        - nombre: string
+        - hp: integer
+        Declara una acción revive que reciba un tPlayer por salida
+        y lo inicialice con nombre="Heroe" y hp=100.
+        En el bloque principal declara un jugador y llama a revive.
+        Imprime los valores "Nombre: x Hp: x"
+      answer: |
+        type
+          tPlayer = record
+            nombre: string;
+            hp: integer;
+          end record
+        end type
+
+        action revive(out p: tPlayer)
+          p.nombre := "Heroe";
+          p.hp := 100;
+        end action
+
+        algorithm
+          var
+            jugador: tPlayer;
+          end var
+
+          revive(jugador);
+          writeString("Nombre: ");
+          writeString(jugador.nombre);
+          writeString("Hp: ");
+          writeInteger(jugador.hp);
+        end algorithm
+      hint: Usa "out" cuando la acción debe devolver un struct completo.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-array-reset
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción resetInventory que reciba como entrada/salida un array de 3 enteros items.
+        Dentro de la acción usa un bucle for para poner todos sus valores a 0.
+        En main declara el array items con {10,20,30}, llama a resetInventory e imprime los valores separados
+        por un espacio "x x x".
+      answer: |
+        #include <stdio.h>
+
+        void resetInventory(int *items);
+
+        int main() {
+            int items[3] = {10, 20, 30};
+            resetInventory(items);
+            printf("%d %d %d", items[0], items[1], items[2]);
+            return 0;
+        }
+
+        void resetInventory(int *items) {
+            for(int i=0; i<3; i++) {
+                items[i] = 0;
+            }
+        }
+      hint: Los arrays en C se pasan como punteros.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-array-reset
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción resetInventory que reciba como entrada/salida un array de 3 enteros items.
+        Dentro de la acción usa un bucle for que itere 3 veces y ponga en 0 los valores del array.
+        En el bloque principal declara items con los valores {10,20,30}, llama a resetInventory
+        y muestra los 3 valores "x x x".
+      answer: |
+        action resetInventory(inout items: array[3] of integer)
+          var
+            i: integer;
+          end var
+
+          for i = 1 to 3 do
+            items[i] := 0;
+          end for
+        end action
+
+        algorithm
+          var
+            items: array[3] of integer;
+          end var
+
+          items[1] := 10;
+          items[2] := 20;
+          items[3] := 30;
+
+          resetInventory(items);
+
+          writeInteger(items[1]);
+          writeInteger(items[2]);
+          writeInteger(items[3]);
+        end algorithm
+      hint: En pseudocódigo los arrays de 3 posiciones se definen como array[3].
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-two-in
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción showAttack que reciba dos enteros atk y def como entrada.
+        Dentro de la acción declara una variable entera total y calcula atk-def.
+        Muestra el valor de total con printf.
+        En main declara atk=50 y def=20 y llama a showAttack.
+      answer: |
+        #include <stdio.h>
+
+        void showAttack(int atk, int def);
+
+        int main() {
+            int atk = 50;
+            int def = 20;
+            showAttack(atk, def);
+            return 0;
+        }
+
+        void showAttack(int atk, int def) {
+            int total = atk - def;
+            printf("%d", total);
+        }
+      hint: Puedes pasar más de un parámetro in a la acción.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-two-in
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción showAttack que reciba dos enteros atk y def como entrada.
+        Dentro de la acción declara una variable entera total y calcula atk-def.
+        Imprime el valor de total.
+        En el bloque principal declara atk=50 y def=20 y llama a showAttack.
+      answer: |
+        action showAttack(in atk: integer, in def: integer)
+          var
+            tota: integer;
+          end var
+
+          total := atk - def;
+          writeInteger(total);
+        end action
+
+        algorithm
+          var
+            atk: integer;
+            def: integer;
+          end var
+
+          atk := 50;
+          def := 20;
+          showAttack(atk, def);
+        end algorithm
+      hint: Usa "in" para ambos parámetros.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-in-out
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción grantXP que reciba como entrada un entero base
+        y como salida un entero *xp.
+        Dentro de la acción asigna *xp = base * 10.
+        En main declara base=5 y una variable xp, llama a grantXP y muestra xp.
+      answer: |
+        #include <stdio.h>
+
+        void grantXP(int base, int *xp);
+
+        int main() {
+            int base = 5;
+            int xp;
+            grantXP(base, &xp);
+            printf("%d", xp);
+            return 0;
+        }
+
+        void grantXP(int base, int *xp) {
+            *xp = base * 10;
+        }
+      hint: Combina parámetros in y out.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-in-out
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción grantXP que reciba como entrada un entero base
+        y como salida un entero xp.
+        Dentro de la acción asigna xp = base * 10.
+        En el bloque principal declara base=5 y xp, llama a grantXP y muestra xp.
+      answer: |
+        action grantXP(in base: integer, out xp: integer)
+          xp := base * 10;
+        end action
+
+        algorithm
+          var
+            base: integer;
+            xp: integer;
+          end var
+
+          base := 5;
+          grantXP(base, xp);
+          writeInteger(xp);
+        end algorithm
+      hint: Usa una mezcla de in y out.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-in-inout
+      language: C
+      week: 5
+      prompt: |
+        Declara una acción powerUp que reciba como entrada un entero bonus
+        y como entrada/salida un entero *atk.
+        Dentro de la acción suma bonus al valor apuntado por atk.
+        En main declara atk=40 y bonus=15, llama a powerUp y muestra atk.
+      answer: |
+        #include <stdio.h>
+
+        void powerUp(int bonus, int *atk);
+
+        int main() {
+            int atk = 40;
+            int bonus = 15;
+            powerUp(bonus, &atk);
+            printf("%d", atk);
+            return 0;
+        }
+
+        void powerUp(int bonus, int *atk) {
+            *atk = *atk + bonus;
+        }
+      hint: Combina un parámetro in y uno inout.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-in-inout
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una acción powerUp que reciba como entrada un entero bonus
+        y como entrada/salida un entero atk.
+        Dentro de la acción suma bonus al valor de atk.
+        En el bloque principal declara atk=40 y bonus=15, llama a powerUp y muestra atk.
+      answer: |
+        action powerUp(in bonus: integer, inout atk: integer)
+          atk := atk + bonus;
+        end action
+
+        algorithm
+          var
+            atk: integer;
+            bonus: integer;
+          end var
+
+          atk := 40;
+          bonus := 15;
+          powerUp(bonus, atk);
+          writeInteger(atk);
+        end algorithm
+      hint: Mezcla in y inout en la acción.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-action-struct-inout
+      language: C
+      week: 5
+      prompt: |
+        Declara una estructura tEnemy con el campo hp (entero).
+        Declara una acción damage que reciba como entrada un entero dmg
+        y como entrada/salida un puntero a tEnemy.
+        Dentro de la acción resta dmg a hp.
+        En main declara un enemigo con hp= {200}.
+        Llama a damage con 30 y enemigo.
+        Imprime el valor del hp de enemigo.
+      answer: |
+        #include <stdio.h>
+
+        typedef struct {
+            int hp;
+        } tEnemy;
+
+        void damage(int dmg, tEnemy *e);
+
+        int main() {
+            tEnemy enemigo = {200};
+            damage(30, &enemigo);
+            printf("%d", enemigo.hp);
+            return 0;
+        }
+
+        void damage(int dmg, tEnemy *e) {
+            e->hp = e->hp - dmg;
+        }
+      hint: Usa -> para modificar un struct desde un puntero.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-action-struct-inout
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara un tipo tEnemy con el campo hp (entero).
+        Declara una acción damage que reciba como entrada un entero dmg
+        y como entrada/salida un tEnemy e.
+        Dentro de la acción resta dmg al campo hp.
+        En el bloque principal declara un enemigo con hp=200.
+        Llama a damage con 30 y enemigo.
+        Imprime el valor del hp de enemigo.
+      answer: |
+        type
+          tEnemy = record
+            hp: integer;
+          end record
+        end type
+
+        action damage(in dmg: integer, inout e: tEnemy)
+          e.hp := e.hp - dmg;
+        end action
+
+        algorithm
+          var
+            enemigo: tEnemy;
+          end var
+
+          enemigo.hp := 200;
+          damage(30, enemigo);
+          writeInteger(enemigo.hp);
+        end algorithm
+      hint: Usa in para dmg y inout para el struct.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+- number: 7
+  explanation:
+  levels:
+  - number: 1
+    explanation:
+      C: 'Explicacion C
+
+        '
+      Pseudocode: 'Explicacion Pseudocode
+
+        '
+    questions:
+    - id: c-5-l1-table-enemy
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_ENEMIES = 50.
+        Declara una estructura tEnemy con los campos:
+        - name: texto (usa MAX_NAME = 30)
+        - health: entero
+        Declara una tabla tEnemyTable con:
+        - data: array de MAX_ENEMIES de tEnemy
+        - count: entero con el número de enemigos almacenados.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_ENEMIES 50
+
+        typedef struct {
+            char name[MAX_NAME];
+            int health;
+        } tEnemy;
+
+        typedef struct {
+            tEnemy data[MAX_ENEMIES];
+            int count;
+        } tEnemyTable;
+      hint: Recuerda que una tabla combina el array y un contador.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-enemy
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_ENEMIES = 50.
+        Declara un tipo tEnemy con los campos:
+        - name: string
+        - health: integer
+        Declara un tipo tEnemyTable con:
+        - data: vector[MAX_ENEMIES] de tEnemy
+        - count: integer
+      answer: |
+        const
+          MAX_ENEMIES: integer = 50;
+        end const
+
+        type
+          tEnemy = record
+            name: string;
+            health: integer;
+          end record
+        end type
+
+        type
+          tEnemyTable = record
+            data: vector[MAX_ENEMIES] of tEnemy;
+            count: integer;
+          end record
+        end type
+      hint: La tabla es un record con el array y el contador.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-init-enemytable
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo e implementación de una función initEnemyTable que reciba
+        un puntero a tEnemyTable y lo inicialice con count = 0.
+      answer: |
+        void initEnemyTable(tEnemyTable* table);
+
+        void initEnemyTable(tEnemyTable* table) {
+            table->count = 0;
+        }
+      hint: Usa -> para acceder a count porque es un puntero.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-init-enemytable
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe el encabezado e implementación de una acción initEnemyTable
+        que reciba un parámetro de tipo inout tEnemyTable y lo inicialice con count = 0.
+      answer: |
+        action initEnemyTable(inout table: tEnemyTable)
+          table.count := 0;
+        end action
+      hint: Una acción en pseudocódigo no devuelve valor.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-item
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_ITEMS = 100.
+        Declara una estructura tItem con los campos:
+        - name: texto (usa MAX_NAME = 30)
+        - value: entero
+        Declara un tipo tInventory con:
+        - data: array de MAX_ITEMS de tItem
+        - count: entero
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_ITEMS 100
+
+        typedef struct {
+            char name[MAX_NAME];
+            int value;
+        } tItem;
+
+        typedef struct {
+            tItem data[MAX_ITEMS];
+            int count;
+        } tInventory;
+      hint: El inventario es otra tabla similar a los enemigos.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-item
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_ITEMS = 100.
+        Declara un tipo tItem con los campos:
+        - name: string
+        - value: integer
+        Declara un tipo tInventory con:
+        - data: vector[MAX_ITEMS] de tItem
+        - count: integer
+      answer: |
+        const
+          MAX_ITEMS: integer = 100;
+        end const
+
+        type
+          tItem = record
+            name: string;
+            value: integer;
+          end record
+        end type
+
+        type
+          tInventory = record
+            data: vector[MAX_ITEMS] of tItem;
+            count: integer;
+          end record
+        end type
+      hint: Las tablas siempre combinan vector y contador.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-main-init-inventory
+      language: C
+      week: 5
+      prompt: |
+        Declara el prototipo e implementación de una función initInventory que ponga count=0.
+        En main declara una variable inv de tipo tInventory, inicialízala con initInventory
+        y devuelve 0.
+      answer: |
+        void initInventory(tInventory* inv);
+
+        void initInventory(tInventory* inv) {
+            inv->count = 0;
+        }
+
+        int main() {
+            tInventory inv;
+            initInventory(&inv);
+            return 0;
+        }
+      hint: Pasa la dirección de inv al llamar a initInventory.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-main-init-inventory
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Escribe la acción initInventory que ponga count=0 en un tInventory.
+        En el bloque principal declara una variable inv de tipo tInventory
+        e inicialízala llamando a initInventory.
+      answer: |
+        action initInventory(inout inv: tInventory)
+          inv.count := 0;
+        end action
+
+        algorithm
+          var
+            inv: tInventory;
+          end var
+
+          initInventory(inv);
+        end algorithm
+      hint: Pasa inv como inout para que se inicialice.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-player
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_PLAYERS = 20.
+        Declara una estructura tPlayer con:
+        - username: texto (usa MAX_NAME = 30)
+        - level: entero
+        Declara una tabla tPlayerTable con:
+        - data: array de MAX_PLAYERS de tPlayer
+        - count: entero
+        En main declara un tPlayerTable players y pon count=0.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_PLAYERS 20
+
+        typedef struct {
+            char username[MAX_NAME];
+            int level;
+        } tPlayer;
+
+        typedef struct {
+            tPlayer data[MAX_PLAYERS];
+            int count;
+        } tPlayerTable;
+
+        int main() {
+            tPlayerTable players;
+            players.count = 0;
+            return 0;
+        }
+      hint: La inicialización directa se hace con .count = 0.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-player
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_PLAYERS = 20.
+        Declara un tipo tPlayer con:
+        - username: string
+        - level: integer
+        Declara un tipo tPlayerTable con:
+        - data: vector[MAX_PLAYERS] de tPlayer
+        - count: integer
+        En el bloque principal declara un tPlayerTable players y pon count=0.
+      answer: |
+        const
+          MAX_PLAYERS: integer = 20;
+        end const
+
+        type
+          tPlayer = record
+            username: string;
+            level: integer;
+          end record
+        end type
+
+        type
+          tPlayerTable = record
+            data: vector[MAX_PLAYERS] of tPlayer;
+            count: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            players: tPlayerTable;
+          end var
+
+          players.count := 0;
+        end algorithm
+      hint: Se inicializa el contador a 0 en el bloque principal.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-weapon
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_WEAPONS = 40.
+        Declara un enum tWeaponType con los valores SWORD, BOW y STAFF.
+        Declara un struct tWeapon con:
+        - name: texto (usa MAX_NAME = 30)
+        - type: tWeaponType
+        Declara una tabla tWeaponTable con data[MAX_WEAPONS] y count.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_WEAPONS 40
+
+        typedef enum { SWORD, BOW, STAFF } tWeaponType;
+
+        typedef struct {
+            char name[MAX_NAME];
+            tWeaponType type;
+        } tWeapon;
+
+        typedef struct {
+            tWeapon data[MAX_WEAPONS];
+            int count;
+        } tWeaponTable;
+      hint: Un enum se define antes de usarlo dentro del struct.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-weapon
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_WEAPONS = 40.
+        Declara un tipo enumerado tWeaponType con valores SWORD, BOW y STAFF.
+        Declara un tipo tWeapon con:
+        - name: string
+        - type: tWeaponType
+        Declara un tipo tWeaponTable con:
+        - data: vector[MAX_WEAPONS] de tWeapon
+        - count: integer
+      answer: |
+        const
+          MAX_WEAPONS: integer = 40;
+        end const
+
+        type
+          tWeaponType = { SWORD, BOW, STAFF };
+        end type
+
+        type
+          tWeapon = record
+            name: string;
+            type: tWeaponType;
+          end record
+        end type
+
+        type
+          tWeaponTable = record
+            data: vector[MAX_WEAPONS] of tWeapon;
+            count: integer;
+          end record
+        end type
+      hint: Recuerda cerrar cada tipo con end type.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-init-weapon-main
+      language: C
+      week: 5
+      prompt: |
+        Declara la función initWeaponTable que inicialice count=0 en un tWeaponTable.
+        En main declara una variable armas de tipo tWeaponTable e inicialízala con initWeaponTable.
+      answer: |
+        void initWeaponTable(tWeaponTable* table);
+
+        void initWeaponTable(tWeaponTable* table) {
+            table->count = 0;
+        }
+
+        int main() {
+            tWeaponTable armas;
+            initWeaponTable(&armas);
+            return 0;
+        }
+      hint: Se pasa la dirección de la tabla con &.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-init-weapon-main
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara la acción initWeaponTable que inicialice count=0 en un tWeaponTable.
+        En el bloque principal declara una variable armas de tipo tWeaponTable e inicialízala con initWeaponTable.
+      answer: |
+        action initWeaponTable(inout table: tWeaponTable)
+          table.count := 0;
+        end action
+
+        algorithm
+          var
+            armas: tWeaponTable;
+          end var
+
+          initWeaponTable(armas);
+        end algorithm
+      hint: En pseudocódigo las acciones se llaman igual que en C.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-npc
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_NPCS = 60.
+        Declara una estructura tNPC con:
+        - name: texto (usa MAX_NAME = 30)
+        - dialogue: texto (usa MAX_MSG = 100)
+        Declara una tabla tNPCTable con:
+        - data: array[MAX_NPCS] de tNPC
+        - count: entero
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_MSG 100
+        #define MAX_NPCS 60
+
+        typedef struct {
+            char name[MAX_NAME];
+            char dialogue[MAX_MSG];
+        } tNPC;
+
+        typedef struct {
+            tNPC data[MAX_NPCS];
+            int count;
+        } tNPCTable;
+      hint: Cada NPC tiene nombre y diálogo como strings.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-npc
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_NPCS = 60.
+        Declara un tipo tNPC con:
+        - name: string
+        - dialogue: string
+        Declara un tipo tNPCTable con:
+        - data: vector[MAX_NPCS] de tNPC
+        - count: integer
+      answer: |
+        const
+          MAX_NPCS: integer = 60;
+        end const
+
+        type
+          tNPC = record
+            name: string;
+            dialogue: string;
+          end record
+        end type
+
+        type
+          tNPCTable = record
+            data: vector[MAX_NPCS] of tNPC;
+            count: integer;
+          end record
+        end type
+      hint: Un NPC tiene cadenas de texto como atributos.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-quest
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_QUESTS = 25.
+        Declara una estructura tQuest con:
+        - title: texto (usa MAX_NAME = 30)
+        - reward: entero
+        Declara una tabla tQuestTable con:
+        - data: array[MAX_QUESTS] de tQuest
+        - count: entero
+        En main declara una variable quests de tipo tQuestTable e inicialízala poniendo count=0.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_QUESTS 25
+
+        typedef struct {
+            char title[MAX_NAME];
+            int reward;
+        } tQuest;
+
+        typedef struct {
+            tQuest data[MAX_QUESTS];
+            int count;
+        } tQuestTable;
+
+        int main() {
+            tQuestTable quests;
+            quests.count = 0;
+            return 0;
+        }
+      hint: La inicialización directa de count se hace en main.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-quest
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_QUESTS = 25.
+        Declara un tipo tQuest con:
+        - title: string
+        - reward: integer
+        Declara un tipo tQuestTable con:
+        - data: vector[MAX_QUESTS] de tQuest
+        - count: integer
+        En el bloque principal declara una variable quests de tipo tQuestTable e inicialízala poniendo count=0.
+      answer: |
+        const
+          MAX_QUESTS: integer = 25;
+        end const
+
+        type
+          tQuest = record
+            title: string;
+            reward: integer;
+          end record
+        end type
+
+        type
+          tQuestTable = record
+            data: vector[MAX_QUESTS] of tQuest;
+            count: integer;
+          end record
+        end type
+
+        algorithm
+          var
+            quests: tQuestTable;
+          end var
+
+          quests.count := 0;
+        end algorithm
+      hint: El contador siempre comienza en 0 al declarar la tabla.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l1-table-boss
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_BOSSES = 10.
+        Declara una estructura tBoss con:
+        - name: texto (usa MAX_NAME = 30)
+        - hp: real
+        - stage: entero
+        Declara una tabla tBossTable con:
+        - data: array[MAX_BOSSES] de tBoss
+        - count: entero
+        Declara e implementa una función initBossTable que reciba un puntero a tBossTable
+        e inicialice count=0.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_BOSSES 10
+
+        typedef struct {
+            char name[MAX_NAME];
+            float hp;
+            int stage;
+        } tBoss;
+
+        typedef struct {
+            tBoss data[MAX_BOSSES];
+            int count;
+        } tBossTable;
+
+        void initBossTable(tBossTable* table);
+
+        void initBossTable(tBossTable* table) {
+            table->count = 0;
+        }
+      hint: Usa float para hp porque es un valor decimal.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l1-table-boss
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_BOSSES = 10.
+        Declara un tipo tBoss con:
+        - name: string
+        - hp: real
+        - stage: integer
+        Declara un tipo tBossTable con:
+        - data: vector[MAX_BOSSES] de tBoss
+        - count: integer
+        Declara e implementa una acción initBossTable que reciba un inout tBossTable
+        e inicialice count=0.
+      answer: |
+        const
+          MAX_BOSSES: integer = 10;
+        end const
+
+        type
+          tBoss = record
+            name: string;
+            hp: real;
+            stage: integer;
+          end record
+        end type
+
+        type
+          tBossTable = record
+            data: vector[MAX_BOSSES] of tBoss;
+            count: integer;
+          end record
+        end type
+
+        action initBossTable(inout table: tBossTable)
+          table.count := 0;
+        end action
+      hint: La acción no devuelve nada, solo modifica la tabla.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+  - number: 2
+    explanation:
+      C:
+      Pseudocode:
+    questions:
+    - id: c-5-l2-insert-skill
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_SKILLS = 30 y MAX_NAME = 30.
+        Declara una estructura tSkill con:
+        - name: texto
+        - level: entero
+        Declara una tabla tSkillTable con:
+        - data: array[MAX_SKILLS] de tSkill
+        - count: entero
+        Implementa la función addSkill que reciba un puntero a tSkillTable (table)
+        y un tSkill (s), lo inserte al final de la tabla y aumente count.
+      answer: |
+        #include <string.h>
+        #define MAX_NAME 30
+        #define MAX_SKILLS 30
+
+        typedef struct {
+            char name[MAX_NAME];
+            int level;
+        } tSkill;
+
+        typedef struct {
+            tSkill data[MAX_SKILLS];
+            int count;
+        } tSkillTable;
+
+        void addSkill(tSkillTable* table, tSkill s) {
+            table->data[table->count] = s;
+            table->count++;
+        }
+      hint: Inserta al final usando table->count como índice.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-insert-skill
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_SKILLS = 30.
+        Declara un tipo tSkill con:
+        - name: string
+        - level: integer
+        Declara un tipo tSkillTable con:
+        - data: vector[MAX_SKILLS] de tSkill
+        - count: integer
+        Implementa una acción addSkill que reciba un inout tSkillTable (table)
+        y un tSkill (s), lo inserte al final de la tabla y aumente count.
+      answer: |
+        const
+          MAX_SKILLS: integer = 30;
+        end const
+
+        type
+          tSkill = record
+            name: string;
+            level: integer;
+          end record
+        end type
+
+        type
+          tSkillTable = record
+            data: vector[MAX_SKILLS] of tSkill;
+            count: integer;
+          end record
+        end type
+
+        action addSkill(inout table: tSkillTable, in s: tSkill)
+          table.data[table.count + 1] := s;
+          table.count := table.count + 1;
+        end action
+      hint: En pseudocódigo los índices empiezan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-insert-potion
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_POTIONS = 50 y MAX_NAME = 30.
+        Declara un struct tPotion con:
+        - name: texto
+        - power: real
+        Declara una tabla tPotionTable con data[MAX_POTIONS] y count.
+        Implementa la función addPotion que reciba un puntero a tPotionTable (table)
+        y un tPotion (p), lo inserte al final y aumente count.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_POTIONS 50
+
+        typedef struct {
+            char name[MAX_NAME];
+            float power;
+        } tPotion;
+
+        typedef struct {
+            tPotion data[MAX_POTIONS];
+            int count;
+        } tPotionTable;
+
+        void addPotion(tPotionTable* table, tPotion p) {
+            table->data[table->count] = p;
+            table->count++;
+        }
+      hint: Usa float para power.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-insert-potion
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_POTIONS = 50.
+        Declara un tipo tPotion con:
+        - name: string
+        - power: real
+        Declara un tipo tPotionTable con data[MAX_POTIONS] y count.
+        Implementa una acción addPotion que reciba un inout tPotionTable (table)
+        y un tPotion (p), lo inserte al final y aumente count.
+      answer: |
+        const
+          MAX_POTIONS: integer = 50;
+        end const
+
+        type
+          tPotion = record
+            name: string;
+            power: real;
+          end record
+        end type
+
+        type
+          tPotionTable = record
+            data: vector[MAX_POTIONS] of tPotion;
+            count: integer;
+          end record
+        end type
+
+        action addPotion(inout table: tPotionTable, in p: tPotion)
+          table.data[table.count + 1] := p;
+          table.count := table.count + 1;
+        end action
+      hint: Recuerda aumentar count tras insertar.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-insert-achievement
+      language: C
+      week: 5
+      prompt: |
+        Declara una constante MAX_ACHIEVEMENTS = 40 y MAX_NAME = 30.
+        Declara un struct tAchievement con:
+        - title: texto
+        - points: entero
+        Declara un tAchievementTable con data[MAX_ACHIEVEMENTS] y count.
+        Implementa la función addAchievement que reciba un puntero a tAchievementTable (table)
+        y un tAchievement (a), lo inserte al final y aumente count.
+      answer: |
+        #define MAX_NAME 30
+        #define MAX_ACHIEVEMENTS 40
+
+        typedef struct {
+            char title[MAX_NAME];
+            int points;
+        } tAchievement;
+
+        typedef struct {
+            tAchievement data[MAX_ACHIEVEMENTS];
+            int count;
+        } tAchievementTable;
+
+        void addAchievement(tAchievementTable* table, tAchievement a) {
+            table->data[table->count] = a;
+            table->count++;
+        }
+      hint: Similar a insertar skills o potions.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-insert-achievement
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Declara una constante MAX_ACHIEVEMENTS = 40.
+        Declara un tipo tAchievement con:
+        - title: string
+        - points: integer
+        Declara un tipo tAchievementTable con data[MAX_ACHIEVEMENTS] y count.
+        Implementa una acción addAchievement que reciba un inout tAchievementTable (table)
+        y un tAchievement (a), lo inserte al final y aumente count.
+      answer: |
+        const
+          MAX_ACHIEVEMENTS: integer = 40;
+        end const
+
+        type
+          tAchievement = record
+            title: string;
+            points: integer;
+          end record
+        end type
+
+        type
+          tAchievementTable = record
+            data: vector[MAX_ACHIEVEMENTS] of tAchievement;
+            count: integer;
+          end record
+        end type
+
+        action addAchievement(inout table: tAchievementTable, in a: tAchievement)
+          table.data[table.count + 1] := a;
+          table.count := table.count + 1;
+        end action
+      hint: No olvides incrementar el contador.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-search-skill
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función searchSkill que reciba un tSkillTable (table) y un nombre (name),
+        y devuelva la posición en el array (o -1 si no existe).
+        Usa un while con booleano found, inicializa pos=-1, i=0.
+      answer: |
+        #include <stdbool.h>
+        #include <string.h>
+
+        int searchSkill(tSkillTable table, const char* name) {
+            int i = 0;
+            int pos = -1;
+            bool found = false;
+            while(i < table.count && !found) {
+                if(strcmp(table.data[i].name, name) == 0) {
+                    pos = i;
+                    found = true;
+                } else {
+                    i++;
+                }
+            }
+            return pos;
+        }
+      hint: Sigue el esquema de búsqueda lineal de la teoría.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-search-skill
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una función searchSkill que reciba un tSkillTable (table) y un string (name),
+        y devuelva un integer con la posición encontrada o -1 si no existe.
+        Usa un while con variable booleana found, inicializa pos=-1, i=1.
+      answer: |
+        function searchSkill(table: tSkillTable, name: string): integer
+          var
+            i: integer;
+            pos: integer;
+            found: boolean;
+          end var
+
+          i := 1;
+          pos := -1;
+          found := false;
+
+          while i ≤ table.count and not found do
+            if table.data[i].name = name then
+              pos := i;
+              found := true;
+            else
+              i := i + 1;
+            end if
+          end while
+
+          return pos;
+        end function
+      hint: Recuerda que los índices en pseudocódigo comienzan en 1.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-search-potion
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función searchPotion que reciba un tPotionTable (table) y un real power,
+        y devuelva la posición encontrada o -1 si no existe.
+        Usa while con booleano found.
+      answer: |
+        #include <stdbool.h>
+
+        int searchPotion(tPotionTable table, float power) {
+            int i = 0;
+            int pos = -1;
+            bool found = false;
+            while(i < table.count && !found) {
+                if(table.data[i].power == power) {
+                    pos = i;
+                    found = true;
+                } else {
+                    i++;
+                }
+            }
+            return pos;
+        }
+      hint: Inicializa pos en -1 como valor por defecto.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-search-potion
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una función searchPotion que reciba un tPotionTable (table) y un real (power),
+        y devuelva un integer con la posición encontrada o -1 si no existe.
+        Usa el esquema de búsqueda lineal con while y booleano found.
+      answer: |
+        function searchPotion(table: tPotionTable, power: real): integer
+          var
+            i: integer;
+            pos: integer;
+            found: boolean;
+          end var
+
+          i := 1;
+          pos := -1;
+          found := false;
+
+          while i ≤ table.count and not found do
+            if table.data[i].power = power then
+              pos := i;
+              found := true;
+            else
+              i := i + 1;
+            end if
+          end while
+
+          return pos;
+        end function
+      hint: Usa pos=-1 como valor inicial de no encontrado.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-search-achievement
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función searchAchievement que reciba un tAchievementTable (table) y un integer points,
+        y devuelva la posición de un logro con esos puntos o -1 si no existe.
+        Usa while con booleano found.
+      answer: |
+        #include <stdbool.h>
+
+        int searchAchievement(tAchievementTable table, int points) {
+            int i = 0;
+            int pos = -1;
+            bool found = false;
+            while(i < table.count && !found) {
+                if(table.data[i].points == points) {
+                    pos = i;
+                    found = true;
+                } else {
+                    i++;
+                }
+            }
+            return pos;
+        }
+      hint: Devuelve -1 si no encuentra el valor buscado.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-search-achievement
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una función searchAchievement que reciba un tAchievementTable (table) y un integer (points),
+        y devuelva un integer con la posición encontrada o -1 si no existe.
+        Usa while con booleano found.
+      answer: |
+        function searchAchievement(table: tAchievementTable, points: integer): integer
+          var
+            i: integer;
+            pos: integer;
+            found: boolean;
+          end var
+
+          i := 1;
+          pos := -1;
+          found := false;
+
+          while i ≤ table.count and not found do
+            if table.data[i].points = points then
+              pos := i;
+              found := true;
+            else
+              i := i + 1;
+            end if
+          end while
+
+          return pos;
+        end function
+      hint: Usa el esquema de búsqueda lineal de la teoría.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-delete-skill
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función deleteSkill que reciba un puntero a tSkillTable (table) y un string (name).
+        Primero busca el nombre con searchSkill. Si se encuentra, desplaza los elementos a la izquierda
+        y disminuye count en 1.
+      answer: |
+        void deleteSkill(tSkillTable* table, const char* name) {
+            int pos = searchSkill(*table, name);
+            if(pos != -1) {
+                for(int i = pos; i < table->count - 1; i++) {
+                    table->data[i] = table->data[i+1];
+                }
+                table->count--;
+            }
+        }
+      hint: Desplaza todos los elementos posteriores una posición a la izquierda.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-delete-skill
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una acción deleteSkill que reciba un inout tSkillTable (table) y un string (name).
+        Primero busca con searchSkill. Si se encuentra, desplaza todos los elementos a la izquierda
+        y reduce count en 1.
+      answer: |
+        action deleteSkill(inout table: tSkillTable, in name: string)
+          var
+            pos: integer;
+            i: integer;
+          end var
+
+          pos := searchSkill(table, name);
+
+          if pos ≠ -1 then
+            for i := pos to table.count - 1 do
+              table.data[i] := table.data[i+1];
+            end for
+            table.count := table.count - 1;
+          end if
+        end action
+      hint: Sigue el patrón de la teoría para eliminación.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-delete-potion
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función deletePotion que reciba un puntero a tPotionTable (table) y un real (power).
+        Usa searchPotion. Si encuentra el elemento, desplaza hacia la izquierda
+        y reduce count en 1.
+      answer: |
+        void deletePotion(tPotionTable* table, float power) {
+            int pos = searchPotion(*table, power);
+            if(pos != -1) {
+                for(int i = pos; i < table->count - 1; i++) {
+                    table->data[i] = table->data[i+1];
+                }
+                table->count--;
+            }
+        }
+      hint: Usa la búsqueda antes de eliminar.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-delete-potion
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una acción deletePotion que reciba un inout tPotionTable (table) y un real (power).
+        Usa searchPotion. Si existe, mueve todos los elementos a la izquierda desde pos
+        y reduce count en 1.
+      answer: |
+        action deletePotion(inout table: tPotionTable, in power: real)
+          var
+            pos: integer;
+            i: integer;
+          end var
+
+          pos := searchPotion(table, power);
+
+          if pos ≠ -1 then
+            for i := pos to table.count - 1 do
+              table.data[i] := table.data[i+1];
+            end for
+            table.count := table.count - 1;
+          end if
+        end action
+      hint: Elimina compactando la tabla.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-delete-achievement
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función deleteAchievement que reciba un puntero a tAchievementTable (table) y un integer (points).
+        Usa searchAchievement. Si se encuentra, desplaza hacia la izquierda
+        y reduce count en 1.
+      answer: |
+        void deleteAchievement(tAchievementTable* table, int points) {
+            int pos = searchAchievement(*table, points);
+            if(pos != -1) {
+                for(int i = pos; i < table->count - 1; i++) {
+                    table->data[i] = table->data[i+1];
+                }
+                table->count--;
+            }
+        }
+      hint: Desplaza desde la posición encontrada hasta el final.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-delete-achievement
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una acción deleteAchievement que reciba un inout tAchievementTable (table) y un integer (points).
+        Usa searchAchievement. Si existe, desplaza a la izquierda los elementos posteriores
+        y reduce count en 1.
+      answer: |
+        action deleteAchievement(inout table: tAchievementTable, in points: integer)
+          var
+            pos: integer;
+            i: integer;
+          end var
+
+          pos := searchAchievement(table, points);
+
+          if pos ≠ -1 then
+            for i := pos to table.count - 1 do
+              table.data[i] := table.data[i+1];
+            end for
+            table.count := table.count - 1;
+          end if
+        end action
+      hint: El contador se decrementa al final.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: c-5-l2-traverse-skill-sum
+      language: C
+      week: 5
+      prompt: |
+        Implementa la función sumSkillLevels que reciba un tSkillTable (table)
+        y devuelva la suma de todos los niveles de las habilidades.
+        Usa un for desde 0 hasta count-1.
+      answer: |
+        int sumSkillLevels(tSkillTable table) {
+            int i;
+            int total = 0;
+            for(i = 0; i < table.count; i++) {
+                total = total + table.data[i].level;
+            }
+            return total;
+        }
+      hint: El esquema de recorrido es con for porque sabemos count.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }
+    - id: p-5-l2-traverse-skill-sum
+      language: Pseudocode
+      week: 5
+      prompt: |
+        Implementa una función sumSkillLevels que reciba un tSkillTable (table)
+        y devuelva un integer con la suma de todos los niveles.
+        Usa un for de 1 hasta count.
+      answer: |
+        function sumSkillLevels(table: tSkillTable): integer
+          var
+            i: integer;
+            total: integer;
+          end var
+
+          total := 0;
+
+          for i := 1 to table.count do
+            total := total + table.data[i].level;
+          end for
+
+          return total;
+        end function
+      hint: En pseudocódigo el recorrido va de 1 a count.
+      mode: normalize
+      input_prefill: |
+        int main(){
+
+            return 0;
+        }

--- a/src/data/quiz_questions_modes.yaml
+++ b/src/data/quiz_questions_modes.yaml
@@ -84,7 +84,7 @@ weeks:
       answer: |
         #include <stdio.h>
 
-        int main(void) {
+        int main() {
           int a, b;
           scanf("%d %d", &a, &b);
           printf("%d\n", a + b);
@@ -113,7 +113,7 @@ weeks:
       answer: |
         #include <stdio.h>
 
-        int main(void) {
+        int main() {
           int n;
           scanf("%d", &n);
           if (n % 2 == 0) {

--- a/src/data/quiz_questions_modes_validation.md
+++ b/src/data/quiz_questions_modes_validation.md
@@ -1,0 +1,46 @@
+# Validación de preguntas (quiz_questions_modes.yaml)
+
+- Fuente: `src/data/quiz_questions_v2.yaml`
+- Generado: `2026-02-19 14:10:10 UTC`
+- Total preguntas: **294**
+- Preguntas C: **158**
+- Preguntas Pseudocode: **136**
+- Mode `judge_c`: **2**
+- Mode `normalize`: **292**
+- `input_prefill` actualizado (week >= 2): **236**
+
+## Issues detectados
+
+- [Sintaxis/compilación C] week 1 id `c-1-nombredron_max_nombre`: /tmp/check20260219-4571-9r6hb8.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-iddron_menos1`: /tmp/check20260219-4571-diyb7h.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-distanciaminima_const`: /tmp/check20260219-4571-vmfqcm.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-dronactivo_true`: /tmp/check20260219-4571-nyqd0j.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-scanf_nombredron`: /tmp/check20260219-4571-rkuphc.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-scanf_iddron`: /tmp/check20260219-4571-q5nlj9.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-scanf_bateriai`: /tmp/check20260219-4571-5qzqs0.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-scanf_categoriadron`: /tmp/check20260219-4571-acq6xb.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-printf_nombre_id`: /tmp/check20260219-4571-clu5kw.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-printf_bateria`: /tmp/check20260219-4571-iubx0c.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-printf_categoria`: /tmp/check20260219-4571-h3fny0.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-estado_en_vuelo`: /tmp/check20260219-4571-gyfqp1.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-lee_estado_enum`: /tmp/check20260219-4571-2fhxwl.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-printf_estado_num`: /tmp/check20260219-4571-twjlg8.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-incremento_iddron`: /tmp/check20260219-4571-9i769d.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-suficiente_bool`: /tmp/check20260219-4571-e6rel0.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-ternario_en_servicio`: /tmp/check20260219-4571-uyys92.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-ternario_apto`: /tmp/check20260219-4571-oer1ei.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-cast_bateriaentera`: /tmp/check20260219-4571-ratog6.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-cast_nuevabateria`: /tmp/check20260219-4571-aqrdcq.c: In function ‘main’:
+- [Sintaxis/compilación C] week 3 id `c-3-for-strncpy-paralelo`: /tmp/check20260219-4571-z5b90z.c: In function ‘main’:
+- [Sintaxis/compilación C] week 4 id `c-4-l3-switch-por-tipo`: /tmp/check20260219-4571-gt7kl5.c: In function ‘main’:
+- [Sintaxis/compilación C] week 4 id `c-4-l3-promedio-y-ternario`: /tmp/check20260219-4571-yvlyw9.c: In function ‘main’:
+- [Sintaxis/compilación C] week 5 id `c-5-l1-init-enemytable`: /tmp/check20260219-4571-8xhgho.c:2:21: error: unknown type name ‘tEnemyTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l1-main-init-inventory`: /tmp/check20260219-4571-c4llmv.c:1:20: error: unknown type name ‘tInventory’
+- [Sintaxis/compilación C] week 5 id `c-5-l1-init-weapon-main`: /tmp/check20260219-4571-usrbd6.c:1:22: error: unknown type name ‘tWeaponTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-search-skill`: /tmp/check20260219-4571-zm5a0c.c:5:17: error: unknown type name ‘tSkillTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-search-potion`: /tmp/check20260219-4571-wp878b.c:4:18: error: unknown type name ‘tPotionTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-search-achievement`: /tmp/check20260219-4571-d5ydny.c:4:23: error: unknown type name ‘tAchievementTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-delete-skill`: /tmp/check20260219-4571-m1joaf.c:2:18: error: unknown type name ‘tSkillTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-delete-potion`: /tmp/check20260219-4571-ct57qq.c:2:19: error: unknown type name ‘tPotionTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-delete-achievement`: /tmp/check20260219-4571-ms5c84.c:2:24: error: unknown type name ‘tAchievementTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-traverse-skill-sum`: /tmp/check20260219-4571-730jti.c:2:20: error: unknown type name ‘tSkillTable’

--- a/src/data/quiz_questions_modes_validation.md
+++ b/src/data/quiz_questions_modes_validation.md
@@ -1,0 +1,79 @@
+# Validación de preguntas (quiz_questions_modes.yaml)
+
+- Fuente: `src/data/quiz_questions_v2.yaml`
+- Generado: `2026-02-19 14:30:44 UTC`
+- Total preguntas: **294**
+- Preguntas C: **158**
+- Preguntas Pseudocode: **136**
+- Mode `judge_c`: **66**
+- Mode `normalize`: **228**
+- `input_prefill` actualizado (week >= 2): **236**
+- Judge con tests ya existentes: **2**
+- Judge con tests auto-generados por ejecución: **41**
+- Judge con tests placeholder (revisión manual): **23**
+
+## Issues detectados
+
+- [Sintaxis/compilación C] week 1 id `c-1-nombredron_max_nombre`: /tmp/check20260219-4313-mgabm2.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-iddron_menos1`: /tmp/check20260219-4313-y4hq27.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-distanciaminima_const`: /tmp/check20260219-4313-zalwmf.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-dronactivo_true`: /tmp/check20260219-4313-l6qgdy.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-scanf_nombredron`: /tmp/check20260219-4313-5599rl.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-scanf_iddron`: /tmp/check20260219-4313-yvigcu.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-scanf_bateriai`: /tmp/check20260219-4313-lo1dcx.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-scanf_categoriadron`: /tmp/check20260219-4313-hz43tg.c: In function ‘main’:
+- [Auto-test placeholder] week 1 id `c-1-printf_nombre_id`: no se pudo auto-ejecutar (compile_failed: /tmp/autotest20260219-4313-owj0wc.c: In function ‘main’:
+); se dejó test vacío para revisión manual.
+- [Sintaxis/compilación C] week 1 id `c-1-printf_nombre_id`: /tmp/check20260219-4313-t00h3p.c: In function ‘main’:
+- [Auto-test placeholder] week 1 id `c-1-printf_bateria`: no se pudo auto-ejecutar (compile_failed: /tmp/autotest20260219-4313-99fag7.c: In function ‘main’:
+); se dejó test vacío para revisión manual.
+- [Sintaxis/compilación C] week 1 id `c-1-printf_bateria`: /tmp/check20260219-4313-e3hi2o.c: In function ‘main’:
+- [Auto-test placeholder] week 1 id `c-1-printf_categoria`: no se pudo auto-ejecutar (compile_failed: /tmp/autotest20260219-4313-2payu8.c: In function ‘main’:
+); se dejó test vacío para revisión manual.
+- [Sintaxis/compilación C] week 1 id `c-1-printf_categoria`: /tmp/check20260219-4313-wh4ie5.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-estado_en_vuelo`: /tmp/check20260219-4313-7bcl86.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-lee_estado_enum`: /tmp/check20260219-4313-klbub1.c: In function ‘main’:
+- [Auto-test placeholder] week 1 id `c-1-printf_estado_num`: no se pudo auto-ejecutar (compile_failed: /tmp/autotest20260219-4313-ixvw78.c: In function ‘main’:
+); se dejó test vacío para revisión manual.
+- [Sintaxis/compilación C] week 1 id `c-1-printf_estado_num`: /tmp/check20260219-4313-8mguix.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-incremento_iddron`: /tmp/check20260219-4313-kzqon1.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-suficiente_bool`: /tmp/check20260219-4313-8ee4ek.c: In function ‘main’:
+- [Auto-test placeholder] week 1 id `c-1-ternario_en_servicio`: no se pudo auto-ejecutar (compile_failed: /tmp/autotest20260219-4313-xmo395.c: In function ‘main’:
+); se dejó test vacío para revisión manual.
+- [Sintaxis/compilación C] week 1 id `c-1-ternario_en_servicio`: /tmp/check20260219-4313-nupzv2.c: In function ‘main’:
+- [Auto-test placeholder] week 1 id `c-1-ternario_apto`: no se pudo auto-ejecutar (compile_failed: /tmp/autotest20260219-4313-z8e93k.c: In function ‘main’:
+); se dejó test vacío para revisión manual.
+- [Sintaxis/compilación C] week 1 id `c-1-ternario_apto`: /tmp/check20260219-4313-88p2ot.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-cast_bateriaentera`: /tmp/check20260219-4313-ye9a4p.c: In function ‘main’:
+- [Sintaxis/compilación C] week 1 id `c-1-cast_nuevabateria`: /tmp/check20260219-4313-x0wj6f.c: In function ‘main’:
+- [Auto-test placeholder] week 2 id `c-2-leer-string`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 2 id `c-2-leer-array-int`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 3 id `c-3-lee-edad`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 3 id `c-3-if-simple`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 3 id `c-3-if-else`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 3 id `c-3-if-else-encadenado`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 3 id `c-3-switch`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 3 id `c-3-for-leer-array`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 3 id `c-3-for-strncpy-paralelo`: no se pudo auto-ejecutar (compile_failed: /tmp/autotest20260219-4313-bek414.c: In function ‘main’:
+); se dejó test vacío para revisión manual.
+- [Sintaxis/compilación C] week 3 id `c-3-for-strncpy-paralelo`: /tmp/check20260219-4313-jwmbei.c: In function ‘main’:
+- [Auto-test placeholder] week 4 id `c-4-l3-registro-basico-for`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 4 id `c-4-l3-menu-switch-do-while`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 4 id `c-4-l3-strcmp-dos-atracciones`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 4 id `c-4-l3-horarios-for`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 4 id `c-4-l3-contar-mantenimiento-for`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 4 id `c-4-l3-switch-por-tipo`: requiere entrada, test generado vacío para revisión manual.
+- [Sintaxis/compilación C] week 4 id `c-4-l3-switch-por-tipo`: /tmp/check20260219-4313-8bf2mp.c: In function ‘main’:
+- [Auto-test placeholder] week 4 id `c-4-l3-entrada-hasta-fin-strcmp`: requiere entrada, test generado vacío para revisión manual.
+- [Auto-test placeholder] week 4 id `c-4-l3-promedio-y-ternario`: requiere entrada, test generado vacío para revisión manual.
+- [Sintaxis/compilación C] week 4 id `c-4-l3-promedio-y-ternario`: /tmp/check20260219-4313-fizmwh.c: In function ‘main’:
+- [Sintaxis/compilación C] week 5 id `c-5-l1-init-enemytable`: /tmp/check20260219-4313-vimvdd.c:2:21: error: unknown type name ‘tEnemyTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l1-main-init-inventory`: /tmp/check20260219-4313-w0kml8.c:1:20: error: unknown type name ‘tInventory’
+- [Sintaxis/compilación C] week 5 id `c-5-l1-init-weapon-main`: /tmp/check20260219-4313-c9uuqo.c:1:22: error: unknown type name ‘tWeaponTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-search-skill`: /tmp/check20260219-4313-2epgu.c:5:17: error: unknown type name ‘tSkillTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-search-potion`: /tmp/check20260219-4313-n102f.c:4:18: error: unknown type name ‘tPotionTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-search-achievement`: /tmp/check20260219-4313-8w5zcd.c:4:23: error: unknown type name ‘tAchievementTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-delete-skill`: /tmp/check20260219-4313-slddt.c:2:18: error: unknown type name ‘tSkillTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-delete-potion`: /tmp/check20260219-4313-u958jh.c:2:19: error: unknown type name ‘tPotionTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-delete-achievement`: /tmp/check20260219-4313-a6wg4n.c:2:24: error: unknown type name ‘tAchievementTable’
+- [Sintaxis/compilación C] week 5 id `c-5-l2-traverse-skill-sum`: /tmp/check20260219-4313-9dkczl.c:2:20: error: unknown type name ‘tSkillTable’

--- a/src/data/quiz_questions_v2.yaml
+++ b/src/data/quiz_questions_v2.yaml
@@ -230,6 +230,52 @@ weeks:
             Este algoritmo simula la inicialización de un jugador al comenzar una partida.
 
         questions:
+          - id: c-1-judge-suma
+            language: C
+            week: 1
+            mode: judge_c
+            prompt: Escribe un programa completo que lea dos enteros y muestre su suma seguida de un salto de línea.
+            answer: |
+              #include <stdio.h>
+
+              int main(void) {
+                int a, b;
+                scanf("%d %d", &a, &b);
+                printf("%d\n", a + b);
+                return 0;
+              }
+            tests:
+              - input: "2 3\n"
+                output: "5\n"
+              - input: "10 -4\n"
+                output: "6\n"
+            hint: Usa scanf para leer ambos enteros y printf para escribir la suma exacta.
+
+          - id: c-1-judge-paridad
+            language: C
+            week: 1
+            mode: judge_c
+            prompt: Escribe un programa completo que lea un entero. Si es par imprime PAR\n, en caso contrario imprime IMPAR\n.
+            answer: |
+              #include <stdio.h>
+
+              int main(void) {
+                int n;
+                scanf("%d", &n);
+                if (n % 2 == 0) {
+                  printf("PAR\n");
+                } else {
+                  printf("IMPAR\n");
+                }
+                return 0;
+              }
+            tests:
+              - input: "8\n"
+                output: "PAR\n"
+              - input: "7\n"
+                output: "IMPAR\n"
+            hint: Puedes usar el operador módulo (%).
+
           - id: c-1-max_nombre
             language: C
             week: 1
@@ -238,7 +284,7 @@ weeks:
             hint:
 
           - id: c-1-max_drones
-            language: Pseudocode
+            language: C
             week: 1
             prompt: Declara una constante para el máximo de drones "MAX_DRONES" con el valor entero 5.
             answer: '#define MAX_DRONES 5'
@@ -281,13 +327,13 @@ weeks:
             prompt: Declara una constante local de tipo entera para el puntaje inicial INITIAL_SCORE, asignale el valor 0.
             answer: |
               int main(){
-                const int INITIAL_SCORE = 0;
+                  const int INITIAL_SCORE = 0;
                 return 0;
               }
             hint: Las constantes locales comienzan por const.
 
           - id: p-1-const_entera
-            language: C
+            language: Pseudocode
             week: 1
             prompt: Declara una constante local de tipo entera para el puntaje inicial INITIAL_SCORE, asignale el valor 0.
             answer: |
@@ -477,51 +523,6 @@ weeks:
               end algorithm
             hint: Recuerda, primero declara y luego inicializa. Los caracteres se inicializan entre ''.
 
-          - id: c-1-judge-suma
-            language: C
-            week: 1
-            mode: judge_c
-            prompt: Escribe un programa completo que lea dos enteros y muestre su suma seguida de un salto de línea.
-            answer: |
-              #include <stdio.h>
-
-              int main(void) {
-                int a, b;
-                scanf("%d %d", &a, &b);
-                printf("%d\n", a + b);
-                return 0;
-              }
-            tests:
-              - input: "2 3\n"
-                output: "5\n"
-              - input: "10 -4\n"
-                output: "6\n"
-            hint: Usa scanf para leer ambos enteros y printf para escribir la suma exacta.
-
-          - id: c-1-judge-paridad
-            language: C
-            week: 1
-            mode: judge_c
-            prompt: Escribe un programa completo que lea un entero. Si es par imprime PAR\n, en caso contrario imprime IMPAR\n.
-            answer: |
-              #include <stdio.h>
-
-              int main(void) {
-                int n;
-                scanf("%d", &n);
-                if (n % 2 == 0) {
-                  printf("PAR\n");
-                } else {
-                  printf("IMPAR\n");
-                }
-                return 0;
-              }
-            tests:
-              - input: "8\n"
-                output: "PAR\n"
-              - input: "7\n"
-                output: "IMPAR\n"
-            hint: Puedes usar el operador módulo (%).
 
       # Entrada y salida
       - number: 2

--- a/src/data/quiz_questions_v2.yaml
+++ b/src/data/quiz_questions_v2.yaml
@@ -477,6 +477,52 @@ weeks:
               end algorithm
             hint: Recuerda, primero declara y luego inicializa. Los caracteres se inicializan entre ''.
 
+          - id: c-1-judge-suma
+            language: C
+            week: 1
+            mode: judge_c
+            prompt: Escribe un programa completo que lea dos enteros y muestre su suma seguida de un salto de línea.
+            answer: |
+              #include <stdio.h>
+
+              int main(void) {
+                int a, b;
+                scanf("%d %d", &a, &b);
+                printf("%d\n", a + b);
+                return 0;
+              }
+            tests:
+              - input: "2 3\n"
+                output: "5\n"
+              - input: "10 -4\n"
+                output: "6\n"
+            hint: Usa scanf para leer ambos enteros y printf para escribir la suma exacta.
+
+          - id: c-1-judge-paridad
+            language: C
+            week: 1
+            mode: judge_c
+            prompt: Escribe un programa completo que lea un entero. Si es par imprime PAR\n, en caso contrario imprime IMPAR\n.
+            answer: |
+              #include <stdio.h>
+
+              int main(void) {
+                int n;
+                scanf("%d", &n);
+                if (n % 2 == 0) {
+                  printf("PAR\n");
+                } else {
+                  printf("IMPAR\n");
+                }
+                return 0;
+              }
+            tests:
+              - input: "8\n"
+                output: "PAR\n"
+              - input: "7\n"
+                output: "IMPAR\n"
+            hint: Puedes usar el operador módulo (%).
+
       # Entrada y salida
       - number: 2
         explanation:
@@ -1309,6 +1355,7 @@ weeks:
             prompt: Resta 10.5 a la bateríaInicial usando operador compuesto.
             answer: |
               int main(){
+                float bateriaInicial = 100.0;
                 bateriaInicial -= 10.5;
                 return 0;
               }

--- a/src/judge_c.rs
+++ b/src/judge_c.rs
@@ -1,0 +1,458 @@
+use crate::model::Question;
+
+#[derive(Debug, Clone)]
+pub enum JudgeResult {
+    Accepted,
+    CompileError {
+        stderr: String,
+    },
+    WrongAnswer {
+        test_index: usize,
+        input: String,
+        expected: String,
+        received: String,
+        diff: String,
+    },
+    Timeout {
+        test_index: usize,
+        input: String,
+        timeout_ms: u64,
+    },
+    RuntimeError {
+        test_index: usize,
+        input: String,
+        stderr: String,
+        exit_code: Option<i32>,
+    },
+    InfrastructureError {
+        message: String,
+    },
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use super::JudgeResult;
+    use crate::model::{JudgeTestCase, Question};
+    use std::collections::hash_map::DefaultHasher;
+    use std::env;
+    use std::fs;
+    use std::hash::{Hash, Hasher};
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    const TIMEOUT_MS: u64 = 2_000;
+    const POLL_MS: u64 = 10;
+
+    #[derive(Clone)]
+    enum SubmissionSource {
+        Raw,
+        WrappedBody,
+        CustomHarness,
+    }
+
+    pub fn grade_c_question(question: &Question, user_code: &str) -> JudgeResult {
+        if question.tests.is_empty() {
+            return JudgeResult::InfrastructureError {
+                message: "La pregunta judge_c no tiene tests configurados.".into(),
+            };
+        }
+
+        let compiler = match detect_compiler() {
+            Ok(path) => path,
+            Err(msg) => return JudgeResult::InfrastructureError { message: msg },
+        };
+
+        let cache_dir = match cache_dir() {
+            Ok(dir) => dir,
+            Err(err) => {
+                return JudgeResult::InfrastructureError {
+                    message: format!("No se pudo preparar el cache del juez: {err}"),
+                };
+            }
+        };
+
+        let candidates = build_source_candidates(question, user_code);
+        let mut first_compile_error = None;
+
+        for (source, source_kind) in candidates {
+            let binary_path = build_cached_binary(&cache_dir, &compiler, &source, &source_kind);
+            if !binary_path.exists() {
+                if let Err(stderr) = compile_source(&compiler, &source, &binary_path) {
+                    if first_compile_error.is_none() {
+                        first_compile_error = Some(stderr);
+                    }
+                    continue;
+                }
+            }
+
+            return run_tests(&binary_path, &question.tests);
+        }
+
+        JudgeResult::CompileError {
+            stderr: first_compile_error
+                .unwrap_or_else(|| "Error de compilación desconocido.".into()),
+        }
+    }
+
+    fn build_source_candidates(
+        question: &Question,
+        user_code: &str,
+    ) -> Vec<(String, SubmissionSource)> {
+        let mut candidates = Vec::new();
+
+        if let Some(harness) = question.judge_harness.as_deref() {
+            candidates.push((
+                apply_harness(user_code, Some(harness)),
+                SubmissionSource::CustomHarness,
+            ));
+            return candidates;
+        }
+
+        candidates.push((user_code.to_string(), SubmissionSource::Raw));
+
+        if !contains_main(user_code) {
+            candidates.push((wrap_as_main_body(user_code), SubmissionSource::WrappedBody));
+        }
+
+        candidates
+    }
+
+    fn contains_main(code: &str) -> bool {
+        let normalized = code.replace(char::is_whitespace, "");
+        normalized.contains("main(")
+    }
+
+    fn wrap_as_main_body(code: &str) -> String {
+        format!(
+            "#include <stdio.h>
+#include <stdbool.h>
+
+int main(void) {{
+{code}
+return 0;
+}}
+"
+        )
+    }
+
+    fn run_tests(binary_path: &Path, tests: &[JudgeTestCase]) -> JudgeResult {
+        for (idx, test) in tests.iter().enumerate() {
+            let exec = execute_test(binary_path, test, idx + 1, TIMEOUT_MS);
+            match exec {
+                JudgeResult::Accepted => continue,
+                other => return other,
+            }
+        }
+        JudgeResult::Accepted
+    }
+
+    fn execute_test(
+        binary_path: &Path,
+        test: &JudgeTestCase,
+        test_index: usize,
+        timeout_ms: u64,
+    ) -> JudgeResult {
+        let mut child = match Command::new(binary_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(err) => {
+                return JudgeResult::InfrastructureError {
+                    message: format!("No se pudo ejecutar el binario compilado: {err}"),
+                };
+            }
+        };
+
+        if let Some(mut stdin) = child.stdin.take() {
+            if let Err(err) = stdin.write_all(test.input.as_bytes()) {
+                return JudgeResult::InfrastructureError {
+                    message: format!("No se pudo enviar stdin al programa: {err}"),
+                };
+            }
+        }
+
+        let start = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    let output = match child.wait_with_output() {
+                        Ok(output) => output,
+                        Err(err) => {
+                            return JudgeResult::InfrastructureError {
+                                message: format!("No se pudo leer la salida del programa: {err}"),
+                            };
+                        }
+                    };
+                    return evaluate_output(
+                        test,
+                        test_index,
+                        output.status.code(),
+                        &output.stdout,
+                        &output.stderr,
+                    );
+                }
+                Ok(None) => {
+                    if start.elapsed() > Duration::from_millis(timeout_ms) {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return JudgeResult::Timeout {
+                            test_index,
+                            input: test.input.clone(),
+                            timeout_ms,
+                        };
+                    }
+                    thread::sleep(Duration::from_millis(POLL_MS));
+                }
+                Err(err) => {
+                    return JudgeResult::InfrastructureError {
+                        message: format!("Error esperando al programa: {err}"),
+                    };
+                }
+            }
+        }
+    }
+
+    fn evaluate_output(
+        test: &JudgeTestCase,
+        test_index: usize,
+        exit_code: Option<i32>,
+        stdout: &[u8],
+        stderr: &[u8],
+    ) -> JudgeResult {
+        let received = normalize_newlines(&String::from_utf8_lossy(stdout));
+        let expected = normalize_newlines(&test.output);
+
+        if exit_code.unwrap_or(-1) != 0 {
+            return JudgeResult::RuntimeError {
+                test_index,
+                input: test.input.clone(),
+                stderr: String::from_utf8_lossy(stderr).to_string(),
+                exit_code,
+            };
+        }
+
+        if !matches_expected_output(&received, &expected) {
+            return JudgeResult::WrongAnswer {
+                test_index,
+                input: test.input.clone(),
+                expected,
+                received: received.clone(),
+                diff: line_diff(&test.output, &received),
+            };
+        }
+
+        JudgeResult::Accepted
+    }
+
+    fn normalize_newlines(value: &str) -> String {
+        value.replace("\r\n", "\n")
+    }
+
+    fn matches_expected_output(received: &str, expected: &str) -> bool {
+        if received == expected {
+            return true;
+        }
+
+        let received_trimmed = received.trim_end();
+        let expected_trimmed = expected.trim_end();
+
+        if received_trimmed == expected_trimmed {
+            return true;
+        }
+
+        if expected_trimmed.is_empty() {
+            return received_trimmed.is_empty();
+        }
+
+        if received_trimmed.ends_with(expected_trimmed) {
+            return true;
+        }
+
+        if !expected_trimmed.chars().any(char::is_whitespace) {
+            if let (Some(exp_tok), Some(rec_tok)) = (
+                last_meaningful_token(expected_trimmed),
+                last_meaningful_token(received_trimmed),
+            ) {
+                return rec_tok == exp_tok;
+            }
+        }
+
+        false
+    }
+
+    fn last_meaningful_token(text: &str) -> Option<String> {
+        text.split_whitespace().rev().find_map(|raw| {
+            let token = raw.trim_matches(|c: char| !c.is_alphanumeric() && c != '_' && c != '-');
+            if token.is_empty() {
+                None
+            } else {
+                Some(token.to_string())
+            }
+        })
+    }
+
+    fn line_diff(expected: &str, received: &str) -> String {
+        let expected_norm = expected.replace("\r\n", "\n");
+        let received_norm = received.replace("\r\n", "\n");
+        let exp: Vec<&str> = expected_norm.split('\n').collect();
+        let rec: Vec<&str> = received_norm.split('\n').collect();
+        let max_lines = exp.len().max(rec.len());
+
+        for i in 0..max_lines {
+            let e = exp.get(i).copied().unwrap_or("<sin línea>");
+            let r = rec.get(i).copied().unwrap_or("<sin línea>");
+            if e != r {
+                return format!("Línea {}\n- esperado: {:?}\n+ recibido: {:?}", i + 1, e, r);
+            }
+        }
+
+        "Diferencia no localizada (posible carácter invisible).".into()
+    }
+
+    fn apply_harness(user_code: &str, harness: Option<&str>) -> String {
+        if let Some(harness) = harness {
+            if harness.contains("{{USER_CODE}}") {
+                return harness.replace("{{USER_CODE}}", user_code);
+            }
+            return format!("{user_code}\n{harness}\n");
+        }
+        user_code.to_string()
+    }
+
+    fn compile_source(compiler: &Path, source: &str, output_binary: &Path) -> Result<(), String> {
+        let source_path = output_binary.with_extension("c");
+        fs::write(&source_path, source)
+            .map_err(|e| format!("No se pudo guardar código temporal: {e}"))?;
+
+        let output = Command::new(compiler)
+            .arg(&source_path)
+            .arg("-std=c11")
+            .arg("-O2")
+            .arg("-o")
+            .arg(output_binary)
+            .output()
+            .map_err(|e| format!("No se pudo invocar al compilador: {e}"))?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(String::from_utf8_lossy(&output.stderr).to_string())
+        }
+    }
+
+    fn detect_compiler() -> Result<PathBuf, String> {
+        for candidate in ["clang", "gcc"] {
+            if let Ok(status) = Command::new(candidate)
+                .arg("--version")
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+            {
+                if status.success() {
+                    return Ok(PathBuf::from(candidate));
+                }
+            }
+        }
+
+        Err("No se encontró un compilador C (clang/gcc) en PATH.
+Linux: instala clang o gcc (ej. sudo apt install clang).
+Windows: instala MSYS2/MinGW y agrega gcc/clang a PATH."
+            .into())
+    }
+
+    fn cache_dir() -> Result<PathBuf, std::io::Error> {
+        let base = if cfg!(target_os = "windows") {
+            env::var_os("LOCALAPPDATA")
+                .map(PathBuf::from)
+                .or_else(|| env::var_os("TEMP").map(PathBuf::from))
+                .unwrap_or_else(env::temp_dir)
+        } else {
+            env::var_os("XDG_CACHE_HOME")
+                .map(PathBuf::from)
+                .or_else(|| env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))
+                .unwrap_or_else(env::temp_dir)
+        };
+
+        let dir = base.join("summer_quiz").join("judge_c_cache");
+        fs::create_dir_all(&dir)?;
+        Ok(dir)
+    }
+
+    fn build_cached_binary(
+        cache_dir: &Path,
+        compiler: &Path,
+        source: &str,
+        source_kind: &SubmissionSource,
+    ) -> PathBuf {
+        let mut hasher = DefaultHasher::new();
+        compiler.to_string_lossy().hash(&mut hasher);
+        "-std=c11 -O2".hash(&mut hasher);
+        source.hash(&mut hasher);
+        std::mem::discriminant(source_kind).hash(&mut hasher);
+        let key = format!("{:016x}", hasher.finish());
+        let ext = if cfg!(target_os = "windows") {
+            "exe"
+        } else {
+            "bin"
+        };
+        cache_dir.join(format!("{key}.{ext}"))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn grade_c_question(question: &Question, user_code: &str) -> JudgeResult {
+    native::grade_c_question(question, user_code)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn grade_c_question(_question: &Question, _user_code: &str) -> JudgeResult {
+    JudgeResult::InfrastructureError {
+        message: "El juez C no está disponible en la versión web (wasm32).".into(),
+    }
+}
+
+pub fn format_judge_message(result: &JudgeResult) -> String {
+    match result {
+        JudgeResult::Accepted => "✅ ¡Correcto!".into(),
+        JudgeResult::CompileError { stderr } => {
+            format!("❌ Error de compilación.\n\n{}", stderr.trim())
+        }
+        JudgeResult::WrongAnswer {
+            test_index,
+            input,
+            expected,
+            received,
+            diff,
+        } => format!(
+            "❌ Wrong Answer (caso #{test_index}).\n\nInput:\n{input}\n\nEsperado:\n{expected}\n\nRecibido:\n{received}\n\nDiff:\n{diff}"
+        ),
+        JudgeResult::Timeout {
+            test_index,
+            input,
+            timeout_ms,
+        } => format!("❌ Timeout en caso #{test_index} ({timeout_ms} ms).\n\nInput:\n{input}"),
+        JudgeResult::RuntimeError {
+            test_index,
+            input,
+            stderr,
+            exit_code,
+        } => format!(
+            "❌ Runtime Error en caso #{test_index} (exit code: {}).\n\nInput:\n{input}\n\nStderr:\n{}",
+            exit_code
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "desconocido".into()),
+            stderr.trim()
+        ),
+        JudgeResult::InfrastructureError { message } => format!("⚠ {message}"),
+    }
+}
+
+pub fn should_use_judge(question: &Question) -> bool {
+    question.uses_judge_c()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod app;
 pub mod code_utils;
 pub mod data;
+pub mod judge_c;
 pub mod model;
 pub mod ui;
 pub mod update;

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,17 +6,37 @@ pub enum Language {
     Pseudocode,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GradingMode {
+    Normalize,
+    #[serde(alias = "judge_c_compile")]
+    JudgeC,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct JudgeTestCase {
+    pub input: String,
+    pub output: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Question {
     pub language: Language,
     pub week: usize,
-    pub prompt: String,   // Pregunta
-    pub answer: String,   // Respuesta
+    pub prompt: String, // Pregunta
+    pub answer: String, // Respuesta
     pub hint: Option<String>,
     #[serde(skip)]
     pub number: usize,
     #[serde(default)]
     pub input_prefill: Option<String>,
+    #[serde(default)]
+    pub mode: Option<GradingMode>,
+    #[serde(default)]
+    pub tests: Vec<JudgeTestCase>,
+    #[serde(default)]
+    pub judge_harness: Option<String>,
     #[serde(default)]
     pub is_done: bool,
     #[serde(default)]
@@ -53,7 +73,6 @@ pub struct Quiz {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum AppState {
-
     PendingUpdate,
     LanguageSelect,
     Welcome,
@@ -63,7 +82,6 @@ pub enum AppState {
     Quiz,
     LevelSummary,
     Summary,
-
 }
 
 // ¡Implementa Default!
@@ -74,6 +92,11 @@ impl Default for AppState {
 }
 
 impl Question {
+    pub fn uses_judge_c(&self) -> bool {
+        matches!(self.mode, Some(GradingMode::JudgeC))
+            || (self.language == Language::C && !self.tests.is_empty())
+    }
+
     /// Reinicia los contadores y flags de esta pregunta.
     pub fn reset_stats(&mut self) {
         self.is_done = false;

--- a/src/ui/views/quiz.rs
+++ b/src/ui/views/quiz.rs
@@ -1,8 +1,8 @@
-use egui::{Align, CentralPanel, Context, ScrollArea};
 use crate::code_utils::{c_syntax, pseudo_syntax};
 use crate::model::{AppState, Language};
-use crate::QuizApp;
 use crate::ui::layout::{code_editor_input, code_editor_solution, two_button_row};
+use crate::QuizApp;
+use egui::{Align, CentralPanel, Context, ScrollArea};
 
 pub fn ui_quiz(app: &mut QuizApp, ctx: &Context) {
     CentralPanel::default().show(ctx, |ui| {
@@ -28,7 +28,10 @@ pub fn ui_quiz(app: &mut QuizApp, ctx: &Context) {
                         let level_number = li + 1;
                         let round = app.progress().round;
                         // Ronda
-                        ui.heading(format!("📅 Semana {} - ⭐ Nivel {}", week_number, level_number));
+                        ui.heading(format!(
+                            "📅 Semana {} - ⭐ Nivel {}",
+                            week_number, level_number
+                        ));
                         ui.heading(format!("🌀 Ronda {}", round));
 
                         ui.add_space(10.0);
@@ -40,8 +43,14 @@ pub fn ui_quiz(app: &mut QuizApp, ctx: &Context) {
                         let font_id = egui::TextStyle::Body.resolve(ui.style());
                         let line_h = ui.fonts(|f| f.row_height(&font_id));
                         let prompt_min_h = prompt_min_lines * line_h;
-                        let galley = ui.fonts(|fonts| fonts.layout(
-                            prompt_text.clone(), font_id.clone(), egui::Color32::WHITE, panel_width));
+                        let galley = ui.fonts(|fonts| {
+                            fonts.layout(
+                                prompt_text.clone(),
+                                font_id.clone(),
+                                egui::Color32::WHITE,
+                                panel_width,
+                            )
+                        });
                         let needed_h = galley.size().y.max(prompt_min_h).min(prompt_max_h);
 
                         ui.allocate_ui_with_layout(
@@ -56,14 +65,11 @@ pub fn ui_quiz(app: &mut QuizApp, ctx: &Context) {
                                     if ui.button("📘 Ver teoría").clicked() {
                                         app.open_level_theory(AppState::Quiz);
                                     }
-
                                 });
 
                                 ui.separator();
-
                             },
                         );
-
 
                         ui.allocate_ui_with_layout(
                             egui::vec2(panel_width, needed_h),
@@ -71,16 +77,17 @@ pub fn ui_quiz(app: &mut QuizApp, ctx: &Context) {
                             |ui| {
                                 ui.set_width(panel_width);
                                 ScrollArea::vertical()
+                                    .id_salt("quiz_prompt_scroll")
                                     .max_height(prompt_max_h)
                                     .min_scrolled_height(prompt_min_h)
                                     .show(ui, |ui| {
                                         ui.set_width(ui.available_width());
-                                        
-                                        ui.label(prompt_text); });
 
-                                        ui.separator();
+                                        ui.label(prompt_text);
+                                    });
+
+                                ui.separator();
                             },
-
                         );
 
                         ui.add_space(5.0);
@@ -97,29 +104,45 @@ pub fn ui_quiz(app: &mut QuizApp, ctx: &Context) {
                         let line_h = ui.fonts(|f| f.row_height(&font_id));
                         let code_rows = min_lines;
 
-
                         if question.fails >= 2 {
                             if !app.progress().show_solution {
                                 if ui.button("Solución").clicked() {
                                     app.progress_mut().show_solution = true;
                                 }
                                 code_editor_input(
-                                    ui, "user_input", panel_width, code_rows, line_h,
-                                    syntax.clone(), &mut app.progress_mut().input, max_input_h,
+                                    ui,
+                                    "user_input",
+                                    panel_width,
+                                    code_rows,
+                                    line_h,
+                                    syntax.clone(),
+                                    &mut app.progress_mut().input,
+                                    max_input_h,
                                 );
                             } else {
                                 if ui.button("Siguiente pregunta").clicked() {
                                     app.avanzar_a_siguiente_pregunta();
                                 }
                                 code_editor_solution(
-                                    ui, panel_width, code_rows, line_h,
-                                    syntax, &question.answer, max_input_h,
+                                    ui,
+                                    panel_width,
+                                    code_rows,
+                                    line_h,
+                                    syntax,
+                                    &question.answer,
+                                    max_input_h,
                                 );
                             }
                         } else {
                             code_editor_input(
-                                ui, "user_input", panel_width, code_rows, line_h,
-                                syntax, &mut app.progress_mut().input, max_input_h,
+                                ui,
+                                "user_input",
+                                panel_width,
+                                code_rows,
+                                line_h,
+                                syntax,
+                                &mut app.progress_mut().input,
+                                max_input_h,
                             );
                         }
 
@@ -146,9 +169,9 @@ pub fn ui_quiz(app: &mut QuizApp, ctx: &Context) {
                         //     app.complete_all_level();
                         // }
 
-
                         // Botones enviar/saltar
-                        let (enviar, saltar) = two_button_row(ui, panel_width, "Enviar", "Saltar pregunta");
+                        let (enviar, saltar) =
+                            two_button_row(ui, panel_width, "Enviar", "Saltar pregunta");
                         if enviar {
                             let input = app.progress().input.clone();
                             app.procesar_respuesta(&input);
@@ -158,13 +181,24 @@ pub fn ui_quiz(app: &mut QuizApp, ctx: &Context) {
                         }
 
                         // Volver / ver progreso
-                        let (volver, progreso) = two_button_row(ui, panel_width, "Volver", "Ver progreso");
-                        if progreso { app.ver_progreso(); }
-                        if volver { app.volver_niveles(); }
+                        let (volver, progreso) =
+                            two_button_row(ui, panel_width, "Volver", "Ver progreso");
+                        if progreso {
+                            app.ver_progreso();
+                        }
+                        if volver {
+                            app.volver_niveles();
+                        }
 
                         ui.add_space(8.0);
                         if !app.message.is_empty() {
-                            ui.label(&app.message);
+                            ScrollArea::vertical()
+                                .id_salt("quiz_message_scroll")
+                                .max_height(140.0)
+                                .auto_shrink([false, false])
+                                .show(ui, |ui| {
+                                    ui.label(&app.message);
+                                });
                         }
                     }
                 });


### PR DESCRIPTION
### Motivation
- Prevent false negatives where student programs print helper prompts or text but still produce the correct final answer token (e.g. `a + b is: 5`).
- Keep strict detection for genuinely wrong/garbage final results while being tolerant of common benign output phrasing.
- Integrate judge-mode grading into the app to support full-program C questions with structured test cases.

### Description
- Relaxed the C judge matching in `src/judge_c.rs` to accept exact matches, `trim_end` matches, expected-as-suffix, and for single-token expected outputs compare against the program's last meaningful token via a new helper `last_meaningful_token`.
- Fixed Rust compatibility (removed a `let`-chain) and added `matches_expected_output`, `line_diff`, `apply_harness`, and other judge helpers to `src/judge_c.rs` and exposed `grade_c_question`, `format_judge_message`, and `should_use_judge`.
- Integrated grading into the app flow in `src/app/actions.rs` so the app calls `grade_c_question` for judge-mode questions, maps `JudgeResult` into user-facing messages via `format_judge_message`, and updates progress/prefill logic accordingly.
- Extended the model in `src/model.rs` with `GradingMode` and `JudgeTestCase`, added question fields (`mode`, `tests`, `judge_harness`, `id`) and `uses_judge_c()` helper, and added example judge-mode questions to `src/data/quiz_questions_v2.yaml`.
- Fixed UI ScrollArea ID collisions by adding `id_salt("quiz_prompt_scroll")` and `id_salt("quiz_message_scroll")` and tidy-ups in `src/ui/views/quiz.rs`.

### Testing
- Ran `rustfmt` and `cargo check --offline`, which completed successfully.
- No automated unit tests were added or executed beyond the compile check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69964437b7108324804945087e9882f4)