### PR TITLE
Fix WASM remote judge endpoint resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="utf-8" />
+    <meta name="summer-quiz-judge-endpoint" content="" />
     <title>SummerQuiz</title>
     <!-- Solo compila el binario principal para WASM -->
     <link data-trunk rel="rust" data-bin="summer_quiz_bin" />


### PR DESCRIPTION
### Motivation
- The WASM build hardcoded the remote judge endpoint to `/api/judge/sync`, which causes HTTP 405 errors on static deployments (e.g. GitHub Pages) when no backend is present at that path; the change makes endpoint selection configurable at runtime or build-time.
- Also address minor warnings by scoping the native default endpoint to non-WASM builds and removing an unnecessary mutable binding.

### Description
- Implement flexible endpoint discovery for browser builds with this precedence: 1) compile-time env `SUMMER_QUIZ_JUDGE_ENDPOINT`, 2) URL query param `?judge_endpoint=...`, 3) HTML meta tag `meta[name="summer-quiz-judge-endpoint"]`, 4) `localStorage["summer_quiz_judge_endpoint"]`, 5) fallback to `/api/judge/sync` by changing `default_endpoint()` and adding helper functions `endpoint_from_build_env`, `endpoint_from_querystring`, `endpoint_from_meta`, `endpoint_from_local_storage`, and `normalize_endpoint`.
- Guard `DEFAULT_NATIVE_ENDPOINT` with `#[cfg(not(target_arch = "wasm32"))]` so it's only present for native builds.
- Make `RequestInit` immutable (remove unnecessary `mut`).
- Add a placeholder meta tag `<meta name="summer-quiz-judge-endpoint" content="" />` in `index.html` to allow static deployments to specify the judge endpoint without rebuilding.

### Testing
- Ran `cargo fmt` and `cargo fmt --check`, which completed successfully.
- Attempted `cargo check --lib` in this environment, but the dependency compilation is long-running and the full check did not complete within the interactive session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b9da93c6483248dbf37f56283ca16)