### PR TITLE
web_judges: add native HTTP remote judge client and per-question endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ semver = "1.0.26"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 self_update = "0.42.0"
-reqwest = { version = "0.12", features = ["blocking"] }
+reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"] }
 
 
 [lib]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST_DIR="$SCRIPT_DIR/dist"
+PAGES_DIR="$SCRIPT_DIR/../gh-pages"
 
 # 1) Build
 trunk build --release --public-url /SummerCQuiz/
-# 2) Sync a gh-pages (worktree)
-rsync -av --delete --exclude=".git" dist/ ../gh-pages/
 
-# 3) Commit & push
-cd ../gh-pages
+# 2) Sync a gh-pages (worktree)
+rsync -av --delete --exclude=".git" "$DIST_DIR/" "$PAGES_DIR/"
+
+# 3) Commit & push (solo si hubo cambios)
+cd "$PAGES_DIR"
 touch .nojekyll
 git add .
-git commit -m "Deploy $(date +'%Y-%m-%d %H:%M')"
-git push origin gh-pages
+
+if git diff --cached --quiet; then
+  echo "ℹ️ No hay cambios para publicar en gh-pages."
+else
+  git commit -m "Deploy $(date +'%Y-%m-%d %H:%M')"
+  git push origin gh-pages
+fi
 
 # 4) Volver al repo principal
-cd ../summer_quiz
+cd "$SCRIPT_DIR"
 echo "✅ Deploy completado: https://sugar144.github.io/SummerCQuiz/"

--- a/docs/web_judges_backend_plan.md
+++ b/docs/web_judges_backend_plan.md
@@ -1,0 +1,52 @@
+# Web Judges - Plan de implementación
+
+## Objetivo
+Habilitar en WASM la evaluación multirespuesta usando un backend de judges remoto.
+
+## Estado actual
+- Los judges locales (C/Java/Kotlin/Rust/Python) requieren `std::process` y filesystem local.
+- En WASM devuelven `InfrastructureError` porque el navegador no puede ejecutar compiladores del sistema.
+- Se implementó una primera versión de `judge_remote` para **native** (desktop) que consume HTTP síncrono y sirve como contrato base del backend.
+
+## Contrato HTTP inicial
+Endpoint por defecto (override por pregunta):
+- `POST http://127.0.0.1:8787/api/judge/sync`
+
+Payload (`application/json`):
+```json
+{
+  "language": "c|pseudocode|kotlin|java|rust|python|git_github",
+  "source": "...",
+  "tests": [{"input": "...", "output": "..."}],
+  "harness": "... opcional ...",
+  "question_id": "... opcional ..."
+}
+```
+
+Respuesta esperada (`status` tagged union):
+- `accepted`
+- `compile_error` + `stderr`
+- `wrong_answer` + `test_index,input,expected,received,diff`
+- `timeout` + `test_index,input,timeout_ms`
+- `runtime_error` + `test_index,input,stderr,exit_code`
+- `infrastructure_error` + `message`
+
+## Diseño propuesto para WASM (fase siguiente)
+1. API backend asíncrona:
+   - `POST /api/judge/submit` -> crea ejecución.
+   - `GET /api/judge/result/:id` -> obtiene resultado.
+2. Frontend web:
+   - Si la pregunta usa `mode: judge_remote`, envía código y muestra estado "evaluando...".
+   - Hace polling no bloqueante y aplica el `JudgeResult` al terminar.
+3. Seguridad backend:
+   - Sandbox por ejecución.
+   - Timeout por test.
+   - Límite de CPU/Memoria.
+
+## Cambios de código iniciados
+- `GradingMode::JudgeRemote` para habilitar migración progresiva por pregunta.
+- `Question.judge_endpoint` para permitir override del endpoint remoto por pregunta.
+- `src/judge/judge_remote.rs` implementa cliente remoto síncrono (native) + mapeo a `JudgeResult`.
+
+## Próximo paso técnico
+Implementar cliente HTTP en WASM (`fetch`) + estado asíncrono en la UI para submit/poll.

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -6,6 +6,7 @@ use crate::judge::judge_c::{
 use crate::judge::judge_java::grade_java_question;
 use crate::judge::judge_kt::grade_kotlin_question;
 use crate::judge::judge_pseudo::{CJudge, PseudoConfig, run_pseudo_tests};
+use crate::judge::judge_remote::grade_remote_question;
 use crate::judge::judge_python::grade_python_question;
 use crate::judge::judge_rust::grade_rust_question;
 use crate::model::GradingMode;
@@ -46,6 +47,8 @@ impl QuizApp {
                 grade_rust_question(q, respuesta)
             } else if matches!(q.mode, Some(GradingMode::JudgePython)) {
                 grade_python_question(q, respuesta)
+            } else if matches!(q.mode, Some(GradingMode::JudgeRemote)) {
+                grade_remote_question(q, respuesta)
             } else if should_use_judge(q) {
                 grade_c_question(q, respuesta)
             } else {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -119,13 +119,16 @@ impl QuizApp {
         };
 
         // --- Esto es igual que antes ---
-        let signal_path = std::path::Path::new(".update_success");
-        if signal_path.exists() {
-            quiz_app.message = format!(
-                "¡Actualización a versión {} completada!",
-                env!("CARGO_PKG_VERSION")
-            );
-            let _ = std::fs::remove_file(signal_path);
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let signal_path = std::path::Path::new(".update_success");
+            if signal_path.exists() {
+                quiz_app.message = format!(
+                    "¡Actualización a versión {} completada!",
+                    env!("CARGO_PKG_VERSION")
+                );
+                let _ = std::fs::remove_file(signal_path);
+            }
         }
 
         quiz_app

--- a/src/judge/judge_pseudo.rs
+++ b/src/judge/judge_pseudo.rs
@@ -77,6 +77,7 @@ pub fn run_pseudo_tests(
         mode: Some(GradingMode::JudgeC),
         tests: tests.to_vec(),
         judge_harness: None,
+        judge_endpoint: None,
         is_done: false,
         saw_solution: false,
         attempts: 0,

--- a/src/judge/judge_remote.rs
+++ b/src/judge/judge_remote.rs
@@ -1,0 +1,173 @@
+use crate::judge::judge_c::JudgeResult;
+use crate::model::Question;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native_remote {
+    use super::*;
+    use reqwest::blocking::Client;
+    use reqwest::header::CONTENT_TYPE;
+    use serde::{Deserialize, Serialize};
+
+    const DEFAULT_REMOTE_JUDGE_URL: &str = "http://127.0.0.1:8787/api/judge/sync";
+
+    #[derive(Debug, Serialize)]
+    struct RemoteJudgeRequest<'a> {
+        language: &'a str,
+        source: &'a str,
+        tests: &'a [crate::model::JudgeTestCase],
+        harness: Option<&'a str>,
+        question_id: Option<&'a str>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(tag = "status", rename_all = "snake_case")]
+    enum RemoteJudgeResponse {
+        Accepted,
+        CompileError {
+            stderr: String,
+        },
+        WrongAnswer {
+            test_index: usize,
+            input: String,
+            expected: String,
+            received: String,
+            #[serde(default)]
+            diff: String,
+        },
+        Timeout {
+            test_index: usize,
+            input: String,
+            timeout_ms: u64,
+        },
+        RuntimeError {
+            test_index: usize,
+            input: String,
+            stderr: String,
+            exit_code: Option<i32>,
+        },
+        InfrastructureError {
+            message: String,
+        },
+    }
+
+    pub fn grade_remote_question(question: &Question, user_code: &str) -> JudgeResult {
+        if question.tests.is_empty() {
+            return JudgeResult::InfrastructureError {
+                message: "La pregunta judge_remote no tiene tests configurados.".into(),
+            };
+        }
+
+        let endpoint = question
+            .judge_endpoint
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(DEFAULT_REMOTE_JUDGE_URL);
+
+        let payload = RemoteJudgeRequest {
+            language: map_language(question),
+            source: user_code,
+            tests: &question.tests,
+            harness: question.judge_harness.as_deref(),
+            question_id: question.id.as_deref(),
+        };
+
+        let client = Client::new();
+        let response = match client
+            .post(endpoint)
+            .header(CONTENT_TYPE, "application/json")
+            .json(&payload)
+            .send()
+        {
+            Ok(response) => response,
+            Err(err) => {
+                return JudgeResult::InfrastructureError {
+                    message: format!("No se pudo contactar el judge remoto ({endpoint}): {err}"),
+                };
+            }
+        };
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().unwrap_or_default();
+            return JudgeResult::InfrastructureError {
+                message: format!("Judge remoto devolvió HTTP {status}. Body: {body}"),
+            };
+        }
+
+        let parsed = match response.json::<RemoteJudgeResponse>() {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                return JudgeResult::InfrastructureError {
+                    message: format!("Respuesta inválida del judge remoto: {err}"),
+                };
+            }
+        };
+
+        map_response(parsed)
+    }
+
+    fn map_language(question: &Question) -> &'static str {
+        match question.language {
+            crate::model::Language::C => "c",
+            crate::model::Language::Pseudocode => "pseudocode",
+            crate::model::Language::Kotlin => "kotlin",
+            crate::model::Language::Java => "java",
+            crate::model::Language::Rust => "rust",
+            crate::model::Language::Python => "python",
+            crate::model::Language::GitGithub => "git_github",
+        }
+    }
+
+    fn map_response(value: RemoteJudgeResponse) -> JudgeResult {
+        match value {
+            RemoteJudgeResponse::Accepted => JudgeResult::Accepted,
+            RemoteJudgeResponse::CompileError { stderr } => JudgeResult::CompileError { stderr },
+            RemoteJudgeResponse::WrongAnswer {
+                test_index,
+                input,
+                expected,
+                received,
+                diff,
+            } => JudgeResult::WrongAnswer {
+                test_index,
+                input,
+                expected,
+                received,
+                diff,
+            },
+            RemoteJudgeResponse::Timeout {
+                test_index,
+                input,
+                timeout_ms,
+            } => JudgeResult::Timeout {
+                test_index,
+                input,
+                timeout_ms,
+            },
+            RemoteJudgeResponse::RuntimeError {
+                test_index,
+                input,
+                stderr,
+                exit_code,
+            } => JudgeResult::RuntimeError {
+                test_index,
+                input,
+                stderr,
+                exit_code,
+            },
+            RemoteJudgeResponse::InfrastructureError { message } => {
+                JudgeResult::InfrastructureError { message }
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use native_remote::grade_remote_question;
+
+#[cfg(target_arch = "wasm32")]
+pub fn grade_remote_question(_question: &Question, _user_code: &str) -> JudgeResult {
+    JudgeResult::InfrastructureError {
+        message: "judge_remote en WASM requiere flujo asíncrono (submit/poll) aún no implementado.".into(),
+    }
+}

--- a/src/judge/mod.rs
+++ b/src/judge/mod.rs
@@ -8,4 +8,6 @@ pub mod judge_python;
 
 pub mod judge_rust;
 
+pub mod judge_remote;
+
 pub mod judge_utils;

--- a/src/model.rs
+++ b/src/model.rs
@@ -22,6 +22,8 @@ pub enum GradingMode {
     JudgeJava,
     JudgeRust,
     JudgePython,
+    #[serde(alias = "judge_remote")]
+    JudgeRemote,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -48,6 +50,8 @@ pub struct Question {
     pub tests: Vec<JudgeTestCase>,
     #[serde(default)]
     pub judge_harness: Option<String>,
+    #[serde(default)]
+    pub judge_endpoint: Option<String>,
     #[serde(default)]
     pub is_done: bool,
     #[serde(default)]


### PR DESCRIPTION
### Motivation
- Provide a concrete native-side implementation for `judge_remote` so desktop builds can call a backend judge and we can stabilize the HTTP contract before implementing WASM async submit/poll. 
- Allow questions to override the remote endpoint so integrations and local development can target different judge backends per-question.

### Description
- Implemented a native HTTP client in `src/judge/judge_remote.rs` that POSTs a JSON payload to a default or per-question endpoint and maps the tagged response (`accepted`, `compile_error`, `wrong_answer`, `timeout`, `runtime_error`, `infrastructure_error`) into the existing `JudgeResult` variants. 
- Added `judge_endpoint: Option<String>` to `Question` in `src/model.rs` and initialized it where pseudo->C synthesized questions are created in `src/judge/judge_pseudo.rs`. 
- Wired the remote path into grading dispatch in `src/app/actions.rs` so `GradingMode::JudgeRemote` calls `grade_remote_question`, and registered `judge_remote` in `src/judge/mod.rs`. 
- Updated `Cargo.toml` to enable `reqwest` features (`blocking`, `json`, `rustls-tls`) for native builds and added `docs/web_judges_backend_plan.md` with the concrete sync contract; improved `deploy.sh` to be more robust.

### Testing
- Ran `cargo check`, which finished successfully (build succeeded) but emitted unrelated dead-code/warning messages from pseudo/judge utilities.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b1f6a1b588324bced63d6c1690f32)