### PR TITLE
WASM judge: deep network diagnostics + HTTPS/localhost mixed-content hint

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,18 +1,38 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-# 1) Build
-trunk build --release --public-url /SummerCQuiz/
-# 2) Sync a gh-pages (worktree)
-rsync -av --delete --exclude=".git" dist/ ../gh-pages/
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+GH_PAGES_DIR="$REPO_ROOT/../gh-pages"
+DIST_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$DIST_DIR"
+}
+trap cleanup EXIT
+
+if [[ ! -d "$GH_PAGES_DIR/.git" ]]; then
+  echo "❌ No se encontró el worktree/repo gh-pages en: $GH_PAGES_DIR"
+  exit 1
+fi
+
+# 1) Build (sin crear ./dist dentro del repo)
+trunk build --release --public-url /SummerCQuiz/ --dist "$DIST_DIR"
+
+# 2) Sync al worktree gh-pages
+rsync -av --delete --exclude=".git" "$DIST_DIR/" "$GH_PAGES_DIR/"
 
 # 3) Commit & push
-cd ../gh-pages
+cd "$GH_PAGES_DIR"
 touch .nojekyll
 git add .
+
+if git diff --cached --quiet; then
+  echo "ℹ️ No hay cambios para desplegar"
+  exit 0
+fi
+
 git commit -m "Deploy $(date +'%Y-%m-%d %H:%M')"
 git push origin gh-pages
 
-# 4) Volver al repo principal
-cd ../summer_quiz
 echo "✅ Deploy completado: https://sugar144.github.io/SummerCQuiz/"

--- a/src/judge/judge_remote.rs
+++ b/src/judge/judge_remote.rs
@@ -131,6 +131,31 @@ fn endpoint_candidates(primary: &str) -> Vec<String> {
     candidates
 }
 
+#[cfg(target_arch = "wasm32")]
+fn wasm_with_local_fallbacks(primary: &str, mut candidates: Vec<String>) -> Vec<String> {
+    fn push_unique(candidates: &mut Vec<String>, value: String) {
+        if !value.trim().is_empty() && !candidates.iter().any(|c| c == &value) {
+            candidates.push(value);
+        }
+    }
+
+    let primary = primary.trim();
+    let is_absolute = primary.starts_with("http://") || primary.starts_with("https://");
+
+    if !is_absolute {
+        for endpoint in [
+            "http://127.0.0.1:8787/api/judge/sync",
+            "http://127.0.0.1:8787/api/judge",
+            "http://localhost:8787/api/judge/sync",
+            "http://localhost:8787/api/judge",
+        ] {
+            push_unique(&mut candidates, endpoint.to_string());
+        }
+    }
+
+    candidates
+}
+
 #[cfg(test)]
 mod tests {
     use super::endpoint_candidates;
@@ -359,6 +384,25 @@ pub fn grade_remote_question(question: &Question, user_code: &str) -> JudgeResul
 }
 
 #[cfg(target_arch = "wasm32")]
+fn is_loopback_http_endpoint(value: &str) -> bool {
+    value.starts_with("http://127.0.0.1:") || value.starts_with("http://localhost:")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn browser_security_hint(window: &web_sys::Window, endpoints: &[String]) -> Option<String> {
+    let protocol = window.location().protocol().ok()?;
+
+    if protocol == "https:" && endpoints.iter().any(|e| is_loopback_http_endpoint(e)) {
+        return Some(
+            "Tu app web está en HTTPS y el judge local en HTTP (localhost/127.0.0.1). El navegador bloquea esto por Mixed Content/Private Network Access. Usa un endpoint HTTPS para el judge o ejecuta la app en HTTP local."
+                .to_string(),
+        );
+    }
+
+    None
+}
+
+#[cfg(target_arch = "wasm32")]
 pub async fn grade_remote_question(question: &Question, user_code: &str) -> JudgeResult {
     use wasm_bindgen::JsCast;
     use wasm_bindgen::JsValue;
@@ -390,40 +434,50 @@ pub async fn grade_remote_question(question: &Question, user_code: &str) -> Judg
         }
     };
 
-    let endpoints = endpoint_candidates(&endpoint);
+    let endpoints = wasm_with_local_fallbacks(&endpoint, endpoint_candidates(&endpoint));
+    let security_hint = browser_security_hint(&window, &endpoints);
     let mut last_http_error = None;
+    let mut last_fetch_error = None;
 
-    for candidate in endpoints {
-        let request = match Request::new_with_str_and_init(&candidate, &opts) {
+    for candidate in &endpoints {
+        let request = match Request::new_with_str_and_init(candidate, &opts) {
             Ok(r) => r,
             Err(err) => {
-                return JudgeResult::InfrastructureError {
-                    message: format!("No se pudo crear request fetch: {:?}", err),
-                };
+                last_fetch_error = Some(format!(
+                    "No se pudo crear request fetch para {}: {:?}",
+                    candidate, err
+                ));
+                continue;
             }
         };
 
         if let Err(err) = request.headers().set("Content-Type", "application/json") {
-            return JudgeResult::InfrastructureError {
-                message: format!("No se pudo asignar headers del request: {:?}", err),
-            };
+            last_fetch_error = Some(format!(
+                "No se pudo asignar headers del request para {}: {:?}",
+                candidate, err
+            ));
+            continue;
         }
 
         let resp_value = match JsFuture::from(window.fetch_with_request(&request)).await {
             Ok(v) => v,
             Err(err) => {
-                return JudgeResult::InfrastructureError {
-                    message: format!("Fetch judge remoto falló: {:?}", err),
-                };
+                last_fetch_error = Some(format!(
+                    "Fetch judge remoto falló en {}: {:?}",
+                    candidate, err
+                ));
+                continue;
             }
         };
 
         let response: Response = match resp_value.dyn_into() {
             Ok(r) => r,
             Err(_) => {
-                return JudgeResult::InfrastructureError {
-                    message: "La respuesta fetch no es un Response válido.".into(),
-                };
+                last_fetch_error = Some(format!(
+                    "La respuesta fetch en {} no es un Response válido.",
+                    candidate
+                ));
+                continue;
             }
         };
 
@@ -438,12 +492,11 @@ pub async fn grade_remote_question(question: &Question, user_code: &str) -> Judg
         }) {
             Ok(text) => text,
             Err(err) => {
-                return JudgeResult::InfrastructureError {
-                    message: format!(
-                        "No se pudo leer body de respuesta del judge remoto: {:?}",
-                        err
-                    ),
-                };
+                last_fetch_error = Some(format!(
+                    "No se pudo leer body de respuesta del judge remoto en {}: {:?}",
+                    candidate, err
+                ));
+                continue;
             }
         };
 
@@ -477,8 +530,16 @@ pub async fn grade_remote_question(question: &Question, user_code: &str) -> Judg
         };
     }
 
+    let details = last_http_error
+        .or(last_fetch_error)
+        .unwrap_or_else(|| "Judge remoto no respondió correctamente.".to_string());
+
+    let endpoints_text = endpoints.join(", ");
+    let hint_suffix = security_hint
+        .map(|h| format!(" Hint: {h}"))
+        .unwrap_or_default();
+
     JudgeResult::InfrastructureError {
-        message: last_http_error
-            .unwrap_or_else(|| "Judge remoto no respondió correctamente.".to_string()),
+        message: format!("{details}. Endpoints probados: [{endpoints_text}].{hint_suffix}"),
     }
 }


### PR DESCRIPTION
### Motivation
- Diagnosticar y exponer la causa real de errores `TypeError: NetworkError` en el flujo WASM del judge remoto, que a menudo vienen de políticas de navegador (mixed-content / Private Network Access / CORS) y no del parsing JSON.
- Evitar que el cliente WASM aborte en la primera falla de `fetch` y así permitir que los endpoints de fallback (incluyendo judge local) sean probados.
- Proveer un mensaje final accionable que incluya detalles útiles para depurar (detalle de error y endpoints probados).

### Description
- Añadí `wasm_with_local_fallbacks` para insertar candidatos `http://127.0.0.1:8787` / `http://localhost:8787` cuando el endpoint no es absoluto, y lo uso en `grade_remote_question` para probar fallbacks locales en WASM.
- Introduje detección `is_loopback_http_endpoint` y `browser_security_hint` para detectar el caso común de app en `https:` intentando llamar `http://localhost` y devolver un hint específico sobre mixed-content/PNA.
- Cambié `grade_remote_question` para iterar sobre `&endpoints`, evitar retornos inmediatos ante errores de `fetch` y en su lugar acumular `last_fetch_error` y `last_http_error`, continuando con otros candidatos; el error final ahora incluye el detalle disponible, la lista de endpoints probados y el hint de seguridad cuando aplique.
- Ajusté llamadas a `Request::new_with_str_and_init` y la lógica de creación/headers para reportar problemas por candidato en vez de abortar inmediatamente; también se mejoró el mensaje final generado.
- Pequeña mejora al script de despliegue `deploy.sh` para usar un `--dist` temporal, manejo más seguro de worktree y saneamiento (`set -euo pipefail`).

### Testing
- Ejecuté `cargo fmt --all` (formateo) con éxito.
- Ejecuté `cargo test endpoint_candidates -- --nocapture` y los tests relevantes pasaron (`2 tests OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c3010fc3c8324aee65145f38c53a9)