### PR TITLE
Implementa judge remoto en web con polling asíncrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,7 +3556,9 @@ dependencies = [
  "self_update",
  "semver",
  "serde",
+ "serde_json",
  "serde_yaml",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ web-sys = "0.3.77"
 egui_code_editor = { version = "0.2.17" }
 egui_commonmark = "0.21.1"
 semver = "1.0.26"
+serde_json = "1.0"
+wasm-bindgen = "0.2"
 
 
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -7,6 +7,7 @@ use crate::judge::judge_java::grade_java_question;
 use crate::judge::judge_kt::grade_kotlin_question;
 use crate::judge::judge_pseudo::{CJudge, PseudoConfig, run_pseudo_tests};
 use crate::judge::judge_python::grade_python_question;
+use crate::judge::judge_remote::grade_remote_question;
 use crate::judge::judge_rust::grade_rust_question;
 use crate::model::GradingMode;
 
@@ -17,7 +18,12 @@ impl QuizApp {
             return;
         }
 
-        // 1) Extraer índices actuales
+        if self.remote_judge_pending.is_some() {
+            self.message =
+                "⏳ Ya hay una evaluación remota en progreso. Espera el resultado.".into();
+            return;
+        }
+
         let (cw, cl, ci) = {
             let prog = self.progress();
             match (
@@ -33,40 +39,56 @@ impl QuizApp {
             }
         };
 
-        // 2) Calcular resultado (normalize o judge_c)
-        let grading_result = {
-            let q = &self.quiz.modules[cw].levels[cl].questions[ci];
-            if q.uses_judge_pseudo() {
-                run_pseudo_tests(respuesta, &q.tests, &PseudoConfig::default(), &CJudge)
-            } else if matches!(q.mode, Some(GradingMode::JudgeKotlin)) {
-                grade_kotlin_question(q, respuesta)
-            } else if matches!(q.mode, Some(GradingMode::JudgeJava)) {
-                grade_java_question(q, respuesta)
-            } else if matches!(q.mode, Some(GradingMode::JudgeRust)) {
-                grade_rust_question(q, respuesta)
-            } else if matches!(q.mode, Some(GradingMode::JudgePython)) {
-                grade_python_question(q, respuesta)
-            } else if should_use_judge(q) {
-                grade_c_question(q, respuesta)
+        let q = &self.quiz.modules[cw].levels[cl].questions[ci];
+
+        #[cfg(target_arch = "wasm32")]
+        if q.uses_judge_remote() {
+            self.start_remote_judge_submission(cw, cl, ci, respuesta.to_string());
+            return;
+        }
+
+        let grading_result = if q.uses_judge_pseudo() {
+            run_pseudo_tests(respuesta, &q.tests, &PseudoConfig::default(), &CJudge)
+        } else if matches!(q.mode, Some(GradingMode::JudgeKotlin)) {
+            grade_kotlin_question(q, respuesta)
+        } else if matches!(q.mode, Some(GradingMode::JudgeJava)) {
+            grade_java_question(q, respuesta)
+        } else if matches!(q.mode, Some(GradingMode::JudgeRust)) {
+            grade_rust_question(q, respuesta)
+        } else if matches!(q.mode, Some(GradingMode::JudgePython)) {
+            grade_python_question(q, respuesta)
+        } else if q.uses_judge_remote() {
+            grade_remote_question(q, respuesta)
+        } else if should_use_judge(q) {
+            grade_c_question(q, respuesta)
+        } else {
+            let user_code = normalize_code(respuesta);
+            let answer_code = normalize_code(&q.answer);
+            if user_code == answer_code {
+                JudgeResult::Accepted
             } else {
-                let user_code = normalize_code(respuesta);
-                let answer_code = normalize_code(&q.answer);
-                if user_code == answer_code {
-                    JudgeResult::Accepted
-                } else {
-                    JudgeResult::WrongAnswer {
-                        test_index: 0,
-                        input: String::new(),
-                        expected: String::new(),
-                        received: String::new(),
-                        diff: String::new(),
-                    }
+                JudgeResult::WrongAnswer {
+                    test_index: 0,
+                    input: String::new(),
+                    expected: String::new(),
+                    received: String::new(),
+                    diff: String::new(),
                 }
             }
         };
+
+        self.apply_grading_result(cw, cl, ci, grading_result);
+    }
+
+    fn apply_grading_result(
+        &mut self,
+        cw: usize,
+        cl: usize,
+        ci: usize,
+        grading_result: JudgeResult,
+    ) {
         let correcta = matches!(grading_result, JudgeResult::Accepted);
 
-        // 3) Mutar la pregunta: intentos y fails / is_done
         {
             let q = &mut self.quiz.modules[cw].levels[cl].questions[ci];
             q.attempts += 1;
@@ -77,14 +99,12 @@ impl QuizApp {
             }
         }
 
-        // 4) Preparar clonados antes de mutar progress
         let question_id = self.quiz.modules[cw].levels[cl].questions[ci].id.clone();
         let need_update_shown = {
             let prog = self.progress();
             !prog.shown_this_round.contains(&(cl, ci))
         };
 
-        // 5) Bloque mutable de progress: marcar completado, shown_this_round, etc.
         let mut mark_pending = false;
         let mut curr_module = None;
         {
@@ -102,36 +122,29 @@ impl QuizApp {
             }
         }
 
-        // 6) Si era correcta, pasamos a la siguiente pregunta de este nivel
         if mark_pending {
             let next_q = self.next_pending_in_level();
             let prog = self.progress_mut();
             prog.current_in_level = next_q;
         }
 
-        // 7) ¿Terminó nivel o semana?
         if self.progress().current_in_level.is_none() {
             let module_idx = curr_module.unwrap_or(cw);
-            // Completar nivel
             if self.is_level_completed(module_idx, cl) {
                 self.complete_level(module_idx, cl);
 
                 if self.is_module_completed(module_idx) {
-                    // la semana ya acabó, pasamos al resumen semanal
                     self.state = AppState::Summary;
                 } else {
-                    // nivel completo pero quedan más niveles → resumen de nivel
                     self.state = AppState::LevelSummary;
                 }
             }
-            // Completar semana y preparar summary
             if self.is_module_completed(module_idx) {
                 self.complete_module(module_idx);
                 self.state = AppState::Summary;
             }
         }
 
-        // 8) Sincronizar y prefill, luego mensaje
         self.sync_is_done();
         if correcta {
             self.update_input_prefill();
@@ -148,14 +161,45 @@ impl QuizApp {
         };
     }
 
+    #[cfg(target_arch = "wasm32")]
+    fn start_remote_judge_submission(&mut self, cw: usize, cl: usize, ci: usize, source: String) {
+        let question = self.quiz.modules[cw].levels[cl].questions[ci].clone();
+        let (tx, rx) = std::sync::mpsc::channel::<JudgeResult>();
+
+        self.remote_judge_pending = Some(PendingRemoteJudge { cw, cl, ci });
+        self.remote_judge_rx = Some(rx);
+        self.message = "⏳ Evaluando en judge remoto...".into();
+
+        wasm_bindgen_futures::spawn_local(async move {
+            let result = grade_remote_question(&question, &source).await;
+            let _ = tx.send(result);
+        });
+    }
+
+    pub fn poll_remote_judge_result(&mut self) {
+        let maybe_result = self
+            .remote_judge_rx
+            .as_ref()
+            .and_then(|rx| rx.try_recv().ok());
+
+        if let Some(result) = maybe_result {
+            if let Some(pending) = self.remote_judge_pending.take() {
+                self.apply_grading_result(pending.cw, pending.cl, pending.ci, result);
+            }
+            self.remote_judge_rx = None;
+        }
+    }
+
+    pub fn is_remote_judge_pending(&self) -> bool {
+        self.remote_judge_pending.is_some()
+    }
+
     pub fn saltar_pregunta(&mut self) {
-        // 1) Extraer índices actuales (o salir si no hay pregunta)
         let (cw, cl, ci) = match self.current_position() {
             Some(pos) => pos,
             None => return,
         };
 
-        // 2) Registrar estadísticas en la pregunta actual
         {
             let q = &mut self.quiz.modules[cw].levels[cl].questions[ci];
             q.skips += 1;
@@ -163,7 +207,6 @@ impl QuizApp {
             q.saw_solution = false;
         }
 
-        // 3) Marcarla como mostrada en esta ronda
         {
             let prog = self.progress_mut();
             if !prog.shown_this_round.contains(&(cl, ci)) {
@@ -171,20 +214,16 @@ impl QuizApp {
             }
         }
 
-        // 4) Determinar siguiente pregunta con lógica de rondas
         let next_q = self.next_pending_in_level();
 
-        // 5) Actualizar el índice y limpiar el input
         {
             let prog = self.progress_mut();
             prog.current_in_level = next_q;
             prog.input.clear();
         }
 
-        // 6) Si no quedan preguntas pendientes en el nivel tras la ronda:
         self.finalize_level_or_module();
 
-        // 7) Actualizar prefill y mensaje
         self.update_input_prefill();
         self.message = "⏩ Pregunta saltada. La verás en la siguiente ronda.".to_string();
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,5 @@
 use crate::data::read_questions_for_language;
+use crate::judge::judge_c::JudgeResult;
 use crate::model::{AppState, Language, Level, Module, Question, Quiz};
 use eframe::egui;
 use egui_commonmark::CommonMarkCache;
@@ -69,6 +70,13 @@ impl Default for QuizProgress {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct PendingRemoteJudge {
+    pub cw: usize,
+    pub cl: usize,
+    pub ci: usize,
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct QuizApp {
     pub progresses: HashMap<Language, QuizProgress>,
@@ -89,6 +97,10 @@ pub struct QuizApp {
     pub update_thread_launched: bool,
     #[serde(skip)]
     pub has_saved_progress: bool,
+    #[serde(skip)]
+    pub remote_judge_pending: Option<PendingRemoteJudge>,
+    #[serde(skip)]
+    pub remote_judge_rx: Option<std::sync::mpsc::Receiver<JudgeResult>>,
 }
 
 impl QuizApp {
@@ -116,6 +128,8 @@ impl QuizApp {
             confirm_reset: false,
             update_thread_launched: false,
             has_saved_progress: false,
+            remote_judge_pending: None,
+            remote_judge_rx: None,
         };
 
         // --- Esto es igual que antes ---
@@ -149,6 +163,8 @@ impl QuizApp {
             confirm_reset: false,
             update_thread_launched: false,
             has_saved_progress: false,
+            remote_judge_pending: None,
+            remote_judge_rx: None,
         }
     }
 

--- a/src/judge/judge_c.rs
+++ b/src/judge/judge_c.rs
@@ -1,6 +1,7 @@
 use crate::model::Question;
 
 #[derive(Debug, Clone)]
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub enum JudgeResult {
     Accepted,
     CompileError {

--- a/src/judge/judge_java.rs
+++ b/src/judge/judge_java.rs
@@ -291,11 +291,8 @@ mod native_java {
 pub use native_java::grade_java_question;
 
 #[cfg(target_arch = "wasm32")]
-pub fn grade_java_question(
-    _question: &crate::model::Question,
-    _user_code: &str,
-) -> JudgeResult {
-     JudgeResult::InfrastructureError {
+pub fn grade_java_question(_question: &crate::model::Question, _user_code: &str) -> JudgeResult {
+    JudgeResult::InfrastructureError {
         message: "El juez Java no está disponible en WASM.".into(),
     }
 }

--- a/src/judge/judge_kt.rs
+++ b/src/judge/judge_kt.rs
@@ -222,11 +222,8 @@ mod native_kotlin {
 pub use native_kotlin::grade_kotlin_question;
 
 #[cfg(target_arch = "wasm32")]
-pub fn grade_kotlin_question(
-    _question: &crate::model::Question,
-    _user_code: &str,
-) -> JudgeResult {
-     JudgeResult::InfrastructureError {
+pub fn grade_kotlin_question(_question: &crate::model::Question, _user_code: &str) -> JudgeResult {
+    JudgeResult::InfrastructureError {
         message: "El juez Kotlin no está disponible en WASM.".into(),
     }
 }

--- a/src/judge/judge_pseudo.rs
+++ b/src/judge/judge_pseudo.rs
@@ -2,6 +2,7 @@ use crate::judge::judge_c::JudgeResult;
 use crate::model::{GradingMode, JudgeTestCase, Language, Question};
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub enum PseudoError {
     LexError {
         message: String,
@@ -77,6 +78,7 @@ pub fn run_pseudo_tests(
         mode: Some(GradingMode::JudgeC),
         tests: tests.to_vec(),
         judge_harness: None,
+        judge_endpoint: None,
         is_done: false,
         saw_solution: false,
         attempts: 0,
@@ -88,6 +90,7 @@ pub fn run_pseudo_tests(
     c_judge.grade(&question, &question.answer)
 }
 
+#[allow(dead_code)]
 pub fn pseudo_to_c(code: &str) -> Result<String, PseudoError> {
     pseudo_to_c_with_config(code, &PseudoConfig::default())
 }

--- a/src/judge/judge_python.rs
+++ b/src/judge/judge_python.rs
@@ -219,11 +219,8 @@ mod native_python {
 pub use native_python::grade_python_question;
 
 #[cfg(target_arch = "wasm32")]
-pub fn grade_python_question(
-    _question: &crate::model::Question,
-    _user_code: &str,
-) -> JudgeResult {
-     JudgeResult::InfrastructureError {
+pub fn grade_python_question(_question: &crate::model::Question, _user_code: &str) -> JudgeResult {
+    JudgeResult::InfrastructureError {
         message: "El juez Python no está disponible en WASM.".into(),
     }
 }

--- a/src/judge/judge_rust.rs
+++ b/src/judge/judge_rust.rs
@@ -268,11 +268,8 @@ mod native_rust {
 pub use native_rust::grade_rust_question;
 
 #[cfg(target_arch = "wasm32")]
-pub fn grade_rust_question(
-    _question: &crate::model::Question,
-    _user_code: &str,
-) -> JudgeResult {
-     JudgeResult::InfrastructureError {
+pub fn grade_rust_question(_question: &crate::model::Question, _user_code: &str) -> JudgeResult {
+    JudgeResult::InfrastructureError {
         message: "El juez Rust no está disponible en WASM.".into(),
     }
 }

--- a/src/judge/judge_utils.rs
+++ b/src/judge/judge_utils.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub fn normalize_newlines(value: &str) -> String {
     value.replace("\r\n", "\n")
 }

--- a/src/judge/mod.rs
+++ b/src/judge/mod.rs
@@ -3,6 +3,7 @@ pub mod judge_java;
 pub mod judge_kt;
 
 pub mod judge_pseudo;
+pub mod judge_remote;
 
 pub mod judge_python;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -22,6 +22,7 @@ pub enum GradingMode {
     JudgeJava,
     JudgeRust,
     JudgePython,
+    JudgeRemote,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -48,6 +49,8 @@ pub struct Question {
     pub tests: Vec<JudgeTestCase>,
     #[serde(default)]
     pub judge_harness: Option<String>,
+    #[serde(default)]
+    pub judge_endpoint: Option<String>,
     #[serde(default)]
     pub is_done: bool,
     #[serde(default)]
@@ -109,6 +112,10 @@ impl Question {
 
     pub fn uses_judge_pseudo(&self) -> bool {
         matches!(self.mode, Some(GradingMode::JudgePseudo)) && !self.tests.is_empty()
+    }
+
+    pub fn uses_judge_remote(&self) -> bool {
+        matches!(self.mode, Some(GradingMode::JudgeRemote)) && !self.tests.is_empty()
     }
 
     pub fn reset_stats(&mut self) {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,6 +10,11 @@ use layout::{bottom_panel, top_panel};
 
 impl App for QuizApp {
     fn update(&mut self, ctx: &Context, _frame: &mut Frame) {
+        self.poll_remote_judge_result();
+        if self.is_remote_judge_pending() {
+            ctx.request_repaint_after(std::time::Duration::from_millis(120));
+        }
+
         // BOTÓN SUPERIOR DE REINICIAR y CAMBIAR LENGUAJE (solo visible durante el quiz y resumen)
         if matches!(self.state, AppState::Quiz | AppState::Summary) {
             top_panel(self, ctx, true);

--- a/src/ui/views/quiz.rs
+++ b/src/ui/views/quiz.rs
@@ -173,14 +173,18 @@ pub fn ui_quiz(app: &mut QuizApp, ctx: &Context) {
                             app.complete_all_level();
                         }
 
+                        if app.is_remote_judge_pending() {
+                            ui.label("⏳ Judge remoto en progreso, espera el resultado...");
+                        }
+
                         // Botones enviar/saltar
                         let (enviar, saltar) =
                             two_button_row(ui, panel_width, "Enviar", "Saltar pregunta");
-                        if enviar {
+                        if enviar && !app.is_remote_judge_pending() {
                             let input = app.progress().input.clone();
                             app.procesar_respuesta(&input);
                         }
-                        if saltar {
+                        if saltar && !app.is_remote_judge_pending() {
                             app.saltar_pregunta();
                         }
 


### PR DESCRIPTION
### Motivation

- Habilitar la evaluación de preguntas en navegadores (WASM) donde los judges locales no pueden ejecutar procesos del sistema. 
- Permitir migración progresiva por pregunta mediante `mode: judge_remote` y un endpoint remoto configurable. 
- Mantener la UX responsiva evitando bloqueos sincronizados en la UI web durante la evaluación remota. 

### Description

- Añadí `GradingMode::JudgeRemote`, el campo opcional `Question.judge_endpoint` y el helper `uses_judge_remote()` al modelo para soportar el modo remoto (archivo `src/model.rs`).
- Implementé `src/judge/judge_remote.rs` que construye el payload HTTP y mapea el tagged-union JSON a `JudgeResult`, con cliente nativo síncrono (`reqwest::blocking`) y cliente WASM asíncrono basado en `fetch` (`web-sys`).
- Integré el flujo en la corrección extraendo `apply_grading_result` y lanzando `start_remote_judge_submission` en WASM; añadí `PendingRemoteJudge` y un `mpsc::Receiver<JudgeResult>` para recibir resultados y aplicar el resultado por polling (archivos `src/app/actions.rs`, `src/app/mod.rs`).
- Añadí polling en el `update` de la UI y bloqueo/aviso en la vista de quiz para evitar envíos duplicados mientras haya una evaluación remota pendiente (`src/ui/mod.rs`, `src/ui/views/quiz.rs`).
- Actualicé `Cargo.toml` para incluir `serde_json` y `wasm-bindgen` necesarios para serialización y `fetch` en WASM, y registré el nuevo módulo `judge_remote` en `src/judge/mod.rs`.

### Testing

- Ejecuté `cargo fmt` sin errores y formateé los ficheros modificados.
- Ejecuté `cargo check` con éxito (`Finished dev profile`) y resolví un error de sintaxis intermedio producido durante los cambios.
- Ejecuté `cargo test -q` y los tests unitarios locales pasaron (`2 passed`).
- Intenté `cargo check --target wasm32-unknown-unknown` y falló por falta del target en este entorno (mensaje: "can't find crate for core"), por lo que la verificación WASM completa no pudo realizarse aquí.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7ad02d50832484caaeea5852816d)