### PR TITLE
Fix remote judge endpoint compatibility across web and backend

### DIFF
--- a/src/bin/summer_quiz_judge_server.rs
+++ b/src/bin/summer_quiz_judge_server.rs
@@ -92,7 +92,7 @@ fn handle_connection(mut stream: TcpStream) -> Result<(), String> {
         return Ok(());
     }
 
-    if !first_line.starts_with("POST /api/judge/sync") {
+    if !is_supported_judge_route(first_line) {
         write_response(&mut stream, 404, "not found", "text/plain");
         return Ok(());
     }
@@ -108,6 +108,17 @@ fn handle_connection(mut stream: TcpStream) -> Result<(), String> {
 
     write_response(&mut stream, 200, &response_json, "application/json");
     Ok(())
+}
+
+fn is_supported_judge_route(first_line: &str) -> bool {
+    [
+        "POST /api/judge/sync",
+        "POST /api/judge",
+        "POST /judge/sync",
+        "POST /judge",
+    ]
+    .iter()
+    .any(|prefix| first_line.starts_with(prefix))
 }
 
 fn evaluate(payload: JudgeRequest) -> JudgeResponse {


### PR DESCRIPTION
### Motivation
- The web client could receive `HTTP 405` when hitting `/api/judge/sync` because client and backend expected slightly different route shapes or the endpoint contained trailing slashes or just an origin (`http://host:port`).
- The goal is to make endpoint selection resilient and to align backend routes with the candidate routes the client tries so remote judging works behind proxies and different deployments.

### Description
- Hardened `endpoint_candidates` in `src/judge/judge_remote.rs` to normalize trailing slashes, decompose origins, and generate a fallback list of compatible routes (`/api/judge/sync`, `/api/judge`, `/judge/sync`, `/judge`) from either an origin or a route base. 
- Added helper logic to detect origin-only endpoints and to push sensible suffixes so the client will try origin+path variants when appropriate.
- Added unit tests in `src/judge/judge_remote.rs` that validate candidate generation for an origin-only endpoint and for endpoints with trailing slashes. 
- Updated the backend `src/bin/summer_quiz_judge_server.rs` to accept the same set of POST routes by introducing `is_supported_judge_route`, so the server responds to the routes the client will attempt.

### Testing
- Ran `cargo fmt --all --check` and the code is formatted correctly (passed). 
- Executed the new unit tests with `cargo test -q endpoint_candidates --lib` and they passed (`2 passed; 0 failed`).
- Verified the server route matcher and client candidate generator locally by inspecting the changed logic and ensuring the candidate list includes `http://127.0.0.1:8787/api/judge/sync`, `http://127.0.0.1:8787/api/judge` and normalized `/api/judge/sync` -> `/api/judge` variants.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c2c22dc088324aef1cfd6efa626b6)